### PR TITLE
Uppercase input sequences

### DIFF
--- a/sc2ts/alignments.py
+++ b/sc2ts/alignments.py
@@ -125,6 +125,7 @@ class AlignmentStore(collections.abc.Mapping):
         bar = tqdm.tqdm(total=num_chunks, disable=not show_progress)
         chunk = []
         for k, v in alignments.items():
+            v = np.char.upper(v)
             chunk.append((k, compress_alignment(v)))
             if len(chunk) == chunk_size:
                 self._flush(chunk)


### PR DESCRIPTION
Sample sequences may be come in lowercase, for example, in the latest batch of sequences kindly prepared by Martin Hunt from the Iqbal group. Here is a simple tweak to convert lowercased sequences into uppercased sequences, which can be mapped to the uppercase nucleotide characters in `core.ALLELES`. Note that a sequence is stored as a Numpy array (dtype="<U1"), and the entire array is uppercased.