### PR TITLE
Fix overly strict causal sample date

### DIFF
--- a/sc2ts/utils.py
+++ b/sc2ts/utils.py
@@ -1320,7 +1320,7 @@ def get_recombinant_samples(ts):
         # Search the subtree for a causal sample.
         for v in tree.nodes(u, order="levelorder"):
             child = ts.node(v)
-            if child.is_sample() and child.metadata["date"] == recomb_date:
+            if child.is_sample() and child.metadata["date"] <= recomb_date:
                 edge = ts.edge(tree.edge(v))
                 assert edge.left == 0 and edge.right == ts.sequence_length
                 causal_sample = child


### PR DESCRIPTION
Note this probably isn't correct in general, but at least lets things run. We need improved metadata here on recombinants (see #233)