### PR TITLE
Tweak dynamic parameters

### DIFF
--- a/sc2ts/inference.py
+++ b/sc2ts/inference.py
@@ -8,6 +8,7 @@ import pickle
 import os
 import sqlite3
 import pathlib
+import random
 
 import tqdm
 import tskit
@@ -579,7 +580,13 @@ def extend(
     #     metadata_db.query("SELECT * FROM samples WHERE strain=='SRR19463295'")
     # )
     # TODO implement this.
-    assert max_daily_samples is None
+    if max_daily_samples is not None:
+        if max_daily_samples < len(metadata_matches):
+            # FIXME this isn't very random - use a hash of the seed and the current
+            # date in future.
+            rng = random.Random(random_seed)
+            metadata_matches = rng.sample(metadata_matches, max_daily_samples)
+            logger.info(f"Subset to {len(metadata_matches)} samples")
 
     samples = preprocess(
         metadata_matches, base_ts, date, alignment_store, show_progress=show_progress

--- a/sc2ts/inference.py
+++ b/sc2ts/inference.py
@@ -565,6 +565,8 @@ def extend(
         hmm_cost_threshold = 5
     if min_group_size is None:
         min_group_size = 10
+    if retrospective_window is None:
+        retrospective_window = 30
 
     check_base_ts(base_ts)
     logger.info(

--- a/sc2ts/inference.py
+++ b/sc2ts/inference.py
@@ -691,6 +691,15 @@ def match_path_ts(samples, ts, path, reversions):
         "samples": [sample.strain for sample in samples],
         "path": [seg.asdict() for seg in path],
     }
+    # FIXME this doesn't work because we don't actually
+    # use this node in the output trees. What we probably want to
+    # do is create a unique ID that we put into the metadata of
+    # every node we ultimately attach from this tree. That could
+    # be a hash of the sample IDs, I guess. It could record
+    # the number of samples also, usefully. Basically we want
+    # to enable tracing around the larger tree later, and to
+    # figure out which nodes were added at as part of a particular
+    # group, on a particular day.
     tables.nodes.add_row(time=1, metadata={"sc2ts": md})
     path = samples[0].path
     site_id_map = {}

--- a/sc2ts/inference.py
+++ b/sc2ts/inference.py
@@ -407,10 +407,15 @@ def match_samples(
 ):
     run_batch = samples
 
-    mu = 0.125  ## FIXME
+    # ls_recomb, ls_mismatch = solve_num_mismatches(num_mismatches, 2)
+    # rho = ls_recomb[0]
+    # mu = ls_mismatch[0]
+    mu = 0.125
+    # print(rho, mu)
     for k in range(2):
         # To catch k mismatches we need a likelihood threshold of mu**k
         likelihood_threshold = mu**k - 1e-15
+        # print(k, likelihood_threshold)
         logger.info(
             f"Running match={k} batch of {len(run_batch)} at threshold={likelihood_threshold}"
         )
@@ -812,13 +817,14 @@ def solve_num_mismatches(k, num_sites, mu=0.125):
     # values of k <= 1 are not relevant for SC2 and lead to awkward corner cases
     assert k > 1
 
-    denom = (1 - mu) ** k
-    r = mu**k / denom
+    # denom = (1 - mu) ** k
+    # r = mu**k / denom
 
     # Add a little bit of extra mass for recombination so that we deterministically
     # chose to recombine over k mutations
     # NOTE: the magnitude of this value will depend also on mu, see above.
-    r += r * 0.125
+    # r += r * 0.125
+    r = mu**k + 1e-3
     ls_recomb = np.full(num_sites - 1, r)
     ls_mismatch = np.full(num_sites, mu)
     return ls_recomb, ls_mismatch

--- a/sc2ts/metadata.py
+++ b/sc2ts/metadata.py
@@ -69,6 +69,12 @@ class MetadataDb(collections.abc.Mapping):
     def close(self):
         self.conn.close()
 
+    def query(self, sql, args=None):
+        logger.debug(f"Running query:{sql}")
+        with self.conn:
+            for row in self.conn.execute(sql):
+                yield row
+
     def get(self, date):
         sql = "SELECT * FROM samples WHERE date==?"
         with self.conn:


### PR DESCRIPTION
Trying out running in three passes with a likelihood threshold of 0, mu, and rho^2  * mu^5 (which is about 1e-10, and around the same as 10 mutations). I've arbitrarily chosen this as the most unlikely thing we'd want to characterise exactly.

Just seeing if this gives us the same results as the previous pass with completely unlimited precision and improves run-time.