### PR TITLE
Fix adding excluded samples to an empty list of reconsidered samples

### DIFF
--- a/sc2ts/inference.py
+++ b/sc2ts/inference.py
@@ -303,10 +303,10 @@ def daily_extend(
         yield ts, excluded_samples, date
 
         # Update list of reconsidered samples.
+        reconsidered_samples.extend(excluded_samples)
         if len(reconsidered_samples) > 0:
             while reconsidered_samples[0].date == earliest_date:
                 reconsidered_samples.popleft()
-            reconsidered_samples.extend(excluded_samples)
 
         earliest_date += datetime.timedelta(days=1)
 


### PR DESCRIPTION
This fixes a logical bug, which led to the list of reconsidered samples being extended only if it is not empty. This means none of the excluded samples are reconsidered if we do not provide a base ts when running `daily-extend`.