### PR TITLE
Fixing missing GISAID lineages

### DIFF
--- a/notebooks/lineage-graphs.ipynb
+++ b/notebooks/lineage-graphs.ipynb
@@ -67,12 +67,21 @@
    "outputs": [],
    "source": [
     "sc2ts.utils.sample_subgraph(\n",
-    "    712029, \n",
-    "    ts, \n",
-    "    ti, \n",
+    "    712029,\n",
+    "    ts,\n",
+    "    ti,\n",
     "    mutations_json_filepath,\n",
     "    expand_down=True,\n",
-    "    imputation_source='Imputed_GISAID_lineage',\n",
+    "    filepath=None,\n",
+    "    ax=None,\n",
+    "    node_size=None,\n",
+    "    node_colours=None,\n",
+    "    colour_metadata_key=None,\n",
+    "    ts_id_labels=None,\n",
+    "    node_metadata_labels=None,\n",
+    "    sample_metadata_labels=None,\n",
+    "    edge_labels=None,\n",
+    "    node_label_replace=None\n",
     ")"
    ]
   }

--- a/notebooks/lineage-imputation.ipynb
+++ b/notebooks/lineage-imputation.ipynb
@@ -10,7 +10,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "06dc368e",
    "metadata": {},
    "outputs": [],
@@ -28,10 +28,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "26f1cf95",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Counting descendants : 100%|███████████████████████████████████████| 783231/783231 [00:00<00:00, 3460493.66it/s]\n",
+      "Indexing metadata    : 100%|█████████████████████████████████████████| 783231/783231 [00:08<00:00, 93027.58it/s]\n",
+      "Classifying mutations: 100%|██████████████████████████████████████| 1062072/1062072 [00:07<00:00, 142610.22it/s]\n",
+      "Counting descendants : 100%|█████████████████████████████████████| 1453347/1453347 [00:00<00:00, 3336969.57it/s]\n",
+      "Indexing metadata    : 100%|███████████████████████████████████████| 1453347/1453347 [00:16<00:00, 87669.72it/s]\n",
+      "Classifying mutations: 100%|██████████████████████████████████████| 1213193/1213193 [00:08<00:00, 141461.46it/s]\n"
+     ]
+    }
+   ],
    "source": [
     "ts_long_path = \"../../sc2ts_ts/upgma-mds-1000-md-30-mm-3-2022-06-30-recinfo\"\n",
     "ts_wide_path = \"../../sc2ts_ts/upgma-full-md-30-mm-3-2021-06-30-recinfo\"\n",
@@ -53,17 +66,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "77546779",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/var/folders/6m/05k8jk1s03q36gn2syqp87m80000gs/T/ipykernel_2688/3177304272.py:1: DtypeWarning: Columns (18) have mixed types. Specify dtype option on import or set low_memory=False.\n",
+      "  md = pd.read_table(gisaid_metadata_filepath)\n"
+     ]
+    }
+   ],
    "source": [
     "md = pd.read_table(gisaid_metadata_filepath)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "id": "c1c93bfc",
    "metadata": {},
    "outputs": [],
@@ -73,7 +95,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "id": "d3004341",
    "metadata": {},
    "outputs": [],
@@ -83,10 +105,29 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "id": "cb061202",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|███████████████████████████████████████████████████████████| 15115274/15115274 [00:15<00:00, 982823.61it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ts number of samples: 657239\n",
+      "number matched to gisaid data: 657168\n",
+      "number of differences: 46311\n",
+      "proportion: 0.0704705646044847\n",
+      "Filling in missing GISAID lineages with Nextclade lineages: 185\n"
+     ]
+    }
+   ],
    "source": [
     "ts_long_gisaid = sc2ts.utils.check_lineages(\n",
     "    ts_long,\n",
@@ -99,12 +140,31 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "id": "1f9f99dc",
    "metadata": {
     "scrolled": true
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|███████████████████████████████████████████████████████████| 15115274/15115274 [00:21<00:00, 715844.46it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ts number of samples: 1265685\n",
+      "number matched to gisaid data: 1265683\n",
+      "number of differences: 65677\n",
+      "proportion: 0.05189056027457112\n",
+      "Filling in missing GISAID lineages with Nextclade lineages: 0\n"
+     ]
+    }
+   ],
    "source": [
     "ts_wide_gisaid = sc2ts.utils.check_lineages(\n",
     "    ts_wide,\n",
@@ -125,10 +185,102 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "id": "3930d1da",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Recording relevant mutations for each node...\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "cee29a41d6a04870a7e1c5c35e153b6a",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  0%|          | 0/1062072 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Inferring lineages...\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "f323804040a74309b9fd1418b5701e94",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  0%|          | 0/781152 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "------------------------------\n",
+      "Sample nodes imputed: 657239 out of possible 657239\n",
+      "Internal nodes imputed: 123914 out of possible 123914\n",
+      "Total imputed: 781153 out of possible 781153\n",
+      "Number of recombinants (not imputed): 2078\n",
+      "------------------------------\n",
+      "Correctly imputed samples: 639658 ( 97.789 % )\n",
+      "Incorrectly imputed samples: 14460 ( 2.211 % )\n",
+      "Imputed using inheritance: 518270 ( 66.347 % ) decision tree: 262883 ( 33.653 % )\n",
+      "------------------------------\n",
+      "Time: 328.4449107646942\n",
+      "Inferring lineages...\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "4b29f820270c4dcbb550d2b94bced052",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  0%|          | 0/781152 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "------------------------------\n",
+      "Sample nodes imputed: 657205 out of possible 657239\n",
+      "Internal nodes imputed: 123948 out of possible 123914\n",
+      "Total imputed: 781153 out of possible 781153\n",
+      "Number of recombinants (not imputed): 2078\n",
+      "------------------------------\n",
+      "Correctly imputed samples: 634978 ( 97.084 % )\n",
+      "Incorrectly imputed samples: 19070 ( 2.916 % )\n",
+      "Imputed using inheritance: 518268 ( 66.347 % ) decision tree: 262885 ( 33.653 % )\n",
+      "------------------------------\n",
+      "Time: 355.47603726387024\n"
+     ]
+    }
+   ],
    "source": [
     "edited_ts_long = sc2ts.utils.lineage_imputation(\n",
     "    mutations_json_filepath,\n",
@@ -141,7 +293,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "id": "23b6e9a7",
    "metadata": {},
    "outputs": [],
@@ -152,10 +304,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "id": "f3369f8a",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0.9398057019493301\n"
+     ]
+    }
+   ],
    "source": [
     "correct = total = 0\n",
     "for node in edited_ts_long.nodes():\n",
@@ -168,10 +328,102 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "id": "3907aca2",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Recording relevant mutations for each node...\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "0a4f818c20eb491aadebb2c7fdedaad3",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  0%|          | 0/1213193 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Inferring lineages...\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "3b953a4c4f0d4a3b9204898f7b0e1cfc",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  0%|          | 0/1449223 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "------------------------------\n",
+      "Sample nodes imputed: 1265685 out of possible 1265685\n",
+      "Internal nodes imputed: 183539 out of possible 183539\n",
+      "Total imputed: 1449224 out of possible 1449224\n",
+      "Number of recombinants (not imputed): 4123\n",
+      "------------------------------\n",
+      "Correctly imputed samples: 1250162 ( 99.203 % )\n",
+      "Incorrectly imputed samples: 10045 ( 0.797 % )\n",
+      "Imputed using inheritance: 1160067 ( 80.047 % ) decision tree: 289157 ( 19.953 % )\n",
+      "------------------------------\n",
+      "Time: 545.9626221656799\n",
+      "Inferring lineages...\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "970bd399175146098828e2ebeeeda576",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  0%|          | 0/1449223 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "------------------------------\n",
+      "Sample nodes imputed: 1265685 out of possible 1265685\n",
+      "Internal nodes imputed: 183539 out of possible 183539\n",
+      "Total imputed: 1449224 out of possible 1449224\n",
+      "Number of recombinants (not imputed): 4123\n",
+      "------------------------------\n",
+      "Correctly imputed samples: 1244789 ( 98.777 % )\n",
+      "Incorrectly imputed samples: 15416 ( 1.223 % )\n",
+      "Imputed using inheritance: 1160067 ( 80.047 % ) decision tree: 289157 ( 19.953 % )\n",
+      "------------------------------\n",
+      "Time: 561.4245040416718\n"
+     ]
+    }
+   ],
    "source": [
     "edited_ts_wide = sc2ts.utils.lineage_imputation(\n",
     "    mutations_json_filepath,\n",
@@ -184,7 +436,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "id": "ac0fe662",
    "metadata": {},
    "outputs": [],
@@ -195,10 +447,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "id": "d1ab97f9",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0.94598267097228\n"
+     ]
+    }
+   ],
    "source": [
     "correct = total = 0\n",
     "for node in edited_ts_wide.nodes():\n",

--- a/sc2ts/utils.py
+++ b/sc2ts/utils.py
@@ -345,8 +345,8 @@ class TreeInfo:
             if node.is_sample():
                 self.epi_isl_map[md["gisaid_epi_isl"]] = node.id
                 if md["gisaid_epi_isl"] is not None:
-                    if '.' in md["gisaid_epi_isl"]:
-                        self.epi_isl_map[md["gisaid_epi_isl"].split('.')[0]] = node.id
+                    if "." in md["gisaid_epi_isl"]:
+                        self.epi_isl_map[md["gisaid_epi_isl"].split(".")[0]] = node.id
                 self.strain_map[md["strain"]] = node.id
                 self.nodes_date[node.id] = md["date"]
                 self.nodes_submission_date[node.id] = md["date_submitted"]
@@ -729,7 +729,8 @@ class TreeInfo:
             key = "Imputed_" + pango_source
             if key not in self.nodes_metadata[u]:
                 raise ValueError(
-                    f"{key} not available. You may need to run the imputation pipeline")
+                    f"{key} not available. You may need to run the imputation pipeline"
+                )
             lineage = self.nodes_metadata[u]["Imputed_" + pango_source]
             return lineage
 
