### PR TITLE
Add `dereference_singleton_recombinants`

### DIFF
--- a/sc2ts/utils.py
+++ b/sc2ts/utils.py
@@ -841,6 +841,7 @@ class TreeInfo:
         for rec in recombs:
             arg = rec.arg_info
             for j in range(len(arg.parents) - 1):
+                assert arg.breakpoints[j + 1] in rec.hmm_runs["forward"].breakpoints
                 row = rec.data_summary()
                 mrca = arg.mrcas[j]
                 row["breakpoint"] = arg.breakpoints[j + 1]
@@ -1369,6 +1370,39 @@ def get_recombinant_samples(ts):
     return out
 
 
+def detach_singleton_recombinants(ts, filter_nodes=False):
+    """
+    Return a new tree sequence where recombinant samples that are the sole
+    descendant of a recombination node have been marked as non-samples,
+    causing those nodes and the recombination nodes above them
+    to be detached from the topology.
+
+    In order to ensure that that node IDs remain stable, by default,
+    detached nodes are *not* filtered from the resulting tree sequence. To
+    remove the nodes completely, set filter_nodes=True (but note that
+    this may render invalid any node IDs used within the tree sequence's
+    metadata).
+    """
+
+    is_sample_leaf = np.zeros(ts.num_nodes, dtype=bool)
+    is_sample_leaf[ts.samples()] = True
+    is_sample_leaf[ts.edges_parent] = False
+    # parent IDs of sample leaves
+    sample_leaf_parents = ts.edges_parent[np.isin(ts.edges_child, np.flatnonzero(is_sample_leaf))]
+    # get repeated parent IDs, one for each edge leading to the parent
+    sample_leaf_parents = ts.edges_parent[np.isin(ts.edges_parent, sample_leaf_parents)]
+    sample_leaf_parents, counts = np.unique(sample_leaf_parents, return_counts=True)
+    single_sample_leaf_parents = sample_leaf_parents[counts == 1]
+    # Find the ones that are also recombination nodes
+    re_nodes = np.flatnonzero(ts.nodes_flags & sc2ts.NODE_IS_RECOMBINANT)
+    single_sample_leaf_re = np.intersect1d(re_nodes, single_sample_leaf_parents)
+    bad_samples = ts.edges_child[np.isin(ts.edges_parent, single_sample_leaf_re)]
+    # All of these should be samples, because they were defined via single edges above a sample
+    assert len(np.setdiff1d(bad_samples, ts.samples())) == 0
+    keep = np.setdiff1d(ts.samples(), bad_samples)
+    return ts.simplify(keep, keep_unary=True, filter_nodes=filter_nodes)
+
+
 def node_path_to_samples(
     nodes, ts, rootwards=True, ignore_initial=True, stop_at_recombination=False
 ):
