### PR TITLE
Rescale ls params and adaptive precision

### DIFF
--- a/sc2ts/cli.py
+++ b/sc2ts/cli.py
@@ -76,10 +76,10 @@ def setup_logging(verbosity, log_file=None):
     # to go to the log to see the traceback, but for production it may
     # be better to let daiquiri record the errors as well.
     daiquiri.setup(outputs=outputs, set_excepthook=False)
-    # Only show stuff coming from sc2ts. Sometimes it's handy to look
-    # at the tsinfer logs too, so we could add an option to set its
-    # levels
+    # Only show stuff coming from sc2ts and the relevant bits of tsinfer.
     logger = logging.getLogger("sc2ts")
+    logger.setLevel(log_level)
+    logger = logging.getLogger("tsinfer.inference")
     logger.setLevel(log_level)
 
 

--- a/sc2ts/inference.py
+++ b/sc2ts/inference.py
@@ -805,15 +805,16 @@ def solve_num_mismatches(ts, k):
         # on how low we can push the HMM precision. We should be able to solve
         # for the optimal value of this parameter such that the magnitude of the
         # values within the HMM are as large as possible (so that we can truncate
-        # usefully). This value is probably close for k=3 (it fails for k=2).
-        mu = 1e-2
+        # usefully).
+        mu = 1e-3
         denom = (1 - mu) ** k + (n - 1) * mu**k
         r = n * mu**k / denom
         assert mu < 0.5
         assert r < 0.5
 
-    # Add a tiny bit of extra mass for recombination so that we deterministically
+    # Add a little bit of extra mass for recombination so that we deterministically
     # chose to recombine over k mutations
+    # NOTE: the magnitude of this value will depend also on mu, see above.
     r += r * 0.01
     ls_recomb = np.full(m - 1, r)
     ls_mismatch = np.full(m, mu)

--- a/sc2ts/inference.py
+++ b/sc2ts/inference.py
@@ -801,7 +801,12 @@ def solve_num_mismatches(ts, k):
         r = 1e-3
         mu = 1e-20
     else:
-        mu = 1e-6
+        # NOTE: the magnitude of mu matters because it puts a limit
+        # on how low we can push the HMM precision. We should be able to solve
+        # for the optimal value of this parameter such that the magnitude of the
+        # values within the HMM are as large as possible (so that we can truncate
+        # usefully). This value is probably close for k=3 (it fails for k=2).
+        mu = 1e-2
         denom = (1 - mu) ** k + (n - 1) * mu**k
         r = n * mu**k / denom
         assert mu < 0.5

--- a/sc2ts/inference.py
+++ b/sc2ts/inference.py
@@ -443,7 +443,7 @@ def preprocess(
         logger.warn(f"Zero metadata matches for {date}")
         return []
 
-    if date.endswith("01-01"):
+    if date.endswith("12-31"):
         logger.warning(f"Skipping {len(metadata_matches)} samples for {date}")
         return []
 


### PR DESCRIPTION
Some useful updates here that make matching substantially faster.

Previous experiments that I did showed that we get exactly the same results for any precision>=12, so I left it at that value and moved on. I tried varying the precision values here and noticed some odd properties, and then realised that the precision value is bound up with the magnitude of the input rho and mu parameters, and if these are too small, then we will necessarily have to have a high precision in order to work with them. So, I rescaled the (arbitrarily chosen) mu value so that our parameters are as large as possible (ish). This then lets us use a more useful range of precision values.

Under this new LS parameter rescaling, we get identical results to the old runs with a precision of 6. Having higher precision values makes very little difference to run times. Precision values < 6 do have a substantial effect, but get different results, most notably missing out on recombinants. However, this seems to only effect things that have a higher HMM cost. For low HMM cost, lower values of precision seem to get exactly the same results as higher values. This is very useful, if true, because most things will have a low HMM cost, and we can therefore get matches for most new sequences very quickly using a low precision value, and then rerun the more difficult sequences with a high precision.

I implemented a crude version of this here, where we first run all samples for a given day with precision=2, and then rerun any samples that have a hmm_cost of >= 2 with precision=6. This is much faster than running all samples with precision=6. For example, for 2020-12-24, we have 1.07k samples to match. The first precision=2 sketch pass takes 55s (19.3 samples/s). This leaves 243 samples with a hmm cost of >= 2 which we need to rerun for. Rerunning these takes 2.5 minutes at a rate of 1.5 samples/s.

This new method infers precisely the same ARG (well, precisely the same numbers of nodes, edges and mutations) as running everything with precision=6, so I'm confident that precision=2 is catching the hmm_cost < 2 case correctly. We could probably do better by rerunning the remaining samples with precision=3, 4,... but we'd need to do some maths to figure out how this is all actually working.