@@ -754,7 +755,8 @@ class TreeInfo:
                     parents=parents,
                     mutations=record["mutations"],
                     parent_imputed_lineages=[
-                        get_imputed_pango(x, self.pango_source) for x in parents],
+                        get_imputed_pango(x, self.pango_source) for x in parents
+                    ],
                 )
             breakpoints = [0]
             parents = []
@@ -770,11 +772,13 @@ class TreeInfo:
                 parents=parents,
                 mrcas=mrcas,
                 parent_imputed_lineages=[
-                    get_imputed_pango(x, self.pango_source) for x in parents],
+                    get_imputed_pango(x, self.pango_source) for x in parents
+                ],
             )
             causal_node = self.strain_map[strain]
             causal_lineage = self.nodes_metadata[causal_node].get(
-                    self.pango_source, "unknown")
+                self.pango_source, "unknown"
+            )
             rec = Recombinant(
                 causal_strain=strain,
                 causal_date=md["date_added"],
@@ -1384,9 +1388,9 @@ def sample_subgraph(
     Draws out a subgraph of the ARG above the given sample, including all nodes and
     edges on the path to the nearest sample nodes (showing any recombinations on
     the way).
-    
+
     # TODO - document the rest of the parameters
-    
+
     :param plt.Axes ax: a matplotlib axis object on which to plot the graph.
         This allows the graph to be placed as a subplot or the size and aspect ratio
         to be adjusted. If ``None`` (default) plot to the current axis with some
@@ -1418,21 +1422,21 @@ def sample_subgraph(
         which distinguishes between sample nodes, recombination nodes, and all others.
     :param dict colour_metadata_key: A key in the metadata, to use when specifying
         bespoke node colours. Default: ``None``, treated as "strain".
-        
+
 
     :return: The networkx Digraph and the positions of nodes in the digraph as a dict of
         ``{node_id : (x, y), ...}``
     :rtype:  tuple(nx.DiGraph, dict)
-    
+
     """
     if node_size is None:
-        node_size=2800
+        node_size = 2800
     if ts_id_labels is None:
-        ts_id_labels=True
+        ts_id_labels = True
     if node_metadata_labels is None:
-        node_metadata_labels="Imputed_GISAID_lineage"
+        node_metadata_labels = "Imputed_GISAID_lineage"
     if sample_metadata_labels is None:
-        sample_metadata_labels="gisaid_epi_isl"
+        sample_metadata_labels = "gisaid_epi_isl"
     if colour_metadata_key is None:
         colour_metadata_key = "strain"
     col_green = "#228833"
@@ -1462,7 +1466,7 @@ def sample_subgraph(
         if ts_id_labels:
             nodelabels[node.id].append(str(node.id))
         if node_metadata_labels:
-             nodelabels[node.id].append(node.metadata[node_metadata_labels])
+            nodelabels[node.id].append(node.metadata[node_metadata_labels])
 
         if (not node.is_sample()) or node.id == sample_node:
             parent_node = None
@@ -1500,15 +1504,20 @@ def sample_subgraph(
                                 nodelabels[ch].append(str(ch_node.id))
                             if node_metadata_labels:
                                 nodelabels[ch].append(
-                                    ch_node.metadata[node_metadata_labels])
+                                    ch_node.metadata[node_metadata_labels]
+                                )
                             if ch_node.is_sample():
                                 default_nodecolours[ch] = col_blue
                                 if sample_metadata_labels:
                                     nodelabels[ch].append(
-                                        ch_node.metadata[sample_metadata_labels])
+                                        ch_node.metadata[sample_metadata_labels]
+                                    )
                                     if t.num_samples(ch) > 1:
                                         nodelabels[ch].append(
-                                            "+" + str(t.num_samples(ch)-1) + " samples")
+                                            "+"
+                                            + str(t.num_samples(ch) - 1)
+                                            + " samples"
+                                        )
                             else:
                                 default_nodecolours[ch] = col_grey
                                 nodes_to_search_down.add(ch)
@@ -1524,7 +1533,7 @@ def sample_subgraph(
                 default_nodecolours[node.id] = col_blue
                 if sample_metadata_labels:
                     nodelabels[node.id].append(node.metadata[sample_metadata_labels])
-            
+
     nodelabels = {k: "\n".join(v) for k, v in nodelabels.items()}
     if node_label_replace is not None:
         for search, replace in node_label_replace.items():
@@ -1535,7 +1544,7 @@ def sample_subgraph(
         edge_labels = {}
         for key, value in edgelabels.items():
             edge_labels[key] = "\n".join([str(v) for v in value])
-    
+
         for m in ts.mutations():
             if m.node in related_nodes:
                 includemut = False
@@ -1563,14 +1572,14 @@ def sample_subgraph(
         for u in G.nodes:
             fill_cols.append(default_nodecolours[u])
     else:
-        default_colour = node_colours.get(None, "None") 
+        default_colour = node_colours.get(None, "None")
         for u in G.nodes:
             try:
                 fill_cols.append(node_colours[u])
             except KeyError:
                 md_val = ts.node(u).metadata.get(colour_metadata_key, None)
                 fill_cols.append(node_colours.get(md_val, default_colour))
-    
+
     stroke_cols = [("black" if c == "None" else c) for c in fill_cols]
 
     nx.draw(
@@ -1584,7 +1593,7 @@ def sample_subgraph(
         node_size=node_size,
         font_size=6,
     )
-    
+
     if len(edge_labels) > 0:
         nx.draw_networkx_edge_labels(
             G, pos, edge_labels=edge_labels, label_pos=0.5, rotate=False, font_size=5
@@ -1594,6 +1603,7 @@ def sample_subgraph(
     else:
         plt.show()
     return G, pos
+
 
 def imputation_setup(filepath, verbose=False):
     """

--- a/sc2ts/utils.py
+++ b/sc2ts/utils.py
@@ -344,6 +344,9 @@ class TreeInfo:
             self.nodes_metadata[node.id] = md
             if node.is_sample():
                 self.epi_isl_map[md["gisaid_epi_isl"]] = node.id
+                if md["gisaid_epi_isl"] is not None:
+                    if '.' in md["gisaid_epi_isl"]:
+                        self.epi_isl_map[md["gisaid_epi_isl"].split('.')[0]] = node.id
                 self.strain_map[md["strain"]] = node.id
                 self.nodes_date[node.id] = md["date"]
                 self.nodes_submission_date[node.id] = md["date_submitted"]
@@ -1505,7 +1508,7 @@ def sample_subgraph(
                                         ch_node.metadata[sample_metadata_labels])
                                     if t.num_samples(ch) > 1:
                                         nodelabels[ch].append(
-                                            str(t.num_samples(ch)-1) + " samples")
+                                            "+" + str(t.num_samples(ch)-1) + " samples")
                             else:
                                 default_nodecolours[ch] = col_grey
                                 nodes_to_search_down.add(ch)


### PR DESCRIPTION
Was missing out some lineages because (for example) EPI_ISL_000000.1 in the ts metadata appears only as EPI_ISL_000000 in the GISAID metadata file.  Still a hundred missing or so, but for some other reasons.