### PR TITLE
Get breakpoint MRCAs systematically and update single-break recombinant export

### DIFF
--- a/sc2ts/utils.py
+++ b/sc2ts/utils.py
@@ -116,10 +116,10 @@ def get_recombinant_mrca_table(ts):
         bp = left_edge.right
         tree.seek(bp)
         assert tree.interval.left == bp
-        left_path = get_root_path(tree, right_edge.parent)
+        right_path = get_root_path(tree, right_edge.parent)
         tree.prev()
         assert tree.interval.right == bp
-        right_path = get_root_path(tree, left_edge.parent)
+        left_path = get_root_path(tree, left_edge.parent)
         mrca = get_path_mrca(left_path, right_path, ts.nodes_time)
         row = {
             "recombinant_node": recombinant_node,

--- a/sc2ts/utils.py
+++ b/sc2ts/utils.py
@@ -133,22 +133,118 @@ def get_recombinant_mrca_table(ts):
 
 
 @dataclasses.dataclass
-class Match:
+class HmmRun:
     breakpoints: list
     parents: list
+    parent_imputed_lineages: list
     mutations: list
 
 
 @dataclasses.dataclass
-class Recombinant:
-    strain: str
-    matches: dict
-    node: int = -1
+class ArgRecombinant:
+    breakpoints: list
+    parents: list
+    parent_imputed_lineages: list
+    mrcas: list
 
-    def is_hmm_consistent(self):
-        return len(self.matches["forward"].parents) == len(
-            self.matches["backward"].parents
-        ) and (self.matches["forward"].mutations == self.matches["backward"].mutations)
+
+@dataclasses.dataclass
+class Recombinant:
+    causal_strain: str
+    causal_date: str
+    causal_lineage: str
+    hmm_runs: dict
+    arg_info: ArgRecombinant
+    node: int
+    max_descendant_samples: int
+
+    def data_summary(self):
+        d = self.asdict()
+        del d["hmm_runs"]
+        del d["arg_info"]
+        d["num_parents"] = self.num_parents
+        d["total_cost"] = self.total_cost
+        d["is_hmm_mutation_consistent"] = self.is_hmm_mutation_consistent()
+        d["is_arg_hmm_path_identical"] = self.is_arg_hmm_path_identical()
+        d[
+            "is_arg_hmm_path_length_consistent"
+        ] = self.is_arg_hmm_path_length_consistent()
+        d["is_path_length_consistent"] = self.is_path_length_consistent()
+        d["is_parent_lineage_consistent"] = self.is_parent_lineage_consistent()
+        return d
+
+    @property
+    def total_cost(self):
+        """
+        How different is the causal sequence from the rest, roughly?
+        """
+        fwd = self.hmm_runs["forward"]
+        bck = self.hmm_runs["backward"]
+        cost_fwd = 3 * (len(fwd.parents) - 1) + len(fwd.mutations)
+        cost_bck = 3 * (len(bck.parents) - 1) + len(bck.mutations)
+        assert cost_fwd == cost_bck
+        return cost_fwd
+
+    @property
+    def num_parents(self):
+        """
+        The ARG version is definitive.
+        """
+        return len(self.arg_info.parents)
+
+    def is_hmm_mutation_consistent(self):
+        """
+        Do we get the same set of mutations in the HMM in the back and
+        forward runs?
+        """
+        fwd = self.hmm_runs["forward"]
+        bck = self.hmm_runs["backward"]
+        return fwd.mutations == bck.mutations
+
+    def is_arg_hmm_path_identical(self):
+        """
+        Does this recombinant have the same path in the forwards HMM run, and in the ARG?
+        """
+        fwd = self.hmm_runs["forward"]
+        arg = self.arg_info
+        return fwd.parents == arg.parents and fwd.breakpoints == arg.breakpoints
+
+    def is_arg_hmm_path_length_consistent(self):
+        """
+        Does this recombinant have the same path length in the forwards HMM run,
+        and in the ARG?
+        """
+        fwd = self.hmm_runs["forward"]
+        arg = self.arg_info
+        return len(fwd.parents) == len(arg.parents)
+
+    def is_path_length_consistent(self):
+        """
+        Returns True if all the HMM runs agree on the number of parents.
+        """
+        fwd = self.hmm_runs["forward"]
+        bck = self.hmm_runs["backward"]
+        return (
+            len(fwd.parents) == len(bck.parents)
+            and self.is_arg_hmm_path_length_consistent()
+        )
+
+    def is_parent_lineage_consistent(self):
+        """
+        Returns True if all the HMM runs agree on the imputed pango lineage status of
+        parents. Implies is_path_length_consistent.
+        """
+        fwd = self.hmm_runs["forward"]
+        bck = self.hmm_runs["backward"]
+        arg = self.arg_info
+        return (
+            fwd.parent_imputed_lineages
+            == bck.parent_imputed_lineages
+            == arg.parent_imputed_lineages
+        )
+
+    def asdict(self):
+        return dataclasses.asdict(self)
 
 
 def get_recombinants(ts):
@@ -622,13 +718,7 @@ class TreeInfo:
         df["causal_date"] = causal_date
         return df
 
-    def export_one_break_recombinants(self):
-        """
-        Return a table of information about one-break recombinants that
-        which we have stable information about under various runs of the
-        HMM.
-        """
-
+    def combine_recombinant_info(self):
         def get_imputed_pango(u):
             lineage = self.nodes_metadata[u]["Imputed_lineage"]
             # Recombinant might be misleading, Unknown seems more accurate?
@@ -636,184 +726,115 @@ class TreeInfo:
                 return "Unknown"
             return lineage
 
-        # Get information about all recombinants from the actual ARG
-        df_base = sc2ts.utils.get_recombinant_mrca_table(ts)
+        df_arg = sc2ts.utils.get_recombinant_mrca_table(self.ts)
+        arg_info = collections.defaultdict(list)
+        for _, row in df_arg.iterrows():
+            arg_info[row.recombinant_node].append(row)
 
-        # Remove all nodes for > 1 break
-        df_base.drop_duplicates("recombinant_node", keep=False)
-
-        data = []
-        for _, row in df_base.iterrows():
-            # Get additional metadata about this recombinant
-            u = int(row.recombinant_node)
+        output = []
+        for u, rows in arg_info.items():
             md = self.nodes_metadata[u]
             match_info = md["match_info"]
+            strain = match_info[0]["strain"]
             assert len(match_info) == 2
-            assert match_info[0]["strain"] == match_info[1]["strain"]
-            matches = {}
+            assert strain == match_info[1]["strain"]
+
+            hmm_runs = {}
             for record in match_info:
-                matches[record["direction"]] = Match(
+                parents = record["parents"]
+                hmm_runs[record["direction"]] = HmmRun(
                     breakpoints=record["breakpoints"],
-                    parents=record["parents"],
+                    parents=parents,
                     mutations=record["mutations"],
+                    parent_imputed_lineages=[get_imputed_pango(x) for x in parents],
                 )
-            rec = Recombinant(match_info[0]["strain"], matches, node=u)
+            breakpoints = [0]
+            parents = []
+            mrcas = []
+            for row in rows:
+                mrcas.append(row.mrca)
+                breakpoints.append(row.breakpoint)
+                parents.append(row.left_parent)
+            parents.append(row.right_parent)
+            breakpoints.append(int(self.ts.sequence_length))
+            arg_rec = ArgRecombinant(
+                breakpoints=breakpoints,
+                parents=parents,
+                mrcas=mrcas,
+                parent_imputed_lineages=[get_imputed_pango(x) for x in parents],
+            )
+            causal_node = self.strain_map[strain]
+            causal_lineage = self.nodes_metadata[causal_node]["Nextclade_pango"]
+            rec = Recombinant(
+                causal_strain=strain,
+                causal_date=md["date_added"],
+                causal_lineage=causal_lineage,
+                node=u,
+                hmm_runs=hmm_runs,
+                max_descendant_samples=self.nodes_max_descendant_samples[u],
+                arg_info=arg_rec,
+            )
+            output.append(rec)
+        return output
 
-            if len(rec.matches["forward"].parents) == 2 and rec.is_hmm_consistent():
-                # The actual parent nodes in the tree don't always agree with those in the
-                # HMM metadata. Require that we have at least the same imputed pango lineages
-                # If we don't, then there seems like a lot of uncertainty.
-                forward_lineages = [
-                    get_imputed_pango(x) for x in rec.matches["forward"].parents
-                ]
-                backward_lineages = [
-                    get_imputed_pango(x) for x in rec.matches["backward"].parents
-                ]
-                arg_lineages = [
-                    get_imputed_pango(x) for x in [row.left_parent, row.right_parent]
-                ]
-
-                if forward_lineages == backward_lineages == arg_lineages:
-                    strain_node = self.strain_map[rec.strain]
-                    strain_date = self.nodes_metadata[strain_node]["date"]
-                    left_parent = rec.matches["forward"].parents[0]
-                    right_parent = rec.matches["forward"].parents[1]
-                    record = {
-                        "node": u,
-                        "strain": rec.strain,
-                        "strain_date": strain_date,
-                        "max_descendant_samples": self.nodes_max_descendant_samples[u],
-                        "lineage_left": forward_lineages[0],
-                        "lineage_right": forward_lineages[1],
-                        "interval_left": rec.matches["backward"].breakpoints[1],
-                        "interval_right": rec.matches["forward"].breakpoints[1],
-                        "num_mutations": len(rec.matches["forward"].mutations),
-                        # "mrca": row.mrca,
-                        "tmrca": ts.nodes_time[row.mrca] - ts.nodes_time[u],
-                    }
-                    data.append(record)
+    def export_single_break_recombinants(self):
+        """
+        Return a table of information about one-break recombinants that
+        which consistently have two parents under all runs of the HMM,
+        and are mutation consistent on the foward and backward
+        additional HMM runs. We are strict here because we're primarily
+        interested in the breakpoint intervals --- mutation consistency
+        is required, for example, because we can have conflicting
+        intervals otherwise (where left > right).
+        """
+        recombs = self.combine_recombinant_info()
+        data = []
+        for rec in recombs:
+            condition = (
+                rec.is_path_length_consistent()
+                and rec.num_parents == 2
+                and rec.is_hmm_mutation_consistent()
+            )
+            if condition:
+                row = rec.data_summary()
+                fwd = rec.hmm_runs["forward"]
+                bck = rec.hmm_runs["backward"]
+                arg = rec.arg_info
+                row["num_mutations"] = len(fwd.mutations)
+                row["interval_left"] = bck.breakpoints[1]
+                row["interval_right"] = fwd.breakpoints[1]
+                mrca = arg.mrcas[0]
+                row["mrca"] = mrca
+                row["mrca_date"] = self.nodes_date[mrca]
+                data.append(row)
         return pd.DataFrame(data)
 
-    def export_recombination_node_breakpoints(self):
+    def export_recombinant_breakpoints(self):
         """
-        Make a dataframe with one row per recombination node breakpoint
-        Return info about the path to the mrca of left and right parents when travelling
-        up the tree to the left of the the breakpoint and to the right of the breakpoint.
+        Make a dataframe with one row per recombination node breakpoint,
+        giving information about that the left and right parent of that
+        break, and their MRCA.
 
+        Recombinants with multiple breaks are represented by multiple rows.
         You can only list the breakpoints in recombination nodes that have 2 parents by
         doing e.g. df.drop_duplicates('node', keep=False)
-
         """
-
-        for rec in self.recombinants:
-            # Sort recombinants by breakpoint location
-            forward_breakpoints = collections.defaultdict(list)
-            meta = self.nodes_metadata
-            for u in self.recombinants:
-                md = meta[u]
-                row = md["match_info"]
-                assert len(row) == 2
-                assert row[0]["strain"] == row[1]["strain"]
-                matches = {}
-                for record in row:
-                    matches[record["direction"]] = Match(
-                        breakpoints=record["breakpoints"],
-                        parents=record["parents"],
-                        mutations=record["mutations"],
-                    )
-                rec = Recombinant(row[0]["strain"], matches, node=u)
-                breaks = rec.matches["forward"].breakpoints[1:-1]
-                for i in range(len(breaks)):
-                    forward_breakpoints[breaks[i]].append(
-                        (
-                            u,
-                            rec.is_hmm_consistent(),
-                            rec.matches["forward"].parents[i : i + 2],
-                        )
-                    )
-            sorted_breakpoints = sorted(forward_breakpoints.keys())
-            tree_a_indexes = (
-                np.searchsorted(
-                    self.ts.breakpoints(as_array=True),
-                    sorted_breakpoints,
-                    side="left",
-                )
-                - 1
-            )
-            tree_b_indexes = (
-                np.searchsorted(
-                    self.ts.breakpoints(as_array=True),
-                    sorted_breakpoints,
-                    side="right",
-                )
-                - 1
-            )
-
-            causal_sample_map = get_recombinant_samples(self.ts)
-            tree_a = self.ts.first()
-            tree_b = self.ts.first()
-            node_times = self.ts.nodes_time
-            data = []
-            for i_a, i_b, brk in zip(
-                tree_a_indexes, tree_b_indexes, sorted_breakpoints
-            ):
-                tree_a.seek_index(i_a)
-                tree_b.seek_index(i_b)
-                for nd, hmm_cons, (l_parent, r_parent) in forward_breakpoints[brk]:
-                    num_nodes_in_path = 0
-                    node_a = l_parent
-                    node_b = r_parent
-                    row = {
-                        "in_arg": tree_a.parent(nd) == node_a
-                        and tree_b.parent(nd) == node_b
-                    }
-                    while True:
-                        if node_a == tskit.NULL or node_b == tskit.NULL:
-                            break
-                        if node_times[node_a] == node_times[node_b]:
-                            if node_a == node_b:
-                                break
-                            else:
-                                if tree_a.parent(node_a) < tree_b.parent(node_b):
-                                    node_a = tree_a.parent(node_a)
-                                else:
-                                    node_b = tree_b.parent(node_b)
-                                num_nodes_in_path += 1
-
-                        elif node_times[node_a] < node_times[node_b]:
-                            node_a = tree_a.parent(node_a)
-                            num_nodes_in_path += 1
-                        elif node_times[node_b] < node_times[node_a]:
-                            node_b = tree_b.parent(node_b)
-                            num_nodes_in_path += 1
-                    mrca = node_a
-                    row["node"] = nd
-                    row["max_descendant_samples"] = self.nodes_max_descendant_samples[
-                        nd
-                    ]
-                    row["breakpoint"] = brk
-                    row["hmm_consistent"] = hmm_cons
-                    row["left_parent"] = l_parent
-                    row["left_parent_pango"] = meta[l_parent].get("Imputed_lineage", "")
-                    row["right_parent"] = r_parent
-                    row["right_parent_pango"] = meta[r_parent].get(
-                        "Imputed_lineage", ""
-                    )
-                    row["parents_mrca"] = mrca
-                    row["tmrca"] = np.nan
-                    row["tmrca_delta"] = np.nan
-                    row["nodes_between_parents"] = np.nan
-                    # Pick one of the causal strains and report its Nextclade label
-                    row["origin_nextclade_pango"] = meta[causal_sample_map[nd]][
-                        "Nextclade_pango"
-                    ]
-
-                    if mrca != tskit.NULL:
-                        row["tmrca"] = node_times[mrca]
-                        row["tmrca_delta"] = node_times[mrca] - node_times[nd]
-                        row["nodes_between_parents"] = num_nodes_in_path
-                    data.append(row)
-            return pd.DataFrame(sorted(data, key=operator.itemgetter("node")))
+        recombs = self.combine_recombinant_info()
+        data = []
+        for rec in recombs:
+            arg = rec.arg_info
+            for j in range(len(arg.parents) - 1):
+                row = rec.data_summary()
+                mrca = arg.mrcas[j]
+                row["breakpoint"] = arg.breakpoints[j + 1]
+                row["left_parent"] = arg.parents[j]
+                row["right_parent"] = arg.parents[j + 1]
+                row["left_parent_imputed_lineage"] = arg.parent_imputed_lineages[j]
+                row["right_parent_imputed_lineage"] = arg.parent_imputed_lineages[j + 1]
+                row["mrca"] = mrca
+                row["mrca_date"] = self.nodes_date[mrca]
+                data.append(row)
+        return pd.DataFrame(sorted(data, key=operator.itemgetter("node")))
 
     def mutators_summary(self, threshold=10):
         mutator_nodes = np.where(self.nodes_num_mutations > threshold)[0]


### PR DESCRIPTION
I've added some code to systematically get all the recombinants from the ARG and the information about MRCAs for each partial edge. It's in the function get_recombinant_mrca_table (takes < 1 second to run on long ARG).

I've used this function to add some more filters on the ``export_recombinants`` function (renamed to export_one_break_recombinants). The point of this consistency filtering is to try and whittle down to things that are fairly consistent among the different runs of the HMM. The reasoning is that if we get radically different things from the three different runs in terms of the parents, then that probably isn't something worth reporting in a publication.
