### PR TITLE
Rework sample_subgraph plot, particularly labels

### DIFF
--- a/sc2ts/utils.py
+++ b/sc2ts/utils.py
@@ -1534,7 +1534,7 @@ def sample_subgraph(
                 nodelabels[node.id].append(node.metadata[sample_metadata_labels])
 
     down_nodes = set()
-    if expand_down or logging.isEnabledFor(logging.INFO):
+    if expand_down or logging.getLogger().isEnabledFor(logging.INFO):
         while nodes_to_search_down:
             node = ts.node(nodes_to_search_down.pop())
             if (not node.is_sample()) or node.id == sample_node:

--- a/sc2ts/utils.py
+++ b/sc2ts/utils.py
@@ -1476,7 +1476,7 @@ def sample_subgraph(
     while nodes_to_search_up:
         node = ts.node(nodes_to_search_up.pop())
         if ts_id_labels or (ts_id_labels is None and node.is_sample()):
-            nodelabels[node.id].append(str(node.id))
+            nodelabels[node.id].append(f"tsk{node.id}")
         if node_metadata_labels:
             nodelabels[node.id].append(node.metadata[node_metadata_labels])
 
@@ -1516,7 +1516,7 @@ def sample_subgraph(
                                 ts_id_labels or
                                 (ts_id_labels is None and ch_node.is_sample())
                             ):
-                                nodelabels[ch].append(str(ch_node.id))
+                                nodelabels[ch].append(f"tsk{ch_node.id}")
                             if node_metadata_labels:
                                 nodelabels[ch].append(
                                     ch_node.metadata[node_metadata_labels]

--- a/sc2ts/utils.py
+++ b/sc2ts/utils.py
@@ -1397,8 +1397,9 @@ def sample_subgraph(
         sensible figsize defaults.
     :param int node_size: The size of the node circles. Default:
         ``None``, treated as 2800.
-    :param bool ts_id_labels: Should we label nodes with their tskit node ID? Default:
-        ``None``, treated as ``True``.
+    :param bool ts_id_labels: Should we label nodes with their tskit node ID? If
+        ``None``, show the node ID only for sample nodes. If ``True``, show
+        it for all nodes. If ``False``, do not show. Default: ``None``.
     :param str node_metadata_labels: Should we label all nodes with a value from their
         metadata: Default: ``None``, treated as ``"Imputed_GISAID_lineage"``. If ``""``,
         do not plot any all-node metadata.
@@ -1444,8 +1445,6 @@ def sample_subgraph(
             
     if node_size is None:
         node_size = 2800
-    if ts_id_labels is None:
-        ts_id_labels = True
     if node_metadata_labels is None:
         node_metadata_labels = "Imputed_GISAID_lineage"
     if sample_metadata_labels is None:
@@ -1476,7 +1475,7 @@ def sample_subgraph(
 
     while nodes_to_search_up:
         node = ts.node(nodes_to_search_up.pop())
-        if ts_id_labels:
+        if ts_id_labels or (ts_id_labels is None and node.is_sample()):
             nodelabels[node.id].append(str(node.id))
         if node_metadata_labels:
             nodelabels[node.id].append(node.metadata[node_metadata_labels])
@@ -1513,7 +1512,10 @@ def sample_subgraph(
                         ch_node = ts.node(ch)
                         if ch not in G.nodes:
                             G.add_node(ch)
-                            if ts_id_labels:
+                            if (
+                                ts_id_labels or
+                                (ts_id_labels is None and ch_node.is_sample())
+                            ):
                                 nodelabels[ch].append(str(ch_node.id))
                             if node_metadata_labels:
                                 nodelabels[ch].append(

--- a/sc2ts/utils.py
+++ b/sc2ts/utils.py
@@ -1632,7 +1632,8 @@ def sample_subgraph(
     # Shouldn't need this once https://github.com/jeromekelleher/sc2ts/issues/132 fixed
     unary_nodes_to_remove = set()
     for k, d in G.degree():
-        if d == 2 and k not in mut_nodes:
+        flags = ts.node(k).flags
+        if d == 2 and k not in mut_nodes and not (flags & sc2ts.NODE_IS_RECOMBINANT):
             G.add_edge(*G.predecessors(k), *G.successors(k))
             if (k, *G.successors(k)) in edge_labels:
                 edge_labels[(*G.predecessors(k), *G.successors(k))] = edge_labels.pop(

--- a/sc2ts/utils.py
+++ b/sc2ts/utils.py
@@ -1645,6 +1645,9 @@ def sample_subgraph(
     positions = {"child": 0.25, "mid": 0.5, "parent": 0.75}
     vert_align = {"child": "bottom", "mid": "center", "parent": "top"}
     for placement, labels in edge_label_pos.items():
+        font_color = "k"
+        if all([l[0] in ('≥', '<') for lab in labels.values() for l in lab.split("\n")]):
+            font_color = "darkred"
         if len(labels) > 0:
             nx.draw_networkx_edge_labels(
                 G,
@@ -1652,6 +1655,7 @@ def sample_subgraph(
                 edge_labels=labels,
                 label_pos=positions[placement],
                 verticalalignment=vert_align[placement],
+                font_color=font_color,
                 rotate=False,
                 font_size=5
             )


### PR DESCRIPTION
This places edge labels containing mutations at the bottom of the edge, and changes the format for recombination positions to put the numbers on 2 lines, with "≥" and "<" in front of the numbers to distinguish from mutations.