### PR TITLE
Only plot if no axis defined

### DIFF
--- a/sc2ts/utils.py
+++ b/sc2ts/utils.py
@@ -1614,7 +1614,7 @@ def sample_subgraph(
         )
     if filepath:
         plt.savefig(filepath)
-    else:
+    elif ax is None:
         plt.show()
     return G, pos
 


### PR DESCRIPTION
We need to be able to turn off `plt.show()` when scriptifying this plot to create figures for publication (rather than outputting to a notebook). The easiest is not to call `show()` when a plot axis has already been specified, which is what we do when creating pdfs for publication.