@@ -1583,12 +1617,12 @@ def plot_subgraph(
                 tip_samples[u] = 0
     for tree in ts.trees():
         for u in tip_samples.keys():
-            # This is't quite right - it show the max num descendants, not the
-            # total number of samples. But it's close enough.
+            # This is't quite right - it shows the max num samples per tree,
+            # not the total number of samples. But it's close enough.
             tip_samples[u] = max(tip_samples[u], tree.num_samples(u))
     for u, s in tip_samples.items():
         if s > 1:
-            nodelabels[u].append(f"+{s-1} samples")
+            nodelabels[u].append(f"+{s-1} {'samples' if s > 2 else 'sample'}")
 
     nodelabels = {k: "\n".join(v) for k, v in nodelabels.items()}
 

--- a/sc2ts/utils.py
+++ b/sc2ts/utils.py
@@ -1400,7 +1400,12 @@ def detach_singleton_recombinants(ts, filter_nodes=False):
     # All of these should be samples, because they were defined via single edges above a sample
     assert len(np.setdiff1d(bad_samples, ts.samples())) == 0
     keep = np.setdiff1d(ts.samples(), bad_samples)
-    return ts.simplify(keep, keep_unary=True, filter_nodes=filter_nodes)
+    return ts.simplify(
+        keep,
+        keep_unary=True,
+        filter_sites=False,
+        filter_nodes=filter_nodes,
+    )
 
 
 def node_path_to_samples(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,17 @@
+import pytest
+import numpy as np
+
+import sc2ts
+import util
+
+
+class TestPadSites:
+    def check_site_padding(self, ts):
+        ts = sc2ts.utils.pad_sites(ts)
+        ref = sc2ts.core.get_reference_sequence()
+        assert ts.num_sites == len(ref) - 1
+        ancestral_state = ts.tables.sites.ancestral_state.view("S1").astype(str)
+        assert np.all(ancestral_state == ref[1:])
+
+    def test_initial(self):
+        self.check_site_padding(sc2ts.initial_ts())

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,5 @@
-import pytest
 import numpy as np
+import pytest
 
 import sc2ts
 import util
@@ -15,3 +15,68 @@ class TestPadSites:
 
     def test_initial(self):
         self.check_site_padding(sc2ts.initial_ts())
+
+
+class TestDetachSingletonRecombinants:
+    def make_recombinant_tree(self, num_samples=1):
+        # Make a tree sequence by adding num_samples samples under a
+        # single recombination node. Start with the following tree:
+        # 4.00┊  0  ┊
+        #     ┊  ┃  ┊
+        # 3.00┊  1  ┊
+        #     ┊  ┃  ┊
+        # 2.00┊  4  ┊
+        #     ┊ ┏┻┓ ┊
+        # 1.00┊ 2 3 ┊
+        #     0   29904
+        ts = util.example_binary(2)
+        L = ts.sequence_length
+        x = L / 2
+        samples = util.get_samples(ts, [[(0, x, 2), (x, L, 3)]] * num_samples)
+        ts_rec = sc2ts.add_matching_results(samples, ts, "2021")
+        assert ts_rec.num_trees == 2
+        return ts_rec
+    
+    @pytest.mark.parametrize(
+        "ts",
+        # Should probably add sc2ts.initial_ts() here, but see
+        # https://github.com/jeromekelleher/sc2ts/issues/152
+        [util.example_binary(1), util.example_binary(2), util.example_binary(3)]
+    )
+    def test_no_recombinants(self, ts):
+        ts2 = sc2ts.detach_singleton_recombinants(ts)
+        ts.tables.assert_equals(ts2.tables, ignore_provenance=True)
+
+    def test_one_sample_recombinant(self):
+        ts = self.make_recombinant_tree()
+        assert ts.num_samples == 3
+        re_nodes = [
+            node.id
+            for node in ts.nodes()
+            if node.flags & sc2ts.NODE_IS_RECOMBINANT
+        ]
+        assert len(re_nodes) == 1
+        re_node = re_nodes[0]
+        nodes_under_re = {re_node}
+        for tree in ts.trees():
+            nodes_under_re.update(tree.nodes(re_node))
+        for u in nodes_under_re:
+            for tree in ts.trees():
+                assert not tree.is_isolated(u)
+        ts2 = sc2ts.detach_singleton_recombinants(ts)
+        assert ts2 != ts
+        assert ts2.num_samples == ts.num_samples - 1
+        assert ts2.num_nodes == ts.num_nodes
+        for u in nodes_under_re:
+            for tree in ts2.trees():
+                assert tree.is_isolated(u)
+        ts3 = sc2ts.detach_singleton_recombinants(ts2, filter_nodes=True)
+        assert ts3.num_samples == ts.num_samples - 1
+        assert ts3.num_nodes == ts.num_nodes - 2  # both sample and re node gone
+
+    def test_two_sample_recombinant(self):
+        """Test that we don't detach anything if the recombinant node is not a singleton"""
+        ts = self.make_recombinant_tree(num_samples=2)
+        assert ts.num_samples == 4
+        ts2 = sc2ts.detach_singleton_recombinants(ts)
+        ts.tables.assert_equals(ts2.tables, ignore_provenance=True)

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,0 +1,43 @@
+import numpy as np
+import tskit
+
+import sc2ts
+
+
+# NOTE: the current API in which we update the Sample objects is
+# really horrible and we need to refactor to make it more testable.
+# This function is a symptom of that.
+def get_samples(ts, paths, mutations=None):
+    if mutations is None:
+        mutations = [[] for _ in paths]
+
+    # Translate from site IDs to positions
+    updated_mutations = []
+    for sample_mutations in mutations:
+        updated = [
+            (ts.sites_position[site], state) for (site, state) in sample_mutations
+        ]
+        updated_mutations.append(updated)
+    samples = [sc2ts.Sample() for _ in paths]
+    sc2ts.update_path_info(samples, ts, paths, updated_mutations)
+    return samples
+
+
+def example_binary(n):
+    base = sc2ts.initial_ts()
+    tables = base.dump_tables()
+    tree = tskit.Tree.generate_balanced(n, span=base.sequence_length)
+    binary_tables = tree.tree_sequence.dump_tables()
+    binary_tables.nodes.time += 1
+    tables.nodes.time += np.max(binary_tables.nodes.time) + 1
+    binary_tables.edges.child += len(tables.nodes)
+    binary_tables.edges.parent += len(tables.nodes)
+    for node in binary_tables.nodes:
+        tables.nodes.append(node.replace(metadata={}))
+    for edge in binary_tables.edges:
+        tables.edges.append(edge)
+    # FIXME brittle
+    tables.edges.add_row(0, base.sequence_length, parent=1, child=tree.root + 2)
+    tables.sort()
+    return tables.tree_sequence()
+


### PR DESCRIPTION
Allows us to create a ts for plotting that doesn't have singleton recombinants and their associated recombination nodes.