### PR TITLE
Pango lineage data

### DIFF
--- a/get_lineage_data.sh
+++ b/get_lineage_data.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# Shell script to download pango lineage data from cov-lineages.
+
+wget https://github.com/cov-lineages/lineages-website/raw/refs/heads/master/_data/lineage_data.full.json
+# Cut down the fields to remove country counts etc.
+cat lineage_data.full.json | jq '[.[]|{Lineage,"Earliest date","Latest date",Description}]' > sc2ts/data/lineages.json

--- a/sc2ts/core.py
+++ b/sc2ts/core.py
@@ -1,3 +1,5 @@
+import dataclasses
+import json
 import pathlib
 import collections.abc
 import csv
@@ -54,6 +56,30 @@ data_path = pathlib.Path(__file__).parent / "data"
 
 def get_problematic_sites():
     return np.loadtxt(data_path / "problematic_sites.txt", dtype=np.int64)
+
+
+@dataclasses.dataclass(frozen=True)
+class CovLineage:
+    name: str
+    earliest_date: str
+    latest_date: str
+    description: str
+
+
+def get_cov_lineages_data():
+    with open(data_path / "lineages.json") as f:
+        data = json.load(f)
+    ret = {}
+    for record in data:
+        lineage = CovLineage(
+            record["Lineage"],
+            record["Earliest date"],
+            record["Latest date"],
+            record["Description"],
+        )
+        assert lineage.name not in ret
+        ret[lineage.name] = lineage
+    return ret
 
 
 __cached_reference = None

--- a/sc2ts/core.py
+++ b/sc2ts/core.py
@@ -58,7 +58,7 @@ def get_problematic_sites():
     return np.loadtxt(data_path / "problematic_sites.txt", dtype=np.int64)
 
 
-@dataclasses.dataclass(frozen=True)
+@dataclasses.dataclass
 class CovLineage:
     name: str
     earliest_date: str

--- a/sc2ts/data/lineages.json
+++ b/sc2ts/data/lineages.json
@@ -1,0 +1,28994 @@
+[
+  {
+    "Lineage": "A",
+    "Earliest date": "2019-12-30",
+    "Latest date": "2023-03-15",
+    "Description": "One of the two original haplotypes of the pandemic (A and B). Many sequences originating from China and many global exports; including to South East Asia Japan South Korea Australia the USA and Europe represented in this lineage"
+  },
+  {
+    "Lineage": "A.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "A.2",
+    "Earliest date": "2020-01-17",
+    "Latest date": "2023-01-27",
+    "Description": "Mostly Spanish lineage now includes South and Central American sequences, other European countries and Kazakhstan."
+  },
+  {
+    "Lineage": "A.2.2",
+    "Earliest date": "2020-03-17",
+    "Latest date": "2020-05-08",
+    "Description": "Australian lineage"
+  },
+  {
+    "Lineage": "A.2.3",
+    "Earliest date": "2020-03-12",
+    "Latest date": "2020-05-29",
+    "Description": "Scottish lineage"
+  },
+  {
+    "Lineage": "A.2.4",
+    "Earliest date": "2020-02-20",
+    "Latest date": "2021-01-13",
+    "Description": "Panama lineage"
+  },
+  {
+    "Lineage": "A.2.5",
+    "Earliest date": "2020-04-15",
+    "Latest date": "2021-11-05",
+    "Description": "Central American/ USA lineage"
+  },
+  {
+    "Lineage": "A.2.5.1",
+    "Earliest date": "2020-04-14",
+    "Latest date": "2021-08-10",
+    "Description": "Costa Rica lineage, from #33"
+  },
+  {
+    "Lineage": "A.2.5.2",
+    "Earliest date": "2020-04-12",
+    "Latest date": "2021-11-05",
+    "Description": "Predominantly Italy lineage"
+  },
+  {
+    "Lineage": "A.2.5.3",
+    "Earliest date": "2021-02-23",
+    "Latest date": "2021-09-04",
+    "Description": "Predominantly Ecuador lineage, from #168"
+  },
+  {
+    "Lineage": "A.3",
+    "Earliest date": "2020-03-03",
+    "Latest date": "2020-08-22",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "A.4",
+    "Earliest date": "2020-03-13",
+    "Latest date": "2020-09-28",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "A.5",
+    "Earliest date": "2020-03-01",
+    "Latest date": "2023-11-25",
+    "Description": "A lineage with a lot of representation from Spanish-speaking countries. A Spanish/ South-American lineage, but now with sequences from an outbreak in Scotland. Also now includes what was previously A.10."
+  },
+  {
+    "Lineage": "A.6",
+    "Earliest date": "2020-01-23",
+    "Latest date": "2020-08-04",
+    "Description": "Thai lineage"
+  },
+  {
+    "Lineage": "A.7",
+    "Earliest date": "2020-05-06",
+    "Latest date": "2020-05-14",
+    "Description": "Indian lineage"
+  },
+  {
+    "Lineage": "A.9",
+    "Earliest date": "2020-03-21",
+    "Latest date": "2020-05-24",
+    "Description": "Indian lineage"
+  },
+  {
+    "Lineage": "A.11",
+    "Earliest date": "2020-03-20",
+    "Latest date": "2021-05-27",
+    "Description": "Ghana/ Senegal lineage"
+  },
+  {
+    "Lineage": "A.12",
+    "Earliest date": "2020-04-10",
+    "Latest date": "2020-12-11",
+    "Description": "Sierra Leone lineage"
+  },
+  {
+    "Lineage": "A.15",
+    "Earliest date": "2020-04-20",
+    "Latest date": "2020-08-10",
+    "Description": "Sweden/ Denmark lineage"
+  },
+  {
+    "Lineage": "A.16",
+    "Earliest date": "2020-02-15",
+    "Latest date": "2020-03-29",
+    "Description": "Japanese lineage"
+  },
+  {
+    "Lineage": "A.17",
+    "Earliest date": "2020-03-02",
+    "Latest date": "2020-03-28",
+    "Description": "French lineage"
+  },
+  {
+    "Lineage": "A.18",
+    "Earliest date": "2020-06-21",
+    "Latest date": "2021-08-02",
+    "Description": "Cote d'Ivoire/ Burkina Faso lineage"
+  },
+  {
+    "Lineage": "A.19",
+    "Earliest date": "2020-02-02",
+    "Latest date": "2021-08-02",
+    "Description": "Cote d'Ivoire/ Burkina Faso lineage"
+  },
+  {
+    "Lineage": "A.21",
+    "Earliest date": "2020-04-10",
+    "Latest date": "2021-07-06",
+    "Description": "Mali/ Burkina Faso lineage"
+  },
+  {
+    "Lineage": "A.22",
+    "Earliest date": "2020-03-15",
+    "Latest date": "2020-05-19",
+    "Description": "UAE lineage"
+  },
+  {
+    "Lineage": "A.23",
+    "Earliest date": "2020-08-14",
+    "Latest date": "2021-07-05",
+    "Description": "Ugandan lineage"
+  },
+  {
+    "Lineage": "A.23.1",
+    "Earliest date": "2020-06-08",
+    "Latest date": "2021-08-22",
+    "Description": "International lineage with a number of variants of potential biological concern, including 681R"
+  },
+  {
+    "Lineage": "A.24",
+    "Earliest date": "2020-07-10",
+    "Latest date": "2020-12-07",
+    "Description": "South Korean lineage"
+  },
+  {
+    "Lineage": "A.25",
+    "Earliest date": "2020-05-29",
+    "Latest date": "2021-06-08",
+    "Description": "Ugandan lineage"
+  },
+  {
+    "Lineage": "A.26",
+    "Earliest date": "2020-03-31",
+    "Latest date": "2020-06-11",
+    "Description": "UK lineage"
+  },
+  {
+    "Lineage": "A.27",
+    "Earliest date": "2020-11-27",
+    "Latest date": "2021-08-24",
+    "Description": "Mayotte/ European cluster with 18 changes in the long branch leading to this cluster, including 7 NS changes in the spike (L18F, L452R, N501Y, A653V, H655Y, D796Y, G1219V), on a 614D background, from #11."
+  },
+  {
+    "Lineage": "A.28",
+    "Earliest date": "2020-07-28",
+    "Latest date": "2021-05-28",
+    "Description": "This lineage has 9 changes on its basal branch, including the 69-70del, N501T (not Y) and H655Y. (This variant is picked up by the qPCR S drop), from #12"
+  },
+  {
+    "Lineage": "A.29",
+    "Earliest date": "2020-08-21",
+    "Latest date": "2021-08-08",
+    "Description": "Lineage circulating in multiple countries, from #78"
+  },
+  {
+    "Lineage": "A.30",
+    "Earliest date": "2021-02-13",
+    "Latest date": "2021-05-15",
+    "Description": "Lineage in several countries, associated with travel from Tanzania, from #138"
+  },
+  {
+    "Lineage": "B",
+    "Earliest date": "2019-12-24",
+    "Latest date": "2024-04-02",
+    "Description": "One of the two original haplotypes of the pandemic(and first to be discovered)"
+  },
+  {
+    "Lineage": "B.1",
+    "Earliest date": "2020-01-01",
+    "Latest date": "2024-06-07",
+    "Description": "A large European lineage the origin of which roughly corresponds to the Northern Italian outbreak early in 2020."
+  },
+  {
+    "Lineage": "B.1.1",
+    "Earliest date": "2020-01-19",
+    "Latest date": "2023-11-08",
+    "Description": "European lineage with 3 clear SNPs `28881GA`,`28882GA`,`28883GC`"
+  },
+  {
+    "Lineage": "B.1.1.1",
+    "Earliest date": "2020-03-02",
+    "Latest date": "2022-04-27",
+    "Description": "England"
+  },
+  {
+    "Lineage": "C.1",
+    "Earliest date": "2020-04-16",
+    "Latest date": "2021-07-29",
+    "Description": "Alias of B.1.1.1.1, South Africa, from #2"
+  },
+  {
+    "Lineage": "C.1.1",
+    "Earliest date": "2020-11-10",
+    "Latest date": "2021-01-15",
+    "Description": "Alias of B.1.1.1.1.1, Mozambique"
+  },
+  {
+    "Lineage": "C.1.2",
+    "Earliest date": "2021-05-11",
+    "Latest date": "2022-05-25",
+    "Description": "Alias of B.1.1.1.1.2, mostly South Africa, from #139"
+  },
+  {
+    "Lineage": "C.2",
+    "Earliest date": "2020-06-09",
+    "Latest date": "2021-03-10",
+    "Description": "Alias of B.1.1.1.2, South Africa and some European"
+  },
+  {
+    "Lineage": "C.2.1",
+    "Earliest date": "2020-12-18",
+    "Latest date": "2021-04-17",
+    "Description": "Alias of B.1.1.1.2.1, Aruba and Curacao, from #32"
+  },
+  {
+    "Lineage": "C.3",
+    "Earliest date": "2020-05-20",
+    "Latest date": "2020-11-25",
+    "Description": "Alias of B.1.1.1.3, England"
+  },
+  {
+    "Lineage": "C.4",
+    "Earliest date": "2020-05-19",
+    "Latest date": "2021-08-18",
+    "Description": "Alias of B.1.1.1.4, Peruvian"
+  },
+  {
+    "Lineage": "C.5",
+    "Earliest date": "2020-09-02",
+    "Latest date": "2020-11-12",
+    "Description": "Alias of B.1.1.1.5, Switzerland and Luxembourg"
+  },
+  {
+    "Lineage": "C.6",
+    "Earliest date": "2020-04-18",
+    "Latest date": "2020-09-21",
+    "Description": "Alias of B.1.1.1.6, South Africa"
+  },
+  {
+    "Lineage": "C.7",
+    "Earliest date": "2020-05-11",
+    "Latest date": "2020-07-13",
+    "Description": "Alias of B.1.1.1.7, Denmark"
+  },
+  {
+    "Lineage": "C.8",
+    "Earliest date": "2020-03-31",
+    "Latest date": "2021-03-07",
+    "Description": "Alias of B.1.1.1.8, Canada and DRC"
+  },
+  {
+    "Lineage": "C.9",
+    "Earliest date": "2020-07-01",
+    "Latest date": "2020-10-06",
+    "Description": "Alias of B.1.1.1.9, South Africa"
+  },
+  {
+    "Lineage": "C.10",
+    "Earliest date": "2020-04-22",
+    "Latest date": "2020-05-08",
+    "Description": "Alias of B.1.1.1.10, Poland"
+  },
+  {
+    "Lineage": "C.11",
+    "Earliest date": "2020-04-01",
+    "Latest date": "2021-05-02",
+    "Description": "Alias of B.1.1.1.11"
+  },
+  {
+    "Lineage": "C.12",
+    "Earliest date": "2020-08-12",
+    "Latest date": "2020-09-23",
+    "Description": "Alias of B.1.1.1.12, New Zealand"
+  },
+  {
+    "Lineage": "C.13",
+    "Earliest date": "2020-03-29",
+    "Latest date": "2021-02-16",
+    "Description": "Alias of B.1.1.1.13, Peruvian"
+  },
+  {
+    "Lineage": "C.14",
+    "Earliest date": "2020-03-20",
+    "Latest date": "2021-07-30",
+    "Description": "Alias of B.1.1.1.14, Peruvian"
+  },
+  {
+    "Lineage": "C.16",
+    "Earliest date": "2020-05-29",
+    "Latest date": "2021-06-02",
+    "Description": "Alias of B.1.1.1.16, Portugal originally, now pan-european"
+  },
+  {
+    "Lineage": "C.17",
+    "Earliest date": "2020-05-26",
+    "Latest date": "2022-10-02",
+    "Description": "Alias of B.1.1.1.17, Egypt"
+  },
+  {
+    "Lineage": "C.18",
+    "Earliest date": "2020-07-01",
+    "Latest date": "2021-10-08",
+    "Description": "Alias of B.1.1.1.18, Italy"
+  },
+  {
+    "Lineage": "C.19",
+    "Earliest date": "2020-12-07",
+    "Latest date": "2021-01-04",
+    "Description": "Alias of B.1.1.1.19, Denmark"
+  },
+  {
+    "Lineage": "C.20",
+    "Earliest date": "2020-10-26",
+    "Latest date": "2021-02-10",
+    "Description": "Alias of B.1.1.1.20, Switzerland"
+  },
+  {
+    "Lineage": "C.21",
+    "Earliest date": "2020-09-15",
+    "Latest date": "2021-01-27",
+    "Description": "Alias of B.1.1.1.21, Spain"
+  },
+  {
+    "Lineage": "C.22",
+    "Earliest date": "2020-04-03",
+    "Latest date": "2021-01-23",
+    "Description": "Alias of B.1.1.1.22, Argentina"
+  },
+  {
+    "Lineage": "C.23",
+    "Earliest date": "2020-05-11",
+    "Latest date": "2021-04-01",
+    "Description": "Alias of B.1.1.1.23, Mainly USA"
+  },
+  {
+    "Lineage": "C.25",
+    "Earliest date": "2020-03-13",
+    "Latest date": "2020-08-27",
+    "Description": "Alias of B.1.1.1.25, Peru"
+  },
+  {
+    "Lineage": "C.26",
+    "Earliest date": "2020-04-28",
+    "Latest date": "2021-08-27",
+    "Description": "Alias of B.1.1.1.26, Chile"
+  },
+  {
+    "Lineage": "C.27",
+    "Earliest date": "2020-04-19",
+    "Latest date": "2020-07-06",
+    "Description": "Alias of B.1.1.1.27, England"
+  },
+  {
+    "Lineage": "C.28",
+    "Earliest date": "2020-04-30",
+    "Latest date": "2020-11-24",
+    "Description": "Alias of B.1.1.1.28, USA"
+  },
+  {
+    "Lineage": "C.29",
+    "Earliest date": "2020-06-25",
+    "Latest date": "2021-02-09",
+    "Description": "Alias of B.1.1.1.29, Chile"
+  },
+  {
+    "Lineage": "C.30",
+    "Earliest date": "2020-08-04",
+    "Latest date": "2021-02-06",
+    "Description": "Alias of B.1.1.1.30, England"
+  },
+  {
+    "Lineage": "C.30.1",
+    "Earliest date": "2020-10-05",
+    "Latest date": "2020-12-28",
+    "Description": "Alias of B.1.1.1.30.1, Denmark"
+  },
+  {
+    "Lineage": "C.31",
+    "Earliest date": "2020-09-14",
+    "Latest date": "2021-03-24",
+    "Description": "Alias of B.1.1.1.31, USA"
+  },
+  {
+    "Lineage": "C.32",
+    "Earliest date": "2020-05-07",
+    "Latest date": "2021-03-02",
+    "Description": "Alias of B.1.1.1.32, Peru"
+  },
+  {
+    "Lineage": "C.33",
+    "Earliest date": "2020-05-18",
+    "Latest date": "2021-02-18",
+    "Description": "Alias of B.1.1.1.33, Peru"
+  },
+  {
+    "Lineage": "C.34",
+    "Earliest date": "2020-08-06",
+    "Latest date": "2020-10-07",
+    "Description": "Alias of B.1.1.1.34, Canada"
+  },
+  {
+    "Lineage": "C.35",
+    "Earliest date": "2020-04-06",
+    "Latest date": "2021-12-07",
+    "Description": "Alias of B.1.1.1.35, Central Europe, England"
+  },
+  {
+    "Lineage": "C.36",
+    "Earliest date": "2020-03-13",
+    "Latest date": "2021-10-29",
+    "Description": "Alias of B.1.1.1.36, Egypt mainly and other countries"
+  },
+  {
+    "Lineage": "C.36.1",
+    "Earliest date": "2020-09-17",
+    "Latest date": "2021-05-12",
+    "Description": "Alias of B.1.1.1.36.1, Canada"
+  },
+  {
+    "Lineage": "C.36.2",
+    "Earliest date": "2020-10-16",
+    "Latest date": "2021-02-24",
+    "Description": "Alias of B.1.1.1.36.2, Switzerland"
+  },
+  {
+    "Lineage": "C.36.3",
+    "Earliest date": "2020-07-14",
+    "Latest date": "2021-12-19",
+    "Description": "Alias of B.1.1.1.36.3, Europe and USA lineage, from #80"
+  },
+  {
+    "Lineage": "C.36.3.1",
+    "Earliest date": "2021-03-29",
+    "Latest date": "2021-09-21",
+    "Description": "Alias of B.1.1.1.36.3.1, Europe and USA lineage, from #80"
+  },
+  {
+    "Lineage": "C.37",
+    "Earliest date": "2020-07-21",
+    "Latest date": "2022-11-15",
+    "Description": "Alias of B.1.1.1.37, lineage in Peru, Chile, USA and Germany, from #52"
+  },
+  {
+    "Lineage": "C.37.1",
+    "Earliest date": "2021-03-18",
+    "Latest date": "2022-05-25",
+    "Description": "Alias of B.1.1.1.37.1, lineage outside of South America, from #158"
+  },
+  {
+    "Lineage": "C.38",
+    "Earliest date": "2021-02-16",
+    "Latest date": "2021-07-04",
+    "Description": "Alias of B.1.1.1.38, lineage in multiple countries, formally B.1.1.527, from #150"
+  },
+  {
+    "Lineage": "C.39",
+    "Earliest date": "2021-02-10",
+    "Latest date": "2021-08-22",
+    "Description": "Alias of B.1.1.1.39, Chile and Peru lineage, from #178"
+  },
+  {
+    "Lineage": "C.40",
+    "Earliest date": "2021-02-02",
+    "Latest date": "2021-09-04",
+    "Description": "Alias of B.1.1.1.40, Peru lineage, from #203"
+  },
+  {
+    "Lineage": "B.1.1.3",
+    "Earliest date": "2020-03-18",
+    "Latest date": "2020-06-03",
+    "Description": "England Lineage"
+  },
+  {
+    "Lineage": "B.1.1.4",
+    "Earliest date": "2020-03-31",
+    "Latest date": "2020-10-03",
+    "Description": "English lineage"
+  },
+  {
+    "Lineage": "B.1.1.5",
+    "Earliest date": "2020-03-16",
+    "Latest date": "2021-02-18",
+    "Description": "European lineage"
+  },
+  {
+    "Lineage": "B.1.1.7",
+    "Earliest date": "2020-01-19",
+    "Latest date": "2024-03-04",
+    "Description": "UK lineage of concern, associated with the N501Y mutation. More information can be found at cov-lineages.org/global_report.html"
+  },
+  {
+    "Lineage": "Q.1",
+    "Earliest date": "2020-12-08",
+    "Latest date": "2021-08-07",
+    "Description": "Alias of B.1.1.7.1, predominantly Lithuania lineage, from #39"
+  },
+  {
+    "Lineage": "Q.2",
+    "Earliest date": "2020-12-15",
+    "Latest date": "2022-05-06",
+    "Description": "Alias of B.1.1.7.2, Italy lineage, from #79"
+  },
+  {
+    "Lineage": "Q.3",
+    "Earliest date": "2020-07-08",
+    "Latest date": "2022-03-07",
+    "Description": "Alias of B.1.1.7.3, USA lineage, from #92"
+  },
+  {
+    "Lineage": "Q.4",
+    "Earliest date": "2020-12-13",
+    "Latest date": "2021-07-19",
+    "Description": "Alias of B.1.1.7.4, lineage in multiple countries with spike H681R, from #176"
+  },
+  {
+    "Lineage": "Q.5",
+    "Earliest date": "2021-04-11",
+    "Latest date": "2021-08-11",
+    "Description": "Alias of B.1.1.7.5, Israel lineage, from #165"
+  },
+  {
+    "Lineage": "Q.6",
+    "Earliest date": "2021-03-02",
+    "Latest date": "2021-08-12",
+    "Description": "Alias of B.1.1.7.6, France lineage, from #183"
+  },
+  {
+    "Lineage": "Q.7",
+    "Earliest date": "2021-01-29",
+    "Latest date": "2021-12-23",
+    "Description": "Alias of B.1.1.7.7, predominantly France lineage, from #183"
+  },
+  {
+    "Lineage": "Q.8",
+    "Earliest date": "2021-03-07",
+    "Latest date": "2021-10-30",
+    "Description": "Alias of B.1.1.7.8, Sri Lanka lineage, from #197"
+  },
+  {
+    "Lineage": "B.1.1.8",
+    "Earliest date": "2020-03-15",
+    "Latest date": "2021-01-25",
+    "Description": "England"
+  },
+  {
+    "Lineage": "B.1.1.10",
+    "Earliest date": "2020-03-01",
+    "Latest date": "2022-04-04",
+    "Description": "European lineage"
+  },
+  {
+    "Lineage": "L.1",
+    "Earliest date": "2020-03-26",
+    "Latest date": "2020-05-28",
+    "Description": "Alias of B.1.1.10.1, Canadian lineage"
+  },
+  {
+    "Lineage": "L.2",
+    "Earliest date": "2020-03-23",
+    "Latest date": "2021-01-21",
+    "Description": "Alias of B.1.1.10.2, Netherlands lineage"
+  },
+  {
+    "Lineage": "L.3",
+    "Earliest date": "2020-07-07",
+    "Latest date": "2021-09-14",
+    "Description": "Alias of B.1.1.10.3, Nigerian/ European lineage with long branch from B.1.1.10"
+  },
+  {
+    "Lineage": "L.4",
+    "Earliest date": "2020-06-29",
+    "Latest date": "2020-09-11",
+    "Description": "Alias of B.1.1.10.4, USA lineage"
+  },
+  {
+    "Lineage": "B.1.1.12",
+    "Earliest date": "2020-06-02",
+    "Latest date": "2021-01-16",
+    "Description": "England"
+  },
+  {
+    "Lineage": "B.1.1.13",
+    "Earliest date": "2020-03-14",
+    "Latest date": "2021-02-10",
+    "Description": "UK"
+  },
+  {
+    "Lineage": "B.1.1.14",
+    "Earliest date": "2020-04-16",
+    "Latest date": "2020-06-27",
+    "Description": "Scotland"
+  },
+  {
+    "Lineage": "B.1.1.15",
+    "Earliest date": "2020-06-09",
+    "Latest date": "2020-10-01",
+    "Description": "UK/ Luxembourg lineage"
+  },
+  {
+    "Lineage": "B.1.1.16",
+    "Earliest date": "2020-03-11",
+    "Latest date": "2020-10-19",
+    "Description": "Wales with European base"
+  },
+  {
+    "Lineage": "B.1.1.17",
+    "Earliest date": "2020-03-06",
+    "Latest date": "2020-04-11",
+    "Description": "Icelandic"
+  },
+  {
+    "Lineage": "B.1.1.25",
+    "Earliest date": "2020-03-31",
+    "Latest date": "2022-12-08",
+    "Description": "Bangladesh Lineage"
+  },
+  {
+    "Lineage": "D.2",
+    "Earliest date": "2020-03-19",
+    "Latest date": "2020-11-17",
+    "Description": "Alias of B.1.1.25.2, Australia"
+  },
+  {
+    "Lineage": "D.3",
+    "Earliest date": "2020-06-14",
+    "Latest date": "2020-10-10",
+    "Description": "Alias of B.1.1.25.3, Australia"
+  },
+  {
+    "Lineage": "D.4",
+    "Earliest date": "2020-08-13",
+    "Latest date": "2020-08-21",
+    "Description": "Alias of B.1.1.25.4, Irish/ Northern Irish lineage"
+  },
+  {
+    "Lineage": "D.5",
+    "Earliest date": "2020-10-12",
+    "Latest date": "2021-06-14",
+    "Description": "Alias of B.1.1.25.5, Swedish/ Denmark lineage"
+  },
+  {
+    "Lineage": "B.1.1.26",
+    "Earliest date": "2020-04-02",
+    "Latest date": "2020-08-26",
+    "Description": "USA Lineage"
+  },
+  {
+    "Lineage": "B.1.1.27",
+    "Earliest date": "2020-03-21",
+    "Latest date": "2021-03-22",
+    "Description": "Oman Lineage, some UAE"
+  },
+  {
+    "Lineage": "B.1.1.28",
+    "Earliest date": "2020-02-10",
+    "Latest date": "2022-06-15",
+    "Description": "Brazil mostly, absorbed B.1.1.94 and B.1.1.143"
+  },
+  {
+    "Lineage": "P.1",
+    "Earliest date": "2020-04-07",
+    "Latest date": "2023-04-21",
+    "Description": "Alias of B.1.1.28.1, Brazilian lineage with a number of spike mutations with likely functional significance E484K, K417T, and N501Y. Described in https://virological.org/t/genomic-characterisation-of-an-emergent-sars-cov-2-lineage-in-manaus-preliminary-findings/586, from #77"
+  },
+  {
+    "Lineage": "P.1.1",
+    "Earliest date": "2021-01-04",
+    "Latest date": "2021-10-17",
+    "Description": "Alias of B.1.1.28.1.1, European lineage in Italy and Germany, from #28"
+  },
+  {
+    "Lineage": "P.1.2",
+    "Earliest date": "2021-01-28",
+    "Latest date": "2021-11-17",
+    "Description": "Alias of B.1.1.28.1.2, Netherlands/Brazil lineage. Imported into Netherlands, likely with local transmission here and continued circulation within and/or reintroduction into Brazil, from #56"
+  },
+  {
+    "Lineage": "P.1.3",
+    "Earliest date": "2021-03-12",
+    "Latest date": "2021-06-30",
+    "Description": "Alias of B.1.1.28.1.3, Brazil lineage, from #141"
+  },
+  {
+    "Lineage": "P.1.4",
+    "Earliest date": "2021-03-19",
+    "Latest date": "2021-11-11",
+    "Description": "Alias of B.1.1.28.1.4, Brazil lineage, from #141"
+  },
+  {
+    "Lineage": "P.1.5",
+    "Earliest date": "2021-04-03",
+    "Latest date": "2021-07-02",
+    "Description": "Alias of B.1.1.28.1.5, Brazil lineage, from #141"
+  },
+  {
+    "Lineage": "P.1.6",
+    "Earliest date": "2021-03-26",
+    "Latest date": "2021-11-16",
+    "Description": "Alias of B.1.1.28.1.6, Brazil lineage, from #141"
+  },
+  {
+    "Lineage": "P.1.7",
+    "Earliest date": "2021-03-15",
+    "Latest date": "2021-12-29",
+    "Description": "Alias of B.1.1.28.1.7, Brazil lineage, from #141"
+  },
+  {
+    "Lineage": "P.1.7.1",
+    "Earliest date": "2021-02-07",
+    "Latest date": "2022-01-10",
+    "Description": "Alias of B.1.1.28.1.7.1, Peru lineage, from #326"
+  },
+  {
+    "Lineage": "P.1.8",
+    "Earliest date": "2021-05-03",
+    "Latest date": "2021-10-25",
+    "Description": "Alias of B.1.1.28.1.8, Brazil lineage, from #164"
+  },
+  {
+    "Lineage": "P.1.9",
+    "Earliest date": "2021-04-09",
+    "Latest date": "2021-12-07",
+    "Description": "Alias of B.1.1.28.1.9, Brazil lineage, from #174"
+  },
+  {
+    "Lineage": "P.1.10",
+    "Earliest date": "2021-02-10",
+    "Latest date": "2021-10-29",
+    "Description": "Alias of B.1.1.28.1.10, predominantly USA lineage, from #179"
+  },
+  {
+    "Lineage": "P.1.10.1",
+    "Earliest date": "2021-04-25",
+    "Latest date": "2021-07-13",
+    "Description": "Alias of B.1.1.28.1.10.1, Aruba lineage, from #179"
+  },
+  {
+    "Lineage": "P.1.10.2",
+    "Earliest date": "2021-05-17",
+    "Latest date": "2021-07-08",
+    "Description": "Alias of B.1.1.28.1.10.2, Mexico lineage, from #179"
+  },
+  {
+    "Lineage": "P.1.11",
+    "Earliest date": "2021-04-08",
+    "Latest date": "2021-10-01",
+    "Description": "Alias of B.1.1.28.1.11, Brazil lineage, from #164"
+  },
+  {
+    "Lineage": "P.1.12",
+    "Earliest date": "2020-12-23",
+    "Latest date": "2021-12-23",
+    "Description": "Alias of B.1.1.28.1.12, predominantly Peru lineage, from #212"
+  },
+  {
+    "Lineage": "P.1.12.1",
+    "Earliest date": "2021-07-17",
+    "Latest date": "2021-12-09",
+    "Description": "Sublineage of P.1.12 reported predominantly from Peru and USA, from #282"
+  },
+  {
+    "Lineage": "P.1.13",
+    "Earliest date": "2021-02-24",
+    "Latest date": "2021-08-19",
+    "Description": "Alias of B.1.1.28.1.13, USA lineage, from #231"
+  },
+  {
+    "Lineage": "P.1.14",
+    "Earliest date": "2020-11-03",
+    "Latest date": "2022-06-23",
+    "Description": "Alias of B.1.1.28.1.14, predominantly Canada lineage, from #231"
+  },
+  {
+    "Lineage": "P.1.15",
+    "Earliest date": "2021-01-17",
+    "Latest date": "2022-06-10",
+    "Description": "Alias of B.1.1.28.1.15, predominantly Chile lineage, from #231"
+  },
+  {
+    "Lineage": "P.1.16",
+    "Earliest date": "2021-01-31",
+    "Latest date": "2021-11-29",
+    "Description": "Alias of B.1.1.28.1.16, predominantly Belgium lineage also in other countries in Europe, from #231"
+  },
+  {
+    "Lineage": "P.1.17",
+    "Earliest date": "2021-01-20",
+    "Latest date": "2021-11-19",
+    "Description": "Alias of B.1.1.28.1.17, predominantly USA and Mexico lineage, from #231"
+  },
+  {
+    "Lineage": "P.1.17.1",
+    "Earliest date": "2021-04-02",
+    "Latest date": "2021-08-16",
+    "Description": "Alias of B.1.1.28.1.17.1, predominantly in Luxembourg, from #231"
+  },
+  {
+    "Lineage": "P.2",
+    "Earliest date": "2020-03-25",
+    "Latest date": "2022-06-08",
+    "Description": "Alias of B.1.1.28.2, Brazilian lineage"
+  },
+  {
+    "Lineage": "P.3",
+    "Earliest date": "2021-01-16",
+    "Latest date": "2021-09-01",
+    "Description": "Alias of B.1.1.28.3, Lineage predominantly in the Philippines with spike mutations E484K, N501Y, P681H, 141-143del. Described in Tablizo et al 2021: https://www.medrxiv.org/content/10.1101/2021.03.03.21252812v2, from #27"
+  },
+  {
+    "Lineage": "P.4",
+    "Earliest date": "2021-02-17",
+    "Latest date": "2021-06-08",
+    "Description": "Alias of B.1.1.28.4, Brazil lineage, from #68"
+  },
+  {
+    "Lineage": "P.5",
+    "Earliest date": "2021-02-27",
+    "Latest date": "2021-05-26",
+    "Description": "Alias of B.1.1.28.5, Brazil lineage, from #86"
+  },
+  {
+    "Lineage": "P.6",
+    "Earliest date": "2020-12-02",
+    "Latest date": "2021-04-25",
+    "Description": "Alias of B.1.1.28.6, Uruguay lineage, from #148"
+  },
+  {
+    "Lineage": "P.7",
+    "Earliest date": "2020-07-01",
+    "Latest date": "2021-05-30",
+    "Description": "Alias of B.1.1.28.7, Brazil lineage, from #29"
+  },
+  {
+    "Lineage": "B.1.1.29",
+    "Earliest date": "2020-04-08",
+    "Latest date": "2020-06-15",
+    "Description": "Wales lineage, formerly temporarily assigned B.1.1.439 due to an error, from #50"
+  },
+  {
+    "Lineage": "B.1.1.30",
+    "Earliest date": "2020-05-18",
+    "Latest date": "2020-06-03",
+    "Description": "Lithuanian"
+  },
+  {
+    "Lineage": "B.1.1.31",
+    "Earliest date": "2020-06-07",
+    "Latest date": "2020-09-25",
+    "Description": "Russian lineage"
+  },
+  {
+    "Lineage": "B.1.1.33",
+    "Earliest date": "2020-03-01",
+    "Latest date": "2023-10-10",
+    "Description": "Brazilian"
+  },
+  {
+    "Lineage": "N.1",
+    "Earliest date": "2020-03-25",
+    "Latest date": "2020-12-15",
+    "Description": "Alias of B.1.1.33.1, US"
+  },
+  {
+    "Lineage": "N.2",
+    "Earliest date": "2020-06-23",
+    "Latest date": "2020-08-28",
+    "Description": "Alias of B.1.1.33.2, European lineage"
+  },
+  {
+    "Lineage": "N.3",
+    "Earliest date": "2020-04-17",
+    "Latest date": "2021-10-19",
+    "Description": "Alias of B.1.1.33.3, Argentinian"
+  },
+  {
+    "Lineage": "N.4",
+    "Earliest date": "2020-03-25",
+    "Latest date": "2021-12-21",
+    "Description": "Alias of B.1.1.33.4, Chilean"
+  },
+  {
+    "Lineage": "N.5",
+    "Earliest date": "2020-04-25",
+    "Latest date": "2021-06-21",
+    "Description": "Alias of B.1.1.33.5, Argentinian"
+  },
+  {
+    "Lineage": "N.6",
+    "Earliest date": "2020-02-16",
+    "Latest date": "2021-10-24",
+    "Description": "Alias of B.1.1.33.6, Chilean"
+  },
+  {
+    "Lineage": "N.7",
+    "Earliest date": "2020-06-18",
+    "Latest date": "2020-10-16",
+    "Description": "Alias of B.1.1.33.7, Uruguay"
+  },
+  {
+    "Lineage": "N.8",
+    "Earliest date": "2020-06-23",
+    "Latest date": "2020-11-13",
+    "Description": "Alias of B.1.1.33.8, Kenyan"
+  },
+  {
+    "Lineage": "N.9",
+    "Earliest date": "2020-04-29",
+    "Latest date": "2021-07-22",
+    "Description": "Alias of B.1.1.33.9, Brazilian lineage, from #26"
+  },
+  {
+    "Lineage": "N.10",
+    "Earliest date": "2020-12-29",
+    "Latest date": "2022-11-17",
+    "Description": "Alias of B.1.1.33.10, Brazilian lineage described in https://virological.org/t/identification-of-a-new-b-1-1-33-sars-cov-2-variant-of-interest-voi-circulating-in-brazil-with-mutation-e484k-and-multiple-deletions-in-the-amino-n-terminal-domain-of-the-spike-protein/675, from #40"
+  },
+  {
+    "Lineage": "B.1.1.34",
+    "Earliest date": "2020-04-15",
+    "Latest date": "2021-01-08",
+    "Description": "South African lineage"
+  },
+  {
+    "Lineage": "B.1.1.37",
+    "Earliest date": "2020-03-23",
+    "Latest date": "2021-09-29",
+    "Description": "UK lineage"
+  },
+  {
+    "Lineage": "B.1.1.38",
+    "Earliest date": "2020-05-25",
+    "Latest date": "2021-04-09",
+    "Description": "Wales"
+  },
+  {
+    "Lineage": "B.1.1.39",
+    "Earliest date": "2020-07-01",
+    "Latest date": "2021-04-15",
+    "Description": "Mostly Switzerland with lots of other countries"
+  },
+  {
+    "Lineage": "AQ.1",
+    "Earliest date": "2020-11-08",
+    "Latest date": "2020-12-30",
+    "Description": "Alias of B.1.1.39.1, Finland lineage"
+  },
+  {
+    "Lineage": "AQ.2",
+    "Earliest date": "2020-08-24",
+    "Latest date": "2020-09-21",
+    "Description": "Alias of B.1.1.39.2, Denmark lineage"
+  },
+  {
+    "Lineage": "B.1.1.40",
+    "Earliest date": "2020-04-20",
+    "Latest date": "2021-03-01",
+    "Description": "South African lineage"
+  },
+  {
+    "Lineage": "B.1.1.41",
+    "Earliest date": "2020-03-21",
+    "Latest date": "2020-11-25",
+    "Description": "England lineage"
+  },
+  {
+    "Lineage": "B.1.1.43",
+    "Earliest date": "2020-03-25",
+    "Latest date": "2021-09-29",
+    "Description": "Scottish lineage"
+  },
+  {
+    "Lineage": "B.1.1.44",
+    "Earliest date": "2020-02-28",
+    "Latest date": "2021-01-26",
+    "Description": "Pan-European, big scottish section"
+  },
+  {
+    "Lineage": "B.1.1.45",
+    "Earliest date": "2020-05-22",
+    "Latest date": "2020-07-02",
+    "Description": "UK"
+  },
+  {
+    "Lineage": "B.1.1.46",
+    "Earliest date": "2020-04-20",
+    "Latest date": "2021-11-01",
+    "Description": "Mostly India"
+  },
+  {
+    "Lineage": "B.1.1.47",
+    "Earliest date": "2020-07-01",
+    "Latest date": "2021-12-10",
+    "Description": "Switzerland and other Northern Europe"
+  },
+  {
+    "Lineage": "B.1.1.48",
+    "Earliest date": "2020-03-27",
+    "Latest date": "2020-07-15",
+    "Description": "Japan"
+  },
+  {
+    "Lineage": "B.1.1.49",
+    "Earliest date": "2020-03-23",
+    "Latest date": "2020-05-29",
+    "Description": "Wales"
+  },
+  {
+    "Lineage": "B.1.1.50",
+    "Earliest date": "2020-03-29",
+    "Latest date": "2023-06-28",
+    "Description": "Israel and Palestine"
+  },
+  {
+    "Lineage": "B.1.1.51",
+    "Earliest date": "2020-03-30",
+    "Latest date": "2020-11-16",
+    "Description": "UK"
+  },
+  {
+    "Lineage": "B.1.1.52",
+    "Earliest date": "2020-06-07",
+    "Latest date": "2020-08-10",
+    "Description": "South Africa"
+  },
+  {
+    "Lineage": "B.1.1.53",
+    "Earliest date": "2020-05-01",
+    "Latest date": "2021-04-30",
+    "Description": "South Africa"
+  },
+  {
+    "Lineage": "B.1.1.54",
+    "Earliest date": "2020-03-19",
+    "Latest date": "2021-03-26",
+    "Description": "South African Lineage"
+  },
+  {
+    "Lineage": "B.1.1.55",
+    "Earliest date": "2020-04-12",
+    "Latest date": "2020-07-11",
+    "Description": "English lineage"
+  },
+  {
+    "Lineage": "B.1.1.56",
+    "Earliest date": "2020-05-21",
+    "Latest date": "2020-11-04",
+    "Description": "South African lineage"
+  },
+  {
+    "Lineage": "B.1.1.57",
+    "Earliest date": "2020-03-31",
+    "Latest date": "2021-04-08",
+    "Description": "South African lineage, a few English sequences, one Zimbabwe"
+  },
+  {
+    "Lineage": "B.1.1.58",
+    "Earliest date": "2020-04-08",
+    "Latest date": "2021-04-07",
+    "Description": "European lineage"
+  },
+  {
+    "Lineage": "B.1.1.59",
+    "Earliest date": "2020-06-01",
+    "Latest date": "2020-09-05",
+    "Description": "UK lineage"
+  },
+  {
+    "Lineage": "B.1.1.61",
+    "Earliest date": "2020-02-29",
+    "Latest date": "2021-07-20",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.1.1.62",
+    "Earliest date": "2020-05-18",
+    "Latest date": "2020-12-21",
+    "Description": "South African lineage"
+  },
+  {
+    "Lineage": "B.1.1.63",
+    "Earliest date": "2020-06-23",
+    "Latest date": "2021-09-22",
+    "Description": "Hong Kong lineage"
+  },
+  {
+    "Lineage": "B.1.1.67",
+    "Earliest date": "2020-03-15",
+    "Latest date": "2021-02-03",
+    "Description": "England and South Africa"
+  },
+  {
+    "Lineage": "B.1.1.70",
+    "Earliest date": "2020-03-06",
+    "Latest date": "2021-12-15",
+    "Description": "European Lineage"
+  },
+  {
+    "Lineage": "AP.1",
+    "Earliest date": "2020-09-04",
+    "Latest date": "2021-02-12",
+    "Description": "Alias of B.1.1.70.1, Wales lineage"
+  },
+  {
+    "Lineage": "B.1.1.71",
+    "Earliest date": "2020-03-06",
+    "Latest date": "2021-03-03",
+    "Description": "Dutch, Central Europe"
+  },
+  {
+    "Lineage": "B.1.1.72",
+    "Earliest date": "2020-07-25",
+    "Latest date": "2021-01-05",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.1.1.74",
+    "Earliest date": "2020-03-25",
+    "Latest date": "2021-01-14",
+    "Description": "NI & Ireland Lineage"
+  },
+  {
+    "Lineage": "B.1.1.75",
+    "Earliest date": "2020-03-17",
+    "Latest date": "2020-08-21",
+    "Description": "Belgian lineage"
+  },
+  {
+    "Lineage": "B.1.1.77",
+    "Earliest date": "2020-05-28",
+    "Latest date": "2020-10-05",
+    "Description": "USA Lineage"
+  },
+  {
+    "Lineage": "B.1.1.82",
+    "Earliest date": "2020-04-06",
+    "Latest date": "2021-02-12",
+    "Description": "Wales lineage"
+  },
+  {
+    "Lineage": "B.1.1.83",
+    "Earliest date": "2020-03-21",
+    "Latest date": "2020-10-01",
+    "Description": "Northern Irish lineage"
+  },
+  {
+    "Lineage": "B.1.1.84",
+    "Earliest date": "2020-06-22",
+    "Latest date": "2020-07-30",
+    "Description": "South African"
+  },
+  {
+    "Lineage": "B.1.1.86",
+    "Earliest date": "2020-05-19",
+    "Latest date": "2020-06-25",
+    "Description": "UK lineage"
+  },
+  {
+    "Lineage": "B.1.1.87",
+    "Earliest date": "2020-04-10",
+    "Latest date": "2020-05-14",
+    "Description": "Hungarian lineage"
+  },
+  {
+    "Lineage": "B.1.1.88",
+    "Earliest date": "2020-03-20",
+    "Latest date": "2020-04-28",
+    "Description": "Portugal lineage"
+  },
+  {
+    "Lineage": "B.1.1.89",
+    "Earliest date": "2020-03-12",
+    "Latest date": "2021-04-14",
+    "Description": "England"
+  },
+  {
+    "Lineage": "B.1.1.90",
+    "Earliest date": "2020-05-20",
+    "Latest date": "2020-07-16",
+    "Description": "Sweden and Denmark lineage"
+  },
+  {
+    "Lineage": "B.1.1.91",
+    "Earliest date": "2020-04-28",
+    "Latest date": "2020-07-14",
+    "Description": "Sweden"
+  },
+  {
+    "Lineage": "B.1.1.92",
+    "Earliest date": "2020-06-07",
+    "Latest date": "2020-06-24",
+    "Description": "English lineage"
+  },
+  {
+    "Lineage": "B.1.1.93",
+    "Earliest date": "2020-06-16",
+    "Latest date": "2020-09-03",
+    "Description": "USA Lineage"
+  },
+  {
+    "Lineage": "B.1.1.95",
+    "Earliest date": "2020-04-03",
+    "Latest date": "2021-01-13",
+    "Description": "English lineage"
+  },
+  {
+    "Lineage": "B.1.1.97",
+    "Earliest date": "2020-05-06",
+    "Latest date": "2020-07-29",
+    "Description": "England"
+  },
+  {
+    "Lineage": "B.1.1.98",
+    "Earliest date": "2020-04-05",
+    "Latest date": "2020-07-08",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.1.1.99",
+    "Earliest date": "2020-04-07",
+    "Latest date": "2021-08-10",
+    "Description": "Mostly South Africa"
+  },
+  {
+    "Lineage": "B.1.1.100",
+    "Earliest date": "2020-09-21",
+    "Latest date": "2020-11-09",
+    "Description": "Denmark lineage"
+  },
+  {
+    "Lineage": "B.1.1.101",
+    "Earliest date": "2020-03-31",
+    "Latest date": "2021-03-08",
+    "Description": "Indian lineage"
+  },
+  {
+    "Lineage": "B.1.1.107",
+    "Earliest date": "2020-06-06",
+    "Latest date": "2020-08-28",
+    "Description": "England"
+  },
+  {
+    "Lineage": "B.1.1.109",
+    "Earliest date": "2020-06-01",
+    "Latest date": "2020-07-03",
+    "Description": "UK lineage"
+  },
+  {
+    "Lineage": "B.1.1.110",
+    "Earliest date": "2020-04-18",
+    "Latest date": "2020-09-14",
+    "Description": "Peru lineage"
+  },
+  {
+    "Lineage": "B.1.1.111",
+    "Earliest date": "2020-05-01",
+    "Latest date": "2021-01-05",
+    "Description": "African lineage (Zambia, Zimbabwe)"
+  },
+  {
+    "Lineage": "B.1.1.112",
+    "Earliest date": "2020-05-08",
+    "Latest date": "2021-02-17",
+    "Description": "Netherlands"
+  },
+  {
+    "Lineage": "B.1.1.113",
+    "Earliest date": "2020-03-15",
+    "Latest date": "2021-10-22",
+    "Description": "Western USA"
+  },
+  {
+    "Lineage": "B.1.1.114",
+    "Earliest date": "2020-03-30",
+    "Latest date": "2020-05-12",
+    "Description": "Wales"
+  },
+  {
+    "Lineage": "B.1.1.115",
+    "Earliest date": "2020-05-09",
+    "Latest date": "2021-02-04",
+    "Description": "UK lineage, now contains former B.1.1.235"
+  },
+  {
+    "Lineage": "B.1.1.116",
+    "Earliest date": "2020-06-17",
+    "Latest date": "2021-01-04",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.1.1.117",
+    "Earliest date": "2020-04-07",
+    "Latest date": "2022-06-14",
+    "Description": "South African some Argentina, now contains B.1.1.252"
+  },
+  {
+    "Lineage": "B.1.1.118",
+    "Earliest date": "2020-05-11",
+    "Latest date": "2021-05-24",
+    "Description": "USA Lineage (TX)"
+  },
+  {
+    "Lineage": "B.1.1.119",
+    "Earliest date": "2020-04-15",
+    "Latest date": "2020-05-07",
+    "Description": "Northern Ireland lineage"
+  },
+  {
+    "Lineage": "B.1.1.120",
+    "Earliest date": "2020-06-01",
+    "Latest date": "2020-07-22",
+    "Description": "UK lineage"
+  },
+  {
+    "Lineage": "B.1.1.121",
+    "Earliest date": "2020-03-31",
+    "Latest date": "2021-01-30",
+    "Description": "Canadian lineage"
+  },
+  {
+    "Lineage": "B.1.1.122",
+    "Earliest date": "2020-04-10",
+    "Latest date": "2021-01-27",
+    "Description": "Netherlands"
+  },
+  {
+    "Lineage": "B.1.1.123",
+    "Earliest date": "2020-05-18",
+    "Latest date": "2020-07-18",
+    "Description": "UK lineage"
+  },
+  {
+    "Lineage": "B.1.1.125",
+    "Earliest date": "2020-05-21",
+    "Latest date": "2020-07-22",
+    "Description": "UK lineage"
+  },
+  {
+    "Lineage": "B.1.1.127",
+    "Earliest date": "2020-04-20",
+    "Latest date": "2020-09-24",
+    "Description": "Russian lineage"
+  },
+  {
+    "Lineage": "B.1.1.128",
+    "Earliest date": "2020-06-02",
+    "Latest date": "2021-03-06",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.1.1.129",
+    "Earliest date": "2020-04-09",
+    "Latest date": "2021-09-01",
+    "Description": "Russian lineage"
+  },
+  {
+    "Lineage": "B.1.1.130",
+    "Earliest date": "2020-07-31",
+    "Latest date": "2020-12-17",
+    "Description": "England"
+  },
+  {
+    "Lineage": "B.1.1.132",
+    "Earliest date": "2020-03-17",
+    "Latest date": "2021-04-19",
+    "Description": "USA Lineage"
+  },
+  {
+    "Lineage": "B.1.1.133",
+    "Earliest date": "2020-03-22",
+    "Latest date": "2021-02-03",
+    "Description": "UAE/ European lineage"
+  },
+  {
+    "Lineage": "B.1.1.134",
+    "Earliest date": "2020-03-28",
+    "Latest date": "2021-03-04",
+    "Description": "UK"
+  },
+  {
+    "Lineage": "B.1.1.135",
+    "Earliest date": "2020-03-12",
+    "Latest date": "2021-01-23",
+    "Description": "US"
+  },
+  {
+    "Lineage": "B.1.1.136",
+    "Earliest date": "2020-06-03",
+    "Latest date": "2020-07-05",
+    "Description": "Australian lineage"
+  },
+  {
+    "Lineage": "B.1.1.137",
+    "Earliest date": "2020-03-19",
+    "Latest date": "2020-05-18",
+    "Description": "UK lineage"
+  },
+  {
+    "Lineage": "B.1.1.138",
+    "Earliest date": "2020-04-04",
+    "Latest date": "2020-12-13",
+    "Description": "UK lineage"
+  },
+  {
+    "Lineage": "B.1.1.139",
+    "Earliest date": "2020-06-17",
+    "Latest date": "2020-12-18",
+    "Description": "USA"
+  },
+  {
+    "Lineage": "B.1.1.141",
+    "Earliest date": "2020-07-22",
+    "Latest date": "2021-08-03",
+    "Description": "Russian, Latvian, Netherlands"
+  },
+  {
+    "Lineage": "B.1.1.142",
+    "Earliest date": "2020-02-24",
+    "Latest date": "2024-07-23",
+    "Description": "Australian lineage"
+  },
+  {
+    "Lineage": "B.1.1.144",
+    "Earliest date": "2020-08-10",
+    "Latest date": "2021-02-23",
+    "Description": "Swiss lineage"
+  },
+  {
+    "Lineage": "B.1.1.145",
+    "Earliest date": "2020-05-20",
+    "Latest date": "2020-07-15",
+    "Description": "UK lineage"
+  },
+  {
+    "Lineage": "B.1.1.147",
+    "Earliest date": "2020-05-13",
+    "Latest date": "2020-07-05",
+    "Description": "England"
+  },
+  {
+    "Lineage": "B.1.1.148",
+    "Earliest date": "2020-04-12",
+    "Latest date": "2021-02-17",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.1.1.149",
+    "Earliest date": "2020-05-01",
+    "Latest date": "2020-11-25",
+    "Description": "English Lineage"
+  },
+  {
+    "Lineage": "B.1.1.152",
+    "Earliest date": "2020-09-03",
+    "Latest date": "2021-09-08",
+    "Description": "Russian"
+  },
+  {
+    "Lineage": "B.1.1.153",
+    "Earliest date": "2020-08-06",
+    "Latest date": "2021-07-29",
+    "Description": "Northern European Lineage"
+  },
+  {
+    "Lineage": "B.1.1.154",
+    "Earliest date": "2020-03-30",
+    "Latest date": "2020-06-11",
+    "Description": "UK lineage"
+  },
+  {
+    "Lineage": "B.1.1.155",
+    "Earliest date": "2020-06-02",
+    "Latest date": "2020-06-25",
+    "Description": "English"
+  },
+  {
+    "Lineage": "B.1.1.157",
+    "Earliest date": "2020-06-14",
+    "Latest date": "2021-03-30",
+    "Description": "Canadian lineage"
+  },
+  {
+    "Lineage": "B.1.1.158",
+    "Earliest date": "2020-06-01",
+    "Latest date": "2021-01-13",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.1.1.159",
+    "Earliest date": "2020-08-15",
+    "Latest date": "2021-06-26",
+    "Description": "European lineage"
+  },
+  {
+    "Lineage": "B.1.1.160",
+    "Earliest date": "2020-05-03",
+    "Latest date": "2020-05-16",
+    "Description": "Northern Ireland lineage"
+  },
+  {
+    "Lineage": "B.1.1.161",
+    "Earliest date": "2020-03-19",
+    "Latest date": "2023-04-21",
+    "Description": "Saudi lineage"
+  },
+  {
+    "Lineage": "B.1.1.162",
+    "Earliest date": "2020-03-21",
+    "Latest date": "2021-01-14",
+    "Description": "England, Russia, Latvia"
+  },
+  {
+    "Lineage": "B.1.1.163",
+    "Earliest date": "2020-04-01",
+    "Latest date": "2021-05-02",
+    "Description": "Russian lineage"
+  },
+  {
+    "Lineage": "B.1.1.164",
+    "Earliest date": "2020-03-16",
+    "Latest date": "2020-06-18",
+    "Description": "UK"
+  },
+  {
+    "Lineage": "B.1.1.165",
+    "Earliest date": "2020-08-28",
+    "Latest date": "2020-11-12",
+    "Description": "England"
+  },
+  {
+    "Lineage": "B.1.1.166",
+    "Earliest date": "2020-03-15",
+    "Latest date": "2021-02-17",
+    "Description": "UK lineage"
+  },
+  {
+    "Lineage": "B.1.1.168",
+    "Earliest date": "2020-03-15",
+    "Latest date": "2021-06-23",
+    "Description": "UK lineage"
+  },
+  {
+    "Lineage": "B.1.1.169",
+    "Earliest date": "2020-05-04",
+    "Latest date": "2021-03-27",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.1.1.170",
+    "Earliest date": "2020-07-19",
+    "Latest date": "2021-06-28",
+    "Description": "UK/Denmark lineage"
+  },
+  {
+    "Lineage": "B.1.1.171",
+    "Earliest date": "2020-03-20",
+    "Latest date": "2021-03-11",
+    "Description": "UK lineage"
+  },
+  {
+    "Lineage": "B.1.1.172",
+    "Earliest date": "2020-04-01",
+    "Latest date": "2020-07-16",
+    "Description": "USA"
+  },
+  {
+    "Lineage": "B.1.1.174",
+    "Earliest date": "2020-03-20",
+    "Latest date": "2021-08-21",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.1.1.175",
+    "Earliest date": "2020-04-29",
+    "Latest date": "2020-06-20",
+    "Description": "Bangladesh"
+  },
+  {
+    "Lineage": "B.1.1.176",
+    "Earliest date": "2020-03-12",
+    "Latest date": "2021-07-06",
+    "Description": "Canadian lineage"
+  },
+  {
+    "Lineage": "B.1.1.177",
+    "Earliest date": "2020-06-04",
+    "Latest date": "2021-03-03",
+    "Description": "Texas"
+  },
+  {
+    "Lineage": "B.1.1.178",
+    "Earliest date": "2020-04-02",
+    "Latest date": "2020-07-27",
+    "Description": "England"
+  },
+  {
+    "Lineage": "B.1.1.180",
+    "Earliest date": "2020-06-08",
+    "Latest date": "2021-01-11",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.1.1.181",
+    "Earliest date": "2020-03-22",
+    "Latest date": "2020-06-22",
+    "Description": "Used to be just Turkey, now lots of Canadian"
+  },
+  {
+    "Lineage": "B.1.1.182",
+    "Earliest date": "2020-09-09",
+    "Latest date": "2021-01-30",
+    "Description": "USA"
+  },
+  {
+    "Lineage": "B.1.1.184",
+    "Earliest date": "2020-04-03",
+    "Latest date": "2020-09-23",
+    "Description": "Russia, some B.1.1.129"
+  },
+  {
+    "Lineage": "B.1.1.185",
+    "Earliest date": "2020-03-31",
+    "Latest date": "2020-05-01",
+    "Description": "Netherlands lineage"
+  },
+  {
+    "Lineage": "B.1.1.186",
+    "Earliest date": "2020-05-12",
+    "Latest date": "2021-12-05",
+    "Description": "Southern USA"
+  },
+  {
+    "Lineage": "B.1.1.187",
+    "Earliest date": "2020-06-24",
+    "Latest date": "2020-12-18",
+    "Description": "UK and italy"
+  },
+  {
+    "Lineage": "B.1.1.189",
+    "Earliest date": "2020-04-11",
+    "Latest date": "2021-11-17",
+    "Description": "European lineage"
+  },
+  {
+    "Lineage": "B.1.1.190",
+    "Earliest date": "2020-03-17",
+    "Latest date": "2020-05-22",
+    "Description": "Wales lineage"
+  },
+  {
+    "Lineage": "B.1.1.191",
+    "Earliest date": "2020-03-20",
+    "Latest date": "2020-10-19",
+    "Description": "Denmark"
+  },
+  {
+    "Lineage": "B.1.1.192",
+    "Earliest date": "2020-03-21",
+    "Latest date": "2021-09-19",
+    "Description": "USA"
+  },
+  {
+    "Lineage": "B.1.1.193",
+    "Earliest date": "2020-09-30",
+    "Latest date": "2020-11-17",
+    "Description": "England"
+  },
+  {
+    "Lineage": "B.1.1.194",
+    "Earliest date": "2020-03-13",
+    "Latest date": "2020-12-24",
+    "Description": "England"
+  },
+  {
+    "Lineage": "B.1.1.196",
+    "Earliest date": "2020-08-26",
+    "Latest date": "2020-12-30",
+    "Description": "UK lineage"
+  },
+  {
+    "Lineage": "B.1.1.197",
+    "Earliest date": "2020-04-09",
+    "Latest date": "2020-05-27",
+    "Description": "UK lineage"
+  },
+  {
+    "Lineage": "B.1.1.198",
+    "Earliest date": "2020-03-09",
+    "Latest date": "2021-10-17",
+    "Description": "UK/ Luxembourg lineage"
+  },
+  {
+    "Lineage": "B.1.1.200",
+    "Earliest date": "2020-03-28",
+    "Latest date": "2020-07-24",
+    "Description": "UK"
+  },
+  {
+    "Lineage": "AN.1",
+    "Earliest date": "2020-07-07",
+    "Latest date": "2021-03-29",
+    "Description": "Alias of B.1.1.200.1, Sweden and Netherlands, from B.1.1.130"
+  },
+  {
+    "Lineage": "B.1.1.201",
+    "Earliest date": "2020-04-29",
+    "Latest date": "2021-12-17",
+    "Description": "India and Singapore and Texas"
+  },
+  {
+    "Lineage": "B.1.1.202",
+    "Earliest date": "2020-05-10",
+    "Latest date": "2020-05-24",
+    "Description": "Italy"
+  },
+  {
+    "Lineage": "B.1.1.203",
+    "Earliest date": "2020-05-20",
+    "Latest date": "2021-02-24",
+    "Description": "England and Ecuador"
+  },
+  {
+    "Lineage": "B.1.1.204",
+    "Earliest date": "2020-03-07",
+    "Latest date": "2021-03-31",
+    "Description": "UK lineage"
+  },
+  {
+    "Lineage": "B.1.1.205",
+    "Earliest date": "2020-05-16",
+    "Latest date": "2021-02-23",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.1.1.207",
+    "Earliest date": "2020-06-18",
+    "Latest date": "2021-06-22",
+    "Description": "USA"
+  },
+  {
+    "Lineage": "B.1.1.208",
+    "Earliest date": "2020-03-22",
+    "Latest date": "2020-06-26",
+    "Description": "UK"
+  },
+  {
+    "Lineage": "B.1.1.209",
+    "Earliest date": "2020-05-06",
+    "Latest date": "2021-03-31",
+    "Description": "Netherlands"
+  },
+  {
+    "Lineage": "B.1.1.210",
+    "Earliest date": "2020-03-17",
+    "Latest date": "2020-09-08",
+    "Description": "USA (TX)"
+  },
+  {
+    "Lineage": "B.1.1.213",
+    "Earliest date": "2020-03-20",
+    "Latest date": "2020-09-08",
+    "Description": "England"
+  },
+  {
+    "Lineage": "B.1.1.214",
+    "Earliest date": "2020-02-22",
+    "Latest date": "2021-07-29",
+    "Description": "Japan"
+  },
+  {
+    "Lineage": "B.1.1.216",
+    "Earliest date": "2020-02-24",
+    "Latest date": "2022-07-09",
+    "Description": "Predominantly Indian lineage with exports elsewhere"
+  },
+  {
+    "Lineage": "AM.1",
+    "Earliest date": "2020-11-09",
+    "Latest date": "2021-02-09",
+    "Description": "Alias of B.1.1.216.1, Portugal lineage"
+  },
+  {
+    "Lineage": "AM.2",
+    "Earliest date": "2020-11-05",
+    "Latest date": "2020-11-24",
+    "Description": "Alias of B.1.1.216.2, Canadian lineage"
+  },
+  {
+    "Lineage": "AM.3",
+    "Earliest date": "2020-10-30",
+    "Latest date": "2020-12-08",
+    "Description": "Alias of B.1.1.216.3, UK lineage"
+  },
+  {
+    "Lineage": "AM.4",
+    "Earliest date": "2020-11-05",
+    "Latest date": "2021-05-02",
+    "Description": "Alias of B.1.1.216.4, Canadian lineage"
+  },
+  {
+    "Lineage": "B.1.1.217",
+    "Earliest date": "2020-04-26",
+    "Latest date": "2021-04-06",
+    "Description": "UK lineage"
+  },
+  {
+    "Lineage": "S.1",
+    "Earliest date": "2020-08-24",
+    "Latest date": "2021-02-05",
+    "Description": "Alias of B.1.1.217.1, Latvian lineage, previously I.1"
+  },
+  {
+    "Lineage": "B.1.1.218",
+    "Earliest date": "2020-05-11",
+    "Latest date": "2021-01-07",
+    "Description": "European lineage"
+  },
+  {
+    "Lineage": "B.1.1.219",
+    "Earliest date": "2020-08-01",
+    "Latest date": "2021-08-18",
+    "Description": "Northern Europe (UK, Denmark, Norway, Sweden)"
+  },
+  {
+    "Lineage": "B.1.1.220",
+    "Earliest date": "2020-03-23",
+    "Latest date": "2021-02-24",
+    "Description": "UK lineage"
+  },
+  {
+    "Lineage": "B.1.1.221",
+    "Earliest date": "2020-03-29",
+    "Latest date": "2020-12-12",
+    "Description": "Belgian lineage"
+  },
+  {
+    "Lineage": "B.1.1.222",
+    "Earliest date": "2020-04-04",
+    "Latest date": "2022-03-02",
+    "Description": "USA/Mexico"
+  },
+  {
+    "Lineage": "B.1.1.224",
+    "Earliest date": "2020-08-31",
+    "Latest date": "2021-02-12",
+    "Description": "Denmark (some German)"
+  },
+  {
+    "Lineage": "B.1.1.225",
+    "Earliest date": "2020-06-16",
+    "Latest date": "2020-10-15",
+    "Description": "USA"
+  },
+  {
+    "Lineage": "B.1.1.226",
+    "Earliest date": "2020-04-21",
+    "Latest date": "2020-08-22",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.1.1.227",
+    "Earliest date": "2020-06-13",
+    "Latest date": "2020-10-02",
+    "Description": "England"
+  },
+  {
+    "Lineage": "B.1.1.228",
+    "Earliest date": "2020-05-13",
+    "Latest date": "2021-12-15",
+    "Description": "USA (WA)"
+  },
+  {
+    "Lineage": "B.1.1.229",
+    "Earliest date": "2020-08-18",
+    "Latest date": "2021-03-05",
+    "Description": "Italy"
+  },
+  {
+    "Lineage": "B.1.1.230",
+    "Earliest date": "2020-05-22",
+    "Latest date": "2020-10-21",
+    "Description": "USA"
+  },
+  {
+    "Lineage": "B.1.1.231",
+    "Earliest date": "2020-03-13",
+    "Latest date": "2021-04-01",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "AL.1",
+    "Earliest date": "2020-04-22",
+    "Latest date": "2021-04-04",
+    "Description": "Alias of B.1.1.231.1, Canada lineage"
+  },
+  {
+    "Lineage": "B.1.1.232",
+    "Earliest date": "2020-03-28",
+    "Latest date": "2021-08-04",
+    "Description": "Northern Europe (UK, Germany, Denmark, Belgium, NL)"
+  },
+  {
+    "Lineage": "AK.1",
+    "Earliest date": "2020-08-07",
+    "Latest date": "2020-12-19",
+    "Description": "Alias of B.1.1.232.1, UK lineage"
+  },
+  {
+    "Lineage": "AK.2",
+    "Earliest date": "2020-09-19",
+    "Latest date": "2020-12-06",
+    "Description": "Alias of B.1.1.232.2, German lineage"
+  },
+  {
+    "Lineage": "B.1.1.234",
+    "Earliest date": "2020-07-20",
+    "Latest date": "2021-02-03",
+    "Description": "England, Ireland, Northern Ireland, Northern Europe"
+  },
+  {
+    "Lineage": "B.1.1.236",
+    "Earliest date": "2020-09-09",
+    "Latest date": "2021-01-29",
+    "Description": "UK"
+  },
+  {
+    "Lineage": "B.1.1.237",
+    "Earliest date": "2020-05-15",
+    "Latest date": "2020-09-08",
+    "Description": "Wales"
+  },
+  {
+    "Lineage": "B.1.1.239",
+    "Earliest date": "2020-06-22",
+    "Latest date": "2021-01-06",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.1.1.241",
+    "Earliest date": "2020-04-29",
+    "Latest date": "2021-10-07",
+    "Description": "European lineage"
+  },
+  {
+    "Lineage": "AH.1",
+    "Earliest date": "2021-01-05",
+    "Latest date": "2021-01-19",
+    "Description": "Alias of B.1.1.241.1, Swiss Lineage"
+  },
+  {
+    "Lineage": "AH.2",
+    "Earliest date": "2020-08-18",
+    "Latest date": "2021-02-07",
+    "Description": "Alias of B.1.1.241.2, French Lineage"
+  },
+  {
+    "Lineage": "AH.3",
+    "Earliest date": "2020-10-23",
+    "Latest date": "2021-09-22",
+    "Description": "Alias of B.1.1.241.3, Finnish Lineage"
+  },
+  {
+    "Lineage": "B.1.1.240",
+    "Earliest date": "2020-08-27",
+    "Latest date": "2021-02-01",
+    "Description": "UK lineage"
+  },
+  {
+    "Lineage": "AJ.1",
+    "Earliest date": "2020-11-08",
+    "Latest date": "2021-03-08",
+    "Description": "Alias of B.1.1.240.1, Portugal lineage"
+  },
+  {
+    "Lineage": "B.1.1.242",
+    "Earliest date": "2020-07-21",
+    "Latest date": "2020-12-02",
+    "Description": "Gambia and Switzerland"
+  },
+  {
+    "Lineage": "B.1.1.243",
+    "Earliest date": "2020-04-24",
+    "Latest date": "2021-04-26",
+    "Description": "Eastern Europe, Central Europe, UK"
+  },
+  {
+    "Lineage": "B.1.1.244",
+    "Earliest date": "2020-04-07",
+    "Latest date": "2021-03-19",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.1.1.249",
+    "Earliest date": "2020-03-26",
+    "Latest date": "2020-05-06",
+    "Description": "Welsh Lineage"
+  },
+  {
+    "Lineage": "B.1.1.251",
+    "Earliest date": "2020-06-02",
+    "Latest date": "2021-03-04",
+    "Description": "UK and US"
+  },
+  {
+    "Lineage": "B.1.1.253",
+    "Earliest date": "2020-05-09",
+    "Latest date": "2020-12-30",
+    "Description": "UK"
+  },
+  {
+    "Lineage": "B.1.1.254",
+    "Earliest date": "2020-03-14",
+    "Latest date": "2021-08-21",
+    "Description": "Mostly South Africa"
+  },
+  {
+    "Lineage": "B.1.1.255",
+    "Earliest date": "2020-05-21",
+    "Latest date": "2021-02-05",
+    "Description": "UK lineage"
+  },
+  {
+    "Lineage": "B.1.1.256",
+    "Earliest date": "2020-04-30",
+    "Latest date": "2020-07-04",
+    "Description": "UK lineage"
+  },
+  {
+    "Lineage": "B.1.1.258",
+    "Earliest date": "2020-05-26",
+    "Latest date": "2021-01-18",
+    "Description": "USA (TX)"
+  },
+  {
+    "Lineage": "B.1.1.261",
+    "Earliest date": "2020-03-31",
+    "Latest date": "2020-11-25",
+    "Description": "Swedish/ Danish/ Faroe Islands lineage"
+  },
+  {
+    "Lineage": "B.1.1.257",
+    "Earliest date": "2020-03-02",
+    "Latest date": "2020-04-30",
+    "Description": "Mostly UK lineage with other northern european plus one singapore"
+  },
+  {
+    "Lineage": "B.1.1.262",
+    "Earliest date": "2020-04-28",
+    "Latest date": "2020-08-23",
+    "Description": "UK lineage"
+  },
+  {
+    "Lineage": "B.1.1.263",
+    "Earliest date": "2020-04-03",
+    "Latest date": "2021-04-03",
+    "Description": "UAE lineage (~95%)"
+  },
+  {
+    "Lineage": "B.1.1.265",
+    "Earliest date": "2020-06-04",
+    "Latest date": "2021-05-12",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.1.1.266",
+    "Earliest date": "2020-05-23",
+    "Latest date": "2021-03-09",
+    "Description": "Czech lineage"
+  },
+  {
+    "Lineage": "B.1.1.267",
+    "Earliest date": "2020-03-24",
+    "Latest date": "2020-06-09",
+    "Description": "Irish lineage"
+  },
+  {
+    "Lineage": "B.1.1.268",
+    "Earliest date": "2020-05-28",
+    "Latest date": "2020-08-23",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.1.1.269",
+    "Earliest date": "2020-05-19",
+    "Latest date": "2021-07-10",
+    "Description": "European lineage"
+  },
+  {
+    "Lineage": "B.1.1.270",
+    "Earliest date": "2020-03-21",
+    "Latest date": "2020-07-16",
+    "Description": "UK lineage"
+  },
+  {
+    "Lineage": "B.1.1.271",
+    "Earliest date": "2020-03-11",
+    "Latest date": "2021-06-06",
+    "Description": "German and Austrian lineage"
+  },
+  {
+    "Lineage": "B.1.1.272",
+    "Earliest date": "2020-08-17",
+    "Latest date": "2021-01-07",
+    "Description": "Denmark"
+  },
+  {
+    "Lineage": "B.1.1.273",
+    "Earliest date": "2020-05-25",
+    "Latest date": "2021-05-03",
+    "Description": "South african lineage, previously part of B.1.1.56"
+  },
+  {
+    "Lineage": "B.1.1.274",
+    "Earliest date": "2020-04-03",
+    "Latest date": "2021-04-13",
+    "Description": "England, Thailand, Russia, USA"
+  },
+  {
+    "Lineage": "B.1.1.275",
+    "Earliest date": "2020-03-19",
+    "Latest date": "2021-01-25",
+    "Description": "DRC with some UAE and England"
+  },
+  {
+    "Lineage": "B.1.1.277",
+    "Earliest date": "2020-03-17",
+    "Latest date": "2021-07-15",
+    "Description": "European lineage"
+  },
+  {
+    "Lineage": "K.1",
+    "Earliest date": "2020-07-23",
+    "Latest date": "2020-10-07",
+    "Description": "Alias of B.1.1.277.1, South Korean lineage"
+  },
+  {
+    "Lineage": "K.2",
+    "Earliest date": "2020-07-26",
+    "Latest date": "2021-02-19",
+    "Description": "Alias of B.1.1.277.2, Russian lineage"
+  },
+  {
+    "Lineage": "K.3",
+    "Earliest date": "2020-08-29",
+    "Latest date": "2020-12-09",
+    "Description": "Alias of B.1.1.277.3, Norway lineage"
+  },
+  {
+    "Lineage": "B.1.1.279",
+    "Earliest date": "2020-03-21",
+    "Latest date": "2020-12-23",
+    "Description": "English Lineage"
+  },
+  {
+    "Lineage": "B.1.1.280",
+    "Earliest date": "2020-07-30",
+    "Latest date": "2021-07-12",
+    "Description": "Lithuanian lineage"
+  },
+  {
+    "Lineage": "B.1.1.282",
+    "Earliest date": "2020-03-26",
+    "Latest date": "2021-03-22",
+    "Description": "Netherlands lineage"
+  },
+  {
+    "Lineage": "B.1.1.283",
+    "Earliest date": "2020-03-16",
+    "Latest date": "2020-07-09",
+    "Description": "Japan"
+  },
+  {
+    "Lineage": "B.1.1.284",
+    "Earliest date": "2020-05-22",
+    "Latest date": "2021-05-31",
+    "Description": "Japan"
+  },
+  {
+    "Lineage": "B.1.1.285",
+    "Earliest date": "2020-01-09",
+    "Latest date": "2021-03-26",
+    "Description": "Japan/ USA lineage"
+  },
+  {
+    "Lineage": "B.1.1.286",
+    "Earliest date": "2020-06-22",
+    "Latest date": "2021-04-12",
+    "Description": "UK"
+  },
+  {
+    "Lineage": "B.1.1.288",
+    "Earliest date": "2020-07-20",
+    "Latest date": "2020-12-20",
+    "Description": "Danish Lineage"
+  },
+  {
+    "Lineage": "B.1.1.289",
+    "Earliest date": "2020-03-20",
+    "Latest date": "2020-07-15",
+    "Description": "UK lineage"
+  },
+  {
+    "Lineage": "B.1.1.290",
+    "Earliest date": "2020-05-11",
+    "Latest date": "2020-07-30",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.1.1.291",
+    "Earliest date": "2020-04-27",
+    "Latest date": "2021-07-20",
+    "Description": "USA Lineage"
+  },
+  {
+    "Lineage": "B.1.1.294",
+    "Earliest date": "2020-03-31",
+    "Latest date": "2021-09-22",
+    "Description": "Russian and UK lineage"
+  },
+  {
+    "Lineage": "M.1",
+    "Earliest date": "2020-12-07",
+    "Latest date": "2021-02-17",
+    "Description": "Alias of B.1.1.294.1, Israel"
+  },
+  {
+    "Lineage": "M.2",
+    "Earliest date": "2020-10-26",
+    "Latest date": "2021-01-20",
+    "Description": "Alias of B.1.1.294.2, Swiss Lineage"
+  },
+  {
+    "Lineage": "M.3",
+    "Earliest date": "2020-09-01",
+    "Latest date": "2021-02-08",
+    "Description": "Alias of B.1.1.294.3, English Lineage"
+  },
+  {
+    "Lineage": "B.1.1.296",
+    "Earliest date": "2020-03-20",
+    "Latest date": "2020-05-19",
+    "Description": "UK lineage"
+  },
+  {
+    "Lineage": "B.1.1.297",
+    "Earliest date": "2020-07-16",
+    "Latest date": "2021-09-20",
+    "Description": "Central Europe lineage"
+  },
+  {
+    "Lineage": "AG.1",
+    "Earliest date": "2020-09-11",
+    "Latest date": "2021-02-03",
+    "Description": "Alias of B.1.1.297.1, Netherlands lineage"
+  },
+  {
+    "Lineage": "B.1.1.298",
+    "Earliest date": "2020-06-08",
+    "Latest date": "2021-01-18",
+    "Description": "Denmark Lineage"
+  },
+  {
+    "Lineage": "B.1.1.299",
+    "Earliest date": "2020-05-22",
+    "Latest date": "2020-07-16",
+    "Description": "UK lineage"
+  },
+  {
+    "Lineage": "B.1.1.300",
+    "Earliest date": "2020-06-11",
+    "Latest date": "2020-07-21",
+    "Description": "UK lineage"
+  },
+  {
+    "Lineage": "B.1.1.301",
+    "Earliest date": "2020-05-22",
+    "Latest date": "2021-03-07",
+    "Description": "UK lineage"
+  },
+  {
+    "Lineage": "B.1.1.302",
+    "Earliest date": "2020-07-06",
+    "Latest date": "2021-10-27",
+    "Description": "Swedish lineage"
+  },
+  {
+    "Lineage": "B.1.1.303",
+    "Earliest date": "2020-06-09",
+    "Latest date": "2020-11-19",
+    "Description": "UK"
+  },
+  {
+    "Lineage": "B.1.1.304",
+    "Earliest date": "2020-03-31",
+    "Latest date": "2021-04-21",
+    "Description": "UK/USA lineage"
+  },
+  {
+    "Lineage": "B.1.1.305",
+    "Earliest date": "2020-07-08",
+    "Latest date": "2021-03-09",
+    "Description": "Pan European"
+  },
+  {
+    "Lineage": "AF.1",
+    "Earliest date": "2020-10-16",
+    "Latest date": "2021-01-27",
+    "Description": "Alias of B.1.1.305.1, Switzerland"
+  },
+  {
+    "Lineage": "B.1.1.306",
+    "Earliest date": "2020-03-01",
+    "Latest date": "2021-12-06",
+    "Description": "Big indian lineage, exports to Zambia, Bahrain and Canada"
+  },
+  {
+    "Lineage": "AE.1",
+    "Earliest date": "2020-05-08",
+    "Latest date": "2021-04-14",
+    "Description": "Alias of B.1.1.306.1, Zambian"
+  },
+  {
+    "Lineage": "AE.2",
+    "Earliest date": "2020-06-23",
+    "Latest date": "2020-11-11",
+    "Description": "Alias of B.1.1.306.2, Bahrain"
+  },
+  {
+    "Lineage": "AE.3",
+    "Earliest date": "2020-06-04",
+    "Latest date": "2021-04-06",
+    "Description": "Alias of B.1.1.306.3, Zambia and Rwanda"
+  },
+  {
+    "Lineage": "AE.4",
+    "Earliest date": "2020-06-23",
+    "Latest date": "2021-02-25",
+    "Description": "Alias of B.1.1.306.4, Bahrain"
+  },
+  {
+    "Lineage": "AE.5",
+    "Earliest date": "2020-06-28",
+    "Latest date": "2020-08-29",
+    "Description": "Alias of B.1.1.306.5, Zambia"
+  },
+  {
+    "Lineage": "AE.6",
+    "Earliest date": "2020-10-11",
+    "Latest date": "2021-01-04",
+    "Description": "Alias of B.1.1.306.6, Bahrain"
+  },
+  {
+    "Lineage": "AE.7",
+    "Earliest date": "2020-07-09",
+    "Latest date": "2020-11-12",
+    "Description": "Alias of B.1.1.306.7, Bahrain"
+  },
+  {
+    "Lineage": "AE.8",
+    "Earliest date": "2020-06-29",
+    "Latest date": "2021-06-17",
+    "Description": "Alias of B.1.1.306.8, Canada lineage"
+  },
+  {
+    "Lineage": "B.1.1.307",
+    "Earliest date": "2020-07-29",
+    "Latest date": "2021-02-14",
+    "Description": "UK lineage"
+  },
+  {
+    "Lineage": "B.1.1.308",
+    "Earliest date": "2020-08-31",
+    "Latest date": "2020-11-23",
+    "Description": "UK"
+  },
+  {
+    "Lineage": "B.1.1.309",
+    "Earliest date": "2020-08-11",
+    "Latest date": "2021-01-09",
+    "Description": "Now all England, was USA, so probably split from something"
+  },
+  {
+    "Lineage": "B.1.1.310",
+    "Earliest date": "2020-05-15",
+    "Latest date": "2020-10-13",
+    "Description": "Northern Irish with English root"
+  },
+  {
+    "Lineage": "B.1.1.311",
+    "Earliest date": "2020-07-29",
+    "Latest date": "2021-04-28",
+    "Description": "Huge UK lineage"
+  },
+  {
+    "Lineage": "B.1.1.312",
+    "Earliest date": "2020-08-13",
+    "Latest date": "2021-03-17",
+    "Description": "Jordan lineage"
+  },
+  {
+    "Lineage": "B.1.1.315",
+    "Earliest date": "2020-08-01",
+    "Latest date": "2021-02-19",
+    "Description": "Previously D.1, UK/ UAE lineage"
+  },
+  {
+    "Lineage": "AD.1",
+    "Earliest date": "2020-11-02",
+    "Latest date": "2021-02-22",
+    "Description": "Alias of B.1.1.315.1, Denmark lineage"
+  },
+  {
+    "Lineage": "AD.2",
+    "Earliest date": "2020-07-21",
+    "Latest date": "2021-09-29",
+    "Description": "Alias of B.1.1.315.2, UK lineage"
+  },
+  {
+    "Lineage": "AD.2.1",
+    "Earliest date": "2020-12-04",
+    "Latest date": "2021-02-27",
+    "Description": "Alias of B.1.1.315.2.1, Lithuanian lineage"
+  },
+  {
+    "Lineage": "B.1.1.316",
+    "Earliest date": "2020-05-17",
+    "Latest date": "2021-09-14",
+    "Description": "International lineage with spike mutation Q677H, parent of lineage R.1 and R.2 which have additional mutations including E484K mutation, from #14"
+  },
+  {
+    "Lineage": "R.1",
+    "Earliest date": "2020-01-14",
+    "Latest date": "2021-12-23",
+    "Description": "Alias of B.1.1.316.1, Sublineage of B.1.1.316 with 3 additional spike mutations, circulating in a number of countries, from #17"
+  },
+  {
+    "Lineage": "R.2",
+    "Earliest date": "2020-12-09",
+    "Latest date": "2021-05-05",
+    "Description": "Alias of B.1.1.316.2, Sublineage of B.1.1.316 with E484K, from #18"
+  },
+  {
+    "Lineage": "B.1.1.317",
+    "Earliest date": "2020-03-19",
+    "Latest date": "2022-06-06",
+    "Description": "Russian lineage, from #53"
+  },
+  {
+    "Lineage": "AS.1",
+    "Earliest date": "2020-10-21",
+    "Latest date": "2021-01-14",
+    "Description": "Alias of B.1.1.317.1, UK lineage"
+  },
+  {
+    "Lineage": "AS.2",
+    "Earliest date": "2020-09-24",
+    "Latest date": "2021-01-23",
+    "Description": "Alias of B.1.1.317.2, UK lineage"
+  },
+  {
+    "Lineage": "B.1.1.318",
+    "Earliest date": "2020-05-14",
+    "Latest date": "2021-10-07",
+    "Description": "Lineage circulating in multiple countries with a number of variants of concern (Spike D614G, Spike D796H, Spike E484K, Spike P681H, Spike T95I, Spike Y144del), from #15"
+  },
+  {
+    "Lineage": "AZ.1",
+    "Earliest date": "2021-02-02",
+    "Latest date": "2021-07-29",
+    "Description": "Alias of B.1.1.318.1, Canada lineage, from #171"
+  },
+  {
+    "Lineage": "AZ.2",
+    "Earliest date": "2021-02-05",
+    "Latest date": "2021-08-19",
+    "Description": "Alias of B.1.1.318.2, predominantly Greece lineage, from #171"
+  },
+  {
+    "Lineage": "AZ.2.1",
+    "Earliest date": "2021-03-15",
+    "Latest date": "2021-06-26",
+    "Description": "Alias of B.1.1.318.2.1, Switzerland lineage, from #171"
+  },
+  {
+    "Lineage": "AZ.3",
+    "Earliest date": "2021-02-08",
+    "Latest date": "2021-08-20",
+    "Description": "Alias of B.1.1.318.3, USA lineage, from #171"
+  },
+  {
+    "Lineage": "AZ.4",
+    "Earliest date": "2021-02-08",
+    "Latest date": "2021-08-14",
+    "Description": "Alias of B.1.1.318.4, Ireland lineage, from #171"
+  },
+  {
+    "Lineage": "AZ.5",
+    "Earliest date": "2021-02-09",
+    "Latest date": "2021-12-06",
+    "Description": "Alias of B.1.1.318.5, Mauritius lineage, from #171"
+  },
+  {
+    "Lineage": "AZ.6",
+    "Earliest date": "2021-03-04",
+    "Latest date": "2021-06-15",
+    "Description": "Alias of B.1.1.318.6, Canada lineage, from #171"
+  },
+  {
+    "Lineage": "B.1.1.319",
+    "Earliest date": "2020-03-02",
+    "Latest date": "2020-12-16",
+    "Description": "Russian/Serbian Lineage"
+  },
+  {
+    "Lineage": "B.1.1.320",
+    "Earliest date": "2020-09-01",
+    "Latest date": "2021-02-08",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.1.1.322",
+    "Earliest date": "2020-06-10",
+    "Latest date": "2021-05-05",
+    "Description": "Mexico/Southwest USA"
+  },
+  {
+    "Lineage": "B.1.1.323",
+    "Earliest date": "2020-02-29",
+    "Latest date": "2020-06-16",
+    "Description": "Northern Europe, split from B.1.1.257"
+  },
+  {
+    "Lineage": "B.1.1.324",
+    "Earliest date": "2020-05-22",
+    "Latest date": "2021-01-31",
+    "Description": "Chilean Lineage"
+  },
+  {
+    "Lineage": "B.1.1.325",
+    "Earliest date": "2020-07-16",
+    "Latest date": "2021-02-23",
+    "Description": "Eastern Europe plus Belgium and Denmark"
+  },
+  {
+    "Lineage": "B.1.1.326",
+    "Earliest date": "2020-03-23",
+    "Latest date": "2021-09-11",
+    "Description": "Indian Lineage"
+  },
+  {
+    "Lineage": "B.1.1.327",
+    "Earliest date": "2020-11-22",
+    "Latest date": "2021-01-12",
+    "Description": "Swiss Lineage"
+  },
+  {
+    "Lineage": "B.1.1.328",
+    "Earliest date": "2020-05-04",
+    "Latest date": "2021-05-26",
+    "Description": "Costa Rica and Florida"
+  },
+  {
+    "Lineage": "B.1.1.329",
+    "Earliest date": "2020-05-28",
+    "Latest date": "2021-04-06",
+    "Description": "Pan-US"
+  },
+  {
+    "Lineage": "B.1.1.330",
+    "Earliest date": "2021-01-02",
+    "Latest date": "2021-01-04",
+    "Description": "Chinese Lineage"
+  },
+  {
+    "Lineage": "B.1.1.331",
+    "Earliest date": "2020-02-26",
+    "Latest date": "2020-04-15",
+    "Description": "Austrian lineage"
+  },
+  {
+    "Lineage": "B.1.1.332",
+    "Earliest date": "2020-07-01",
+    "Latest date": "2021-03-17",
+    "Description": "Brazilian Lineage"
+  },
+  {
+    "Lineage": "B.1.1.333",
+    "Earliest date": "2020-01-29",
+    "Latest date": "2021-05-13",
+    "Description": "Norwegian Lineage"
+  },
+  {
+    "Lineage": "B.1.1.334",
+    "Earliest date": "2020-05-23",
+    "Latest date": "2021-01-20",
+    "Description": "USA and Mexico"
+  },
+  {
+    "Lineage": "B.1.1.335",
+    "Earliest date": "2020-04-17",
+    "Latest date": "2021-01-27",
+    "Description": "USA and Canada"
+  },
+  {
+    "Lineage": "B.1.1.336",
+    "Earliest date": "2020-09-01",
+    "Latest date": "2021-07-01",
+    "Description": "Russian lineage"
+  },
+  {
+    "Lineage": "B.1.1.337",
+    "Earliest date": "2020-06-27",
+    "Latest date": "2021-03-20",
+    "Description": "US"
+  },
+  {
+    "Lineage": "B.1.1.338",
+    "Earliest date": "2020-12-07",
+    "Latest date": "2021-03-01",
+    "Description": "German lineage"
+  },
+  {
+    "Lineage": "B.1.1.339",
+    "Earliest date": "2020-03-19",
+    "Latest date": "2020-12-26",
+    "Description": "UAE and England"
+  },
+  {
+    "Lineage": "B.1.1.340",
+    "Earliest date": "2020-05-13",
+    "Latest date": "2020-08-19",
+    "Description": "Indian Lineage"
+  },
+  {
+    "Lineage": "B.1.1.341",
+    "Earliest date": "2020-09-14",
+    "Latest date": "2020-10-21",
+    "Description": "UK lineage"
+  },
+  {
+    "Lineage": "B.1.1.342",
+    "Earliest date": "2020-06-16",
+    "Latest date": "2020-07-28",
+    "Description": "USA"
+  },
+  {
+    "Lineage": "B.1.1.343",
+    "Earliest date": "2020-11-24",
+    "Latest date": "2021-04-10",
+    "Description": "Canadian lineage"
+  },
+  {
+    "Lineage": "B.1.1.344",
+    "Earliest date": "2020-04-09",
+    "Latest date": "2021-02-22",
+    "Description": "Mexico, Texas"
+  },
+  {
+    "Lineage": "B.1.1.345",
+    "Earliest date": "2020-11-10",
+    "Latest date": "2021-03-07",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.1.1.346",
+    "Earliest date": "2020-09-21",
+    "Latest date": "2020-10-26",
+    "Description": "Denmark lineage"
+  },
+  {
+    "Lineage": "B.1.1.347",
+    "Earliest date": "2020-07-14",
+    "Latest date": "2021-03-14",
+    "Description": "Central Europe"
+  },
+  {
+    "Lineage": "B.1.1.348",
+    "Earliest date": "2020-04-30",
+    "Latest date": "2021-07-20",
+    "Description": "South America & USA"
+  },
+  {
+    "Lineage": "B.1.1.349",
+    "Earliest date": "2020-08-04",
+    "Latest date": "2021-06-04",
+    "Description": "Russia, one \"Congo\""
+  },
+  {
+    "Lineage": "B.1.1.350",
+    "Earliest date": "2020-03-23",
+    "Latest date": "2020-08-14",
+    "Description": "Latvian lineage"
+  },
+  {
+    "Lineage": "B.1.1.351",
+    "Earliest date": "2020-09-10",
+    "Latest date": "2021-09-21",
+    "Description": "USA, England, Finland, Denmark"
+  },
+  {
+    "Lineage": "B.1.1.352",
+    "Earliest date": "2020-09-29",
+    "Latest date": "2021-02-10",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.1.1.353",
+    "Earliest date": "2020-09-08",
+    "Latest date": "2021-03-28",
+    "Description": "UAE, Israel, Australia"
+  },
+  {
+    "Lineage": "B.1.1.354",
+    "Earliest date": "2020-05-19",
+    "Latest date": "2021-12-16",
+    "Description": "Singapore, malaysia, India, UAE, England"
+  },
+  {
+    "Lineage": "B.1.1.355",
+    "Earliest date": "2020-09-10",
+    "Latest date": "2021-02-07",
+    "Description": "England, Northern Europe"
+  },
+  {
+    "Lineage": "B.1.1.356",
+    "Earliest date": "2020-05-20",
+    "Latest date": "2020-09-02",
+    "Description": "Texas"
+  },
+  {
+    "Lineage": "B.1.1.357",
+    "Earliest date": "2020-07-01",
+    "Latest date": "2020-08-28",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.1.1.358",
+    "Earliest date": "2020-09-26",
+    "Latest date": "2021-02-04",
+    "Description": "USA"
+  },
+  {
+    "Lineage": "B.1.1.359",
+    "Earliest date": "2020-07-06",
+    "Latest date": "2021-08-02",
+    "Description": "Ghana and Denmark"
+  },
+  {
+    "Lineage": "B.1.1.360",
+    "Earliest date": "2020-04-03",
+    "Latest date": "2020-05-01",
+    "Description": "Wales"
+  },
+  {
+    "Lineage": "B.1.1.361",
+    "Earliest date": "2020-06-04",
+    "Latest date": "2020-07-04",
+    "Description": "England"
+  },
+  {
+    "Lineage": "B.1.1.362",
+    "Earliest date": "2020-06-09",
+    "Latest date": "2021-03-22",
+    "Description": "USA"
+  },
+  {
+    "Lineage": "B.1.1.363",
+    "Earliest date": "2020-03-30",
+    "Latest date": "2020-07-27",
+    "Description": "Wales"
+  },
+  {
+    "Lineage": "B.1.1.364",
+    "Earliest date": "2020-06-09",
+    "Latest date": "2020-12-31",
+    "Description": "Russia, S Korea, England"
+  },
+  {
+    "Lineage": "B.1.1.365",
+    "Earliest date": "2020-06-01",
+    "Latest date": "2020-08-26",
+    "Description": "England"
+  },
+  {
+    "Lineage": "B.1.1.366",
+    "Earliest date": "2020-03-28",
+    "Latest date": "2020-07-19",
+    "Description": "UAE"
+  },
+  {
+    "Lineage": "B.1.1.367",
+    "Earliest date": "2020-05-14",
+    "Latest date": "2021-03-29",
+    "Description": "USA"
+  },
+  {
+    "Lineage": "B.1.1.368",
+    "Earliest date": "2020-08-03",
+    "Latest date": "2021-09-14",
+    "Description": "USA and Canada"
+  },
+  {
+    "Lineage": "B.1.1.369",
+    "Earliest date": "2020-03-02",
+    "Latest date": "2020-11-25",
+    "Description": "England"
+  },
+  {
+    "Lineage": "B.1.1.370",
+    "Earliest date": "2020-04-05",
+    "Latest date": "2021-01-13",
+    "Description": "England, USA, Russia, Germany"
+  },
+  {
+    "Lineage": "AT.1",
+    "Earliest date": "2021-01-18",
+    "Latest date": "2021-08-09",
+    "Description": "Alias of B.1.1.370.1, Russia and Finland lineage, from #47"
+  },
+  {
+    "Lineage": "B.1.1.371",
+    "Earliest date": "2020-03-07",
+    "Latest date": "2021-01-24",
+    "Description": "Saudi Arabia to Romania to Western Europe, contains B.1.1.161 at the base"
+  },
+  {
+    "Lineage": "B.1.1.372",
+    "Earliest date": "2020-03-08",
+    "Latest date": "2021-04-23",
+    "Description": "England"
+  },
+  {
+    "Lineage": "B.1.1.373",
+    "Earliest date": "2020-06-05",
+    "Latest date": "2021-04-01",
+    "Description": "Russia, split from B.1.1.31"
+  },
+  {
+    "Lineage": "B.1.1.374",
+    "Earliest date": "2020-10-23",
+    "Latest date": "2021-05-17",
+    "Description": "Balkans, Finland"
+  },
+  {
+    "Lineage": "B.1.1.375",
+    "Earliest date": "2020-09-10",
+    "Latest date": "2021-02-12",
+    "Description": "Mozambique, was C.1.1"
+  },
+  {
+    "Lineage": "B.1.1.376",
+    "Earliest date": "2020-05-11",
+    "Latest date": "2021-04-13",
+    "Description": "USA (California)"
+  },
+  {
+    "Lineage": "B.1.1.377",
+    "Earliest date": "2020-10-19",
+    "Latest date": "2021-03-08",
+    "Description": "Denmark"
+  },
+  {
+    "Lineage": "B.1.1.378",
+    "Earliest date": "2020-03-16",
+    "Latest date": "2021-07-26",
+    "Description": "UK and Brazil"
+  },
+  {
+    "Lineage": "B.1.1.379",
+    "Earliest date": "2020-04-05",
+    "Latest date": "2020-06-12",
+    "Description": "Wales"
+  },
+  {
+    "Lineage": "B.1.1.380",
+    "Earliest date": "2020-06-12",
+    "Latest date": "2021-05-17",
+    "Description": "USA"
+  },
+  {
+    "Lineage": "B.1.1.381",
+    "Earliest date": "2020-05-04",
+    "Latest date": "2021-02-10",
+    "Description": "Peruvian"
+  },
+  {
+    "Lineage": "B.1.1.382",
+    "Earliest date": "2020-04-19",
+    "Latest date": "2020-11-26",
+    "Description": "South African lineage"
+  },
+  {
+    "Lineage": "B.1.1.383",
+    "Earliest date": "2020-04-29",
+    "Latest date": "2020-09-04",
+    "Description": "South African"
+  },
+  {
+    "Lineage": "B.1.1.384",
+    "Earliest date": "2020-12-28",
+    "Latest date": "2021-04-19",
+    "Description": "Swiss Lineage"
+  },
+  {
+    "Lineage": "B.1.1.385",
+    "Earliest date": "2020-09-11",
+    "Latest date": "2021-10-12",
+    "Description": "German Lineage"
+  },
+  {
+    "Lineage": "B.1.1.386",
+    "Earliest date": "2020-05-30",
+    "Latest date": "2021-01-04",
+    "Description": "South African lineage"
+  },
+  {
+    "Lineage": "B.1.1.387",
+    "Earliest date": "2020-08-04",
+    "Latest date": "2021-03-12",
+    "Description": "South African lineage"
+  },
+  {
+    "Lineage": "B.1.1.388",
+    "Earliest date": "2020-04-26",
+    "Latest date": "2021-03-12",
+    "Description": "Columbian lineage"
+  },
+  {
+    "Lineage": "B.1.1.389",
+    "Earliest date": "2020-06-18",
+    "Latest date": "2021-04-07",
+    "Description": "Costa Rica lineage"
+  },
+  {
+    "Lineage": "B.1.1.391",
+    "Earliest date": "2020-03-30",
+    "Latest date": "2021-02-04",
+    "Description": "UAE lineage"
+  },
+  {
+    "Lineage": "B.1.1.392",
+    "Earliest date": "2020-08-29",
+    "Latest date": "2021-01-07",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.1.1.393",
+    "Earliest date": "2020-11-04",
+    "Latest date": "2021-02-06",
+    "Description": "Brazilian lineage"
+  },
+  {
+    "Lineage": "B.1.1.394",
+    "Earliest date": "2020-06-21",
+    "Latest date": "2020-08-31",
+    "Description": "Portugal lineage"
+  },
+  {
+    "Lineage": "B.1.1.395",
+    "Earliest date": "2020-04-27",
+    "Latest date": "2020-05-18",
+    "Description": "UK lineage, previously part of B.1.1.279"
+  },
+  {
+    "Lineage": "B.1.1.396",
+    "Earliest date": "2020-06-05",
+    "Latest date": "2021-05-07",
+    "Description": "Russian lineage, some previously B.1.1.184"
+  },
+  {
+    "Lineage": "B.1.1.397",
+    "Earliest date": "2020-09-11",
+    "Latest date": "2021-08-13",
+    "Description": "Predominantly Russia, includes some previous B.1.1.67 and H.1 sequences"
+  },
+  {
+    "Lineage": "B.1.1.398",
+    "Earliest date": "2020-03-19",
+    "Latest date": "2021-08-04",
+    "Description": "USA/ Indonesian lineage"
+  },
+  {
+    "Lineage": "B.1.1.399",
+    "Earliest date": "2020-04-15",
+    "Latest date": "2020-06-04",
+    "Description": "Irish lineage"
+  },
+  {
+    "Lineage": "B.1.1.400",
+    "Earliest date": "2020-04-07",
+    "Latest date": "2020-05-08",
+    "Description": "Spain lineage"
+  },
+  {
+    "Lineage": "B.1.1.401",
+    "Earliest date": "2020-06-01",
+    "Latest date": "2020-11-26",
+    "Description": "Portugal lineage"
+  },
+  {
+    "Lineage": "B.1.1.402",
+    "Earliest date": "2020-04-11",
+    "Latest date": "2020-10-22",
+    "Description": "USA (Texas), split from B.1.1.177"
+  },
+  {
+    "Lineage": "B.1.1.403",
+    "Earliest date": "2020-09-03",
+    "Latest date": "2021-01-24",
+    "Description": "USA"
+  },
+  {
+    "Lineage": "B.1.1.404",
+    "Earliest date": "2020-05-25",
+    "Latest date": "2021-04-26",
+    "Description": "Ghana, Burkina Faso, Luxembourg, Germany"
+  },
+  {
+    "Lineage": "B.1.1.405",
+    "Earliest date": "2020-09-14",
+    "Latest date": "2020-12-25",
+    "Description": "Germany lineage"
+  },
+  {
+    "Lineage": "AC.1",
+    "Earliest date": "2020-10-21",
+    "Latest date": "2021-02-10",
+    "Description": "Alias of B.1.1.405.1, UK lineage"
+  },
+  {
+    "Lineage": "B.1.1.406",
+    "Earliest date": "2020-03-25",
+    "Latest date": "2020-12-13",
+    "Description": "Spain, UK, Italy"
+  },
+  {
+    "Lineage": "B.1.1.407",
+    "Earliest date": "2020-06-09",
+    "Latest date": "2021-02-14",
+    "Description": "Mostly Russia"
+  },
+  {
+    "Lineage": "B.1.1.408",
+    "Earliest date": "2020-07-11",
+    "Latest date": "2020-08-10",
+    "Description": "UK lineage"
+  },
+  {
+    "Lineage": "B.1.1.409",
+    "Earliest date": "2020-03-18",
+    "Latest date": "2021-02-17",
+    "Description": "UAE, Israel, Saudi Arabia"
+  },
+  {
+    "Lineage": "B.1.1.410",
+    "Earliest date": "2020-05-19",
+    "Latest date": "2020-08-24",
+    "Description": "Portugal lineage"
+  },
+  {
+    "Lineage": "B.1.1.411",
+    "Earliest date": "2020-03-22",
+    "Latest date": "2021-01-18",
+    "Description": "Ecuador and US"
+  },
+  {
+    "Lineage": "B.1.1.412",
+    "Earliest date": "2020-06-18",
+    "Latest date": "2021-06-07",
+    "Description": "South African lineage"
+  },
+  {
+    "Lineage": "B.1.1.413",
+    "Earliest date": "2020-09-07",
+    "Latest date": "2021-07-29",
+    "Description": "Europe, Turkey, Iran"
+  },
+  {
+    "Lineage": "B.1.1.414",
+    "Earliest date": "2020-07-14",
+    "Latest date": "2020-09-11",
+    "Description": "Indian lineage"
+  },
+  {
+    "Lineage": "B.1.1.415",
+    "Earliest date": "2020-11-28",
+    "Latest date": "2021-01-07",
+    "Description": "Austrian lineage"
+  },
+  {
+    "Lineage": "B.1.1.416",
+    "Earliest date": "2020-03-19",
+    "Latest date": "2021-09-17",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.1.1.417",
+    "Earliest date": "2020-06-23",
+    "Latest date": "2021-01-21",
+    "Description": "Canada lineage"
+  },
+  {
+    "Lineage": "B.1.1.418",
+    "Earliest date": "2020-10-06",
+    "Latest date": "2021-03-03",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.1.1.419",
+    "Earliest date": "2020-03-14",
+    "Latest date": "2020-07-03",
+    "Description": "UK lineage, includes some formally B.1.1.193 sequences"
+  },
+  {
+    "Lineage": "B.1.1.420",
+    "Earliest date": "2020-08-12",
+    "Latest date": "2021-07-16",
+    "Description": "Western Europe, USA"
+  },
+  {
+    "Lineage": "B.1.1.421",
+    "Earliest date": "2020-05-28",
+    "Latest date": "2020-08-05",
+    "Description": "Portuguese lineage"
+  },
+  {
+    "Lineage": "B.1.1.422",
+    "Earliest date": "2020-10-26",
+    "Latest date": "2021-01-07",
+    "Description": "Lithuanian lineage"
+  },
+  {
+    "Lineage": "B.1.1.423",
+    "Earliest date": "2020-05-19",
+    "Latest date": "2020-12-04",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.1.1.424",
+    "Earliest date": "2020-04-05",
+    "Latest date": "2021-08-12",
+    "Description": "Russia lineage, contains some formally B.1.1.167 sequences"
+  },
+  {
+    "Lineage": "B.1.1.425",
+    "Earliest date": "2020-08-25",
+    "Latest date": "2020-11-12",
+    "Description": "England and Denmark"
+  },
+  {
+    "Lineage": "B.1.1.426",
+    "Earliest date": "2020-06-13",
+    "Latest date": "2020-12-02",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.1.1.427",
+    "Earliest date": "2020-07-25",
+    "Latest date": "2020-09-28",
+    "Description": "Russian Lineage"
+  },
+  {
+    "Lineage": "B.1.1.428",
+    "Earliest date": "2020-10-26",
+    "Latest date": "2021-04-13",
+    "Description": "Switzerland and North Macedonia"
+  },
+  {
+    "Lineage": "B.1.1.429",
+    "Earliest date": "2020-09-15",
+    "Latest date": "2021-07-06",
+    "Description": "Latvia and Finland"
+  },
+  {
+    "Lineage": "B.1.1.430",
+    "Earliest date": "2020-06-03",
+    "Latest date": "2021-01-11",
+    "Description": "North Macedonia"
+  },
+  {
+    "Lineage": "B.1.1.431",
+    "Earliest date": "2020-06-23",
+    "Latest date": "2020-10-20",
+    "Description": "Australia and Canada"
+  },
+  {
+    "Lineage": "B.1.1.432",
+    "Earliest date": "2020-04-24",
+    "Latest date": "2021-05-08",
+    "Description": "USA and Mexico"
+  },
+  {
+    "Lineage": "B.1.1.433",
+    "Earliest date": "2020-08-10",
+    "Latest date": "2021-03-15",
+    "Description": "Denmark and Switzerland, some B.1.1.281"
+  },
+  {
+    "Lineage": "B.1.1.434",
+    "Earliest date": "2020-06-24",
+    "Latest date": "2021-06-22",
+    "Description": "Mostly USA lineage with some UK and Canada (was B.1.1.304)"
+  },
+  {
+    "Lineage": "B.1.1.435",
+    "Earliest date": "2020-09-26",
+    "Latest date": "2021-04-16",
+    "Description": "Russian"
+  },
+  {
+    "Lineage": "B.1.1.436",
+    "Earliest date": "2020-03-23",
+    "Latest date": "2020-05-02",
+    "Description": "Belgium lineage"
+  },
+  {
+    "Lineage": "B.1.1.437",
+    "Earliest date": "2020-06-08",
+    "Latest date": "2021-07-17",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.1.1.438",
+    "Earliest date": "2020-03-12",
+    "Latest date": "2021-02-15",
+    "Description": "Swedish lineage"
+  },
+  {
+    "Lineage": "B.1.1.440",
+    "Earliest date": "2020-05-09",
+    "Latest date": "2021-03-12",
+    "Description": "USA and Mexico"
+  },
+  {
+    "Lineage": "B.1.1.441",
+    "Earliest date": "2020-06-26",
+    "Latest date": "2020-11-06",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.1.1.442",
+    "Earliest date": "2020-05-16",
+    "Latest date": "2021-04-13",
+    "Description": "Argentinian"
+  },
+  {
+    "Lineage": "B.1.1.444",
+    "Earliest date": "2020-07-27",
+    "Latest date": "2020-10-18",
+    "Description": "South African (was B.1.1.117)"
+  },
+  {
+    "Lineage": "B.1.1.445",
+    "Earliest date": "2020-12-14",
+    "Latest date": "2021-01-15",
+    "Description": "Switzerland lineage"
+  },
+  {
+    "Lineage": "B.1.1.446",
+    "Earliest date": "2020-10-16",
+    "Latest date": "2020-12-25",
+    "Description": "Sweden lineage"
+  },
+  {
+    "Lineage": "B.1.1.447",
+    "Earliest date": "2020-05-05",
+    "Latest date": "2020-09-02",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.1.1.448",
+    "Earliest date": "2020-05-01",
+    "Latest date": "2021-07-30",
+    "Description": "South African (was B.1.1.54)"
+  },
+  {
+    "Lineage": "B.1.1.449",
+    "Earliest date": "2020-09-04",
+    "Latest date": "2021-02-04",
+    "Description": "Russia lineage"
+  },
+  {
+    "Lineage": "B.1.1.450",
+    "Earliest date": "2020-11-20",
+    "Latest date": "2020-12-09",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.1.1.451",
+    "Earliest date": "2020-10-10",
+    "Latest date": "2021-01-05",
+    "Description": "Norway lineage"
+  },
+  {
+    "Lineage": "B.1.1.452",
+    "Earliest date": "2020-09-10",
+    "Latest date": "2020-11-25",
+    "Description": "Russia lineage"
+  },
+  {
+    "Lineage": "B.1.1.453",
+    "Earliest date": "2020-08-05",
+    "Latest date": "2021-05-17",
+    "Description": "US"
+  },
+  {
+    "Lineage": "B.1.1.456",
+    "Earliest date": "2020-06-18",
+    "Latest date": "2020-11-26",
+    "Description": "South African"
+  },
+  {
+    "Lineage": "B.1.1.458",
+    "Earliest date": "2020-05-14",
+    "Latest date": "2021-02-23",
+    "Description": "Swedish lineage"
+  },
+  {
+    "Lineage": "B.1.1.459",
+    "Earliest date": "2020-04-04",
+    "Latest date": "2021-02-03",
+    "Description": "South African lineage (some were part of Belgian lineage B.1.1.75"
+  },
+  {
+    "Lineage": "B.1.1.461",
+    "Earliest date": "2020-09-18",
+    "Latest date": "2021-03-18",
+    "Description": "USA TX lineage"
+  },
+  {
+    "Lineage": "B.1.1.462",
+    "Earliest date": "2020-03-25",
+    "Latest date": "2021-01-31",
+    "Description": "United Arab Emirates"
+  },
+  {
+    "Lineage": "B.1.1.463",
+    "Earliest date": "2020-05-11",
+    "Latest date": "2020-11-02",
+    "Description": "USA CA lineage"
+  },
+  {
+    "Lineage": "B.1.1.464",
+    "Earliest date": "2020-04-01",
+    "Latest date": "2021-07-07",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "AW.1",
+    "Earliest date": "2020-10-12",
+    "Latest date": "2021-03-12",
+    "Description": "Alias of B.1.1.464.1, Canadian lineage, from #103"
+  },
+  {
+    "Lineage": "B.1.1.465",
+    "Earliest date": "2020-04-21",
+    "Latest date": "2020-04-24",
+    "Description": "Japanese lineage"
+  },
+  {
+    "Lineage": "B.1.1.466",
+    "Earliest date": "2020-06-04",
+    "Latest date": "2020-08-18",
+    "Description": "Gambian lineage"
+  },
+  {
+    "Lineage": "B.1.1.467",
+    "Earliest date": "2020-10-08",
+    "Latest date": "2021-03-09",
+    "Description": "USA lineage (NY)"
+  },
+  {
+    "Lineage": "B.1.1.480",
+    "Earliest date": "2020-04-13",
+    "Latest date": "2021-04-07",
+    "Description": "USA Lineage"
+  },
+  {
+    "Lineage": "B.1.1.481",
+    "Earliest date": "2020-08-11",
+    "Latest date": "2020-10-07",
+    "Description": "Russian Lineage"
+  },
+  {
+    "Lineage": "B.1.1.482",
+    "Earliest date": "2020-03-02",
+    "Latest date": "2020-11-04",
+    "Description": "USA Lineage"
+  },
+  {
+    "Lineage": "AV.1",
+    "Earliest date": "2020-05-12",
+    "Latest date": "2021-07-05",
+    "Description": "Alias of B.1.1.482.1, UK and France lineage with several VOC/VUI-like mutations, from #73"
+  },
+  {
+    "Lineage": "B.1.1.483",
+    "Earliest date": "2020-12-06",
+    "Latest date": "2021-01-05",
+    "Description": "Belgian lineage"
+  },
+  {
+    "Lineage": "B.1.1.484",
+    "Earliest date": "2020-05-31",
+    "Latest date": "2020-07-01",
+    "Description": "Nigerian Lineage"
+  },
+  {
+    "Lineage": "B.1.1.485",
+    "Earliest date": "2020-04-01",
+    "Latest date": "2021-02-19",
+    "Description": "Ghanaian Lineage"
+  },
+  {
+    "Lineage": "B.1.1.486",
+    "Earliest date": "2020-08-13",
+    "Latest date": "2022-04-20",
+    "Description": "USA Lineage"
+  },
+  {
+    "Lineage": "B.1.1.487",
+    "Earliest date": "2020-03-22",
+    "Latest date": "2021-04-29",
+    "Description": "UK and Nigerian Lineage"
+  },
+  {
+    "Lineage": "B.1.1.500",
+    "Earliest date": "2020-04-10",
+    "Latest date": "2021-02-06",
+    "Description": "UAE lineage"
+  },
+  {
+    "Lineage": "B.1.1.506",
+    "Earliest date": "2020-05-14",
+    "Latest date": "2021-03-16",
+    "Description": "Mainly Russian"
+  },
+  {
+    "Lineage": "B.1.1.507",
+    "Earliest date": "2020-09-07",
+    "Latest date": "2021-10-18",
+    "Description": "South African Lineage (was B.1.1.254)"
+  },
+  {
+    "Lineage": "B.1.1.512",
+    "Earliest date": "2020-07-21",
+    "Latest date": "2021-01-31",
+    "Description": "USA/Mexico"
+  },
+  {
+    "Lineage": "B.1.1.513",
+    "Earliest date": "2020-03-16",
+    "Latest date": "2020-07-06",
+    "Description": "USA lineage (NY)"
+  },
+  {
+    "Lineage": "B.1.1.514",
+    "Earliest date": "2020-04-12",
+    "Latest date": "2021-06-29",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.1.1.515",
+    "Earliest date": "2020-03-16",
+    "Latest date": "2020-10-07",
+    "Description": "German lineage"
+  },
+  {
+    "Lineage": "B.1.1.516",
+    "Earliest date": "2020-04-14",
+    "Latest date": "2021-02-15",
+    "Description": "Costa Rica lineage"
+  },
+  {
+    "Lineage": "B.1.1.517",
+    "Earliest date": "2020-11-16",
+    "Latest date": "2021-04-23",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.1.1.518",
+    "Earliest date": "2020-05-23",
+    "Latest date": "2021-05-26",
+    "Description": "USA/ Mexico lineage"
+  },
+  {
+    "Lineage": "B.1.1.519",
+    "Earliest date": "2020-07-26",
+    "Latest date": "2022-09-27",
+    "Description": "USA/ Mexico lineage, from #111"
+  },
+  {
+    "Lineage": "B.1.1.521",
+    "Earliest date": "2020-05-15",
+    "Latest date": "2021-10-23",
+    "Description": "European lineage"
+  },
+  {
+    "Lineage": "B.1.1.522",
+    "Earliest date": "2021-02-08",
+    "Latest date": "2021-04-28",
+    "Description": "Belgium lineage"
+  },
+  {
+    "Lineage": "B.1.1.523",
+    "Earliest date": "2021-01-02",
+    "Latest date": "2022-03-23",
+    "Description": "Lineage in multiple countries, predominantly Russia, from #69"
+  },
+  {
+    "Lineage": "B.1.1.524",
+    "Earliest date": "2020-11-14",
+    "Latest date": "2021-06-04",
+    "Description": "Predominantly Russia lineage, from #85"
+  },
+  {
+    "Lineage": "B.1.1.525",
+    "Earliest date": "2021-01-05",
+    "Latest date": "2021-08-05",
+    "Description": "Predominantly Russia lineage, from #85"
+  },
+  {
+    "Lineage": "B.1.1.526",
+    "Earliest date": "2020-10-21",
+    "Latest date": "2021-09-23",
+    "Description": "India lineage, previously designated B.1.624, from #91"
+  },
+  {
+    "Lineage": "B.1.1.528",
+    "Earliest date": "2020-12-07",
+    "Latest date": "2022-07-05",
+    "Description": "South Africa lineage, from #177"
+  },
+  {
+    "Lineage": "B.1.1.529",
+    "Earliest date": "2020-04-14",
+    "Latest date": "2024-03-08",
+    "Description": "South Africa and Botswana lineage, from #343"
+  },
+  {
+    "Lineage": "BA.1",
+    "Earliest date": "2020-06-25",
+    "Latest date": "2024-01-20",
+    "Description": "Alias of B.1.1.529.1, from #361"
+  },
+  {
+    "Lineage": "BA.1.1",
+    "Earliest date": "2020-01-27",
+    "Latest date": "2024-07-14",
+    "Description": "Alias of B.1.1.529.1.1, from #360"
+  },
+  {
+    "Lineage": "BA.1.1.1",
+    "Earliest date": "2020-10-29",
+    "Latest date": "2024-03-07",
+    "Description": "Alias of B.1.1.529.1.1.1, European lineage"
+  },
+  {
+    "Lineage": "BC.1",
+    "Earliest date": "2021-01-13",
+    "Latest date": "2022-08-05",
+    "Description": "Alias of B.1.1.529.1.1.1.1, Japan lineage"
+  },
+  {
+    "Lineage": "BC.2",
+    "Earliest date": "2021-12-16",
+    "Latest date": "2022-07-04",
+    "Description": "Alias of B.1.1.529.1.1.1.2, Peru lineage, from #570"
+  },
+  {
+    "Lineage": "BA.1.1.2",
+    "Earliest date": "2021-01-06",
+    "Latest date": "2023-04-13",
+    "Description": "Alias of B.1.1.529.1.1.2, Japan lineage"
+  },
+  {
+    "Lineage": "BA.1.1.3",
+    "Earliest date": "2021-05-03",
+    "Latest date": "2022-03-28",
+    "Description": "Alias of B.1.1.529.1.1.3, Switzerland lineage"
+  },
+  {
+    "Lineage": "BA.1.1.4",
+    "Earliest date": "2021-12-04",
+    "Latest date": "2022-08-10",
+    "Description": "Alias of B.1.1.529.1.1.4, UK lineage"
+  },
+  {
+    "Lineage": "BA.1.1.5",
+    "Earliest date": "2021-12-12",
+    "Latest date": "2022-04-20",
+    "Description": "Alias of B.1.1.529.1.1.5, South Korea lineage"
+  },
+  {
+    "Lineage": "BA.1.1.6",
+    "Earliest date": "2021-12-05",
+    "Latest date": "2022-07-11",
+    "Description": "Alias of B.1.1.529.1.1.6, Canada lineage"
+  },
+  {
+    "Lineage": "BA.1.1.7",
+    "Earliest date": "2021-07-16",
+    "Latest date": "2022-07-28",
+    "Description": "Alias of B.1.1.529.1.1.7, lineage in India and other countries"
+  },
+  {
+    "Lineage": "BA.1.1.8",
+    "Earliest date": "2021-11-26",
+    "Latest date": "2022-03-29",
+    "Description": "Alias of B.1.1.529.1.1.8, USA lineage"
+  },
+  {
+    "Lineage": "BA.1.1.9",
+    "Earliest date": "2021-12-28",
+    "Latest date": "2023-03-19",
+    "Description": "Alias of B.1.1.529.1.1.9, New Zealand lineage"
+  },
+  {
+    "Lineage": "BA.1.1.10",
+    "Earliest date": "2021-07-08",
+    "Latest date": "2022-07-18",
+    "Description": "Alias of B.1.1.529.1.1.10, Canada lineage"
+  },
+  {
+    "Lineage": "BA.1.1.11",
+    "Earliest date": "2021-01-01",
+    "Latest date": "2022-07-08",
+    "Description": "Alias of B.1.1.529.1.1.11, European lineage"
+  },
+  {
+    "Lineage": "BA.1.1.12",
+    "Earliest date": "2021-12-06",
+    "Latest date": "2022-05-28",
+    "Description": "Alias of B.1.1.529.1.1.12, UK lineage"
+  },
+  {
+    "Lineage": "BA.1.1.13",
+    "Earliest date": "2021-01-01",
+    "Latest date": "2022-06-19",
+    "Description": "Alias of B.1.1.529.1.1.13, UK lineage"
+  },
+  {
+    "Lineage": "BA.1.1.14",
+    "Earliest date": "2020-12-10",
+    "Latest date": "2023-06-25",
+    "Description": "Alias of B.1.1.529.1.1.14, European lineage"
+  },
+  {
+    "Lineage": "BA.1.1.15",
+    "Earliest date": "2021-04-29",
+    "Latest date": "2022-11-29",
+    "Description": "Alias of B.1.1.529.1.1.15, Europe and Australia lineage"
+  },
+  {
+    "Lineage": "BA.1.1.16",
+    "Earliest date": "2021-11-18",
+    "Latest date": "2023-10-16",
+    "Description": "Alias of B.1.1.529.1.1.16, Canada and USA lineage"
+  },
+  {
+    "Lineage": "BA.1.1.17",
+    "Earliest date": "2021-01-12",
+    "Latest date": "2022-05-16",
+    "Description": "Alias of B.1.1.529.1.1.17, USA lineage, from #452"
+  },
+  {
+    "Lineage": "BA.1.1.18",
+    "Earliest date": "2020-08-27",
+    "Latest date": "2024-02-13",
+    "Description": "Alias of B.1.1.529.1.1.18, USA lineage"
+  },
+  {
+    "Lineage": "BA.1.2",
+    "Earliest date": "2021-12-14",
+    "Latest date": "2022-03-04",
+    "Description": "Alias of B.1.1.529.1.2, Mayotte and Reunion lineage"
+  },
+  {
+    "Lineage": "BA.1.3",
+    "Earliest date": "2021-12-02",
+    "Latest date": "2022-04-28",
+    "Description": "Alias of B.1.1.529.1.3, Canada lineage"
+  },
+  {
+    "Lineage": "BA.1.4",
+    "Earliest date": "2021-11-26",
+    "Latest date": "2022-06-05",
+    "Description": "Alias of B.1.1.529.1.4, France lineage"
+  },
+  {
+    "Lineage": "BA.1.5",
+    "Earliest date": "2021-01-13",
+    "Latest date": "2022-08-02",
+    "Description": "Alias of B.1.1.529.1.5, UK lineage"
+  },
+  {
+    "Lineage": "BA.1.6",
+    "Earliest date": "2021-12-01",
+    "Latest date": "2022-05-02",
+    "Description": "Alias of B.1.1.529.1.6, Canada and Sint Maarten lineage"
+  },
+  {
+    "Lineage": "BA.1.7",
+    "Earliest date": "2021-12-01",
+    "Latest date": "2022-03-19",
+    "Description": "Alias of B.1.1.529.1.7, UK lineage"
+  },
+  {
+    "Lineage": "BA.1.8",
+    "Earliest date": "2021-07-16",
+    "Latest date": "2022-05-18",
+    "Description": "Alias of B.1.1.529.1.8, European lineage"
+  },
+  {
+    "Lineage": "BA.1.9",
+    "Earliest date": "2021-12-09",
+    "Latest date": "2022-05-16",
+    "Description": "Alias of B.1.1.529.1.9, Brazil lineage"
+  },
+  {
+    "Lineage": "BA.1.10",
+    "Earliest date": "2021-11-24",
+    "Latest date": "2022-05-31",
+    "Description": "Alias of B.1.1.529.1.10, UK lineage"
+  },
+  {
+    "Lineage": "BA.1.12",
+    "Earliest date": "2021-11-22",
+    "Latest date": "2022-05-04",
+    "Description": "Alias of B.1.1.529.1.12, UK lineage"
+  },
+  {
+    "Lineage": "BA.1.13",
+    "Earliest date": "2021-08-31",
+    "Latest date": "2022-10-04",
+    "Description": "Alias of B.1.1.529.1.13, European lineage"
+  },
+  {
+    "Lineage": "BA.1.13.1",
+    "Earliest date": "2021-12-12",
+    "Latest date": "2022-12-02",
+    "Description": "Alias of B.1.1.529.1.13.1, Indonesia lineage"
+  },
+  {
+    "Lineage": "BA.1.14",
+    "Earliest date": "2021-01-10",
+    "Latest date": "2023-01-13",
+    "Description": "Alias of B.1.1.529.1.14, lineage in Brazil and other countries"
+  },
+  {
+    "Lineage": "BA.1.14.1",
+    "Earliest date": "2021-11-17",
+    "Latest date": "2023-07-15",
+    "Description": "Alias of B.1.1.529.1.14.1, Brazil lineage, from #506"
+  },
+  {
+    "Lineage": "BA.1.14.2",
+    "Earliest date": "2021-11-08",
+    "Latest date": "2022-08-02",
+    "Description": "Alias of B.1.1.529.1.14.2, Brazil lineage"
+  },
+  {
+    "Lineage": "BA.1.15",
+    "Earliest date": "2020-11-10",
+    "Latest date": "2024-01-17",
+    "Description": "Alias of B.1.1.529.1.15, lineage in USA and other countries"
+  },
+  {
+    "Lineage": "BA.1.15.1",
+    "Earliest date": "2021-01-01",
+    "Latest date": "2022-09-02",
+    "Description": "Alias of B.1.1.529.1.15.1, UK lineage"
+  },
+  {
+    "Lineage": "BA.1.15.2",
+    "Earliest date": "2021-12-12",
+    "Latest date": "2022-05-15",
+    "Description": "Alias of B.1.1.529.1.15.2, USA lineage, from #508"
+  },
+  {
+    "Lineage": "BA.1.15.3",
+    "Earliest date": "2021-11-28",
+    "Latest date": "2022-05-21",
+    "Description": "Alias of B.1.1.529.1.15.3, Peru lineage, from #573"
+  },
+  {
+    "Lineage": "BA.1.16",
+    "Earliest date": "2021-01-01",
+    "Latest date": "2022-07-27",
+    "Description": "Alias of B.1.1.529.1.16, UK lineage"
+  },
+  {
+    "Lineage": "BA.1.16.1",
+    "Earliest date": "2022-01-03",
+    "Latest date": "2022-04-06",
+    "Description": "Alias of B.1.1.529.1.16.1, Thailand, Cambodia and Indonesia lineage"
+  },
+  {
+    "Lineage": "BA.1.16.2",
+    "Earliest date": "2021-12-22",
+    "Latest date": "2022-03-20",
+    "Description": "Alias of B.1.1.529.1.16.2, Greece lineage"
+  },
+  {
+    "Lineage": "BA.1.17",
+    "Earliest date": "2020-11-06",
+    "Latest date": "2023-08-30",
+    "Description": "Alias of B.1.1.529.1.17, European lineage"
+  },
+  {
+    "Lineage": "BA.1.17.1",
+    "Earliest date": "2021-12-18",
+    "Latest date": "2022-04-26",
+    "Description": "Alias of B.1.1.529.1.17.1, Australia lineage"
+  },
+  {
+    "Lineage": "BA.1.17.2",
+    "Earliest date": "2020-10-23",
+    "Latest date": "2023-10-01",
+    "Description": "Alias of B.1.1.529.1.17.2, from #462"
+  },
+  {
+    "Lineage": "BD.1",
+    "Earliest date": "2021-03-02",
+    "Latest date": "2022-10-27",
+    "Description": "Alias of B.1.1.529.1.17.2.1, UK lineage, from #461"
+  },
+  {
+    "Lineage": "BA.1.18",
+    "Earliest date": "2020-11-13",
+    "Latest date": "2023-08-07",
+    "Description": "Alias of B.1.1.529.1.18, Europe and North America lineage, from #474"
+  },
+  {
+    "Lineage": "BA.1.19",
+    "Earliest date": "2020-06-01",
+    "Latest date": "2022-05-30",
+    "Description": "Alias of B.1.1.529.1.19, Europe lineage, from #475"
+  },
+  {
+    "Lineage": "BA.1.20",
+    "Earliest date": "2021-01-03",
+    "Latest date": "2023-03-16",
+    "Description": "Alias of B.1.1.529.1.20, USA lineage, from #375"
+  },
+  {
+    "Lineage": "BA.1.21",
+    "Earliest date": "2021-01-09",
+    "Latest date": "2023-05-15",
+    "Description": "Alias of B.1.1.529.1.21, lineage, from #505"
+  },
+  {
+    "Lineage": "BA.1.21.1",
+    "Earliest date": "2021-01-03",
+    "Latest date": "2022-06-28",
+    "Description": "Alias of B.1.1.529.1.21.1, Italy lineage, from #409"
+  },
+  {
+    "Lineage": "BA.1.22",
+    "Earliest date": "2021-12-29",
+    "Latest date": "2022-03-16",
+    "Description": "Alias of B.1.1.529.1.22, Peru lineage, from #529"
+  },
+  {
+    "Lineage": "BA.1.23",
+    "Earliest date": "2022-02-06",
+    "Latest date": "2022-08-17",
+    "Description": "Alias of B.1.1.529.1.23, mainly found in USA, from #663"
+  },
+  {
+    "Lineage": "BA.1.24",
+    "Earliest date": "2022-01-28",
+    "Latest date": "2022-07-25",
+    "Description": "Alias of B.1.1.529.1.24, found in Spain, from #666"
+  },
+  {
+    "Lineage": "BA.2",
+    "Earliest date": "2020-03-28",
+    "Latest date": "2024-08-26",
+    "Description": "Alias of B.1.1.529.2, from #361"
+  },
+  {
+    "Lineage": "BA.2.1",
+    "Earliest date": "2021-12-08",
+    "Latest date": "2023-07-05",
+    "Description": "Alias of B.1.1.529.2.1, UK lineage"
+  },
+  {
+    "Lineage": "BA.2.2",
+    "Earliest date": "2021-12-06",
+    "Latest date": "2023-02-02",
+    "Description": "Alias of B.1.1.529.2.2, Hong Kong lineage, from #430"
+  },
+  {
+    "Lineage": "BA.2.2.1",
+    "Earliest date": "2021-12-06",
+    "Latest date": "2023-04-20",
+    "Description": "Alias of B.1.1.529.2.2.1, China lineage, from #675"
+  },
+  {
+    "Lineage": "BA.2.3",
+    "Earliest date": "2020-06-15",
+    "Latest date": "2023-12-11",
+    "Description": "Alias of B.1.1.529.2.3, lineage in Philippines and other countries"
+  },
+  {
+    "Lineage": "BA.2.3.1",
+    "Earliest date": "2022-01-10",
+    "Latest date": "2023-05-25",
+    "Description": "Alias of B.1.1.529.2.3.1, Japan lineage, from #495"
+  },
+  {
+    "Lineage": "BA.2.3.2",
+    "Earliest date": "2022-01-22",
+    "Latest date": "2023-12-20",
+    "Description": "Alias of B.1.1.529.2.3.2, Vietnam and Japan lineage"
+  },
+  {
+    "Lineage": "BS.1",
+    "Earliest date": "2022-08-17",
+    "Latest date": "2022-12-09",
+    "Description": "Alias of B.1.1.529.2.3.2.1, Vietnam lineage, from #1052"
+  },
+  {
+    "Lineage": "BS.1.1",
+    "Earliest date": "2022-08-20",
+    "Latest date": "2023-05-09",
+    "Description": "Alias of B.1.1.529.2.3.2.1.1, Vietnam lineage, defined by S:K356T, from #1097"
+  },
+  {
+    "Lineage": "BS.1.2",
+    "Earliest date": "2022-09-17",
+    "Latest date": "2022-10-17",
+    "Description": "Alias of B.1.1.529.2.3.2.1.2, Vietnam lineage, defined by S:T430I"
+  },
+  {
+    "Lineage": "BA.2.3.4",
+    "Earliest date": "2022-01-24",
+    "Latest date": "2022-07-14",
+    "Description": "Alias of B.1.1.529.2.3.4, Canada lineage"
+  },
+  {
+    "Lineage": "BA.2.3.5",
+    "Earliest date": "2020-11-13",
+    "Latest date": "2023-06-02",
+    "Description": "Alias of B.1.1.529.2.3.5, mainly found in USA, England and Spain, from #627"
+  },
+  {
+    "Lineage": "BA.2.3.6",
+    "Earliest date": "2022-01-13",
+    "Latest date": "2022-08-12",
+    "Description": "Alias of B.1.1.529.2.3.6, mainly found in Canada and USA, from #633"
+  },
+  {
+    "Lineage": "BA.2.3.7",
+    "Earliest date": "2022-01-10",
+    "Latest date": "2023-03-06",
+    "Description": "Alias of B.1.1.529.2.3.7, mainly found in Japan, Hong Kong and Taiwan, from #643"
+  },
+  {
+    "Lineage": "BA.2.3.8",
+    "Earliest date": "2022-01-23",
+    "Latest date": "2022-08-19",
+    "Description": "Alias of B.1.1.529.2.3.8, South Korea lineage"
+  },
+  {
+    "Lineage": "BA.2.3.9",
+    "Earliest date": "2022-01-22",
+    "Latest date": "2023-01-27",
+    "Description": "Alias of B.1.1.529.2.3.9, lineage in Netherlands and other countries"
+  },
+  {
+    "Lineage": "BA.2.3.10",
+    "Earliest date": "2022-02-17",
+    "Latest date": "2023-01-06",
+    "Description": "Alias of B.1.1.529.2.3.10, Canada and USA lineage"
+  },
+  {
+    "Lineage": "BA.2.3.11",
+    "Earliest date": "2022-01-01",
+    "Latest date": "2023-04-12",
+    "Description": "Alias of B.1.1.529.2.3.11, Japan lineage, from #605"
+  },
+  {
+    "Lineage": "BA.2.3.12",
+    "Earliest date": "2022-02-08",
+    "Latest date": "2022-08-26",
+    "Description": "Alias of B.1.1.529.2.3.12, South Korea lineage"
+  },
+  {
+    "Lineage": "BA.2.3.13",
+    "Earliest date": "2022-01-05",
+    "Latest date": "2022-09-02",
+    "Description": "Alias of B.1.1.529.2.3.13, Japan lineage"
+  },
+  {
+    "Lineage": "BA.2.3.14",
+    "Earliest date": "2022-02-11",
+    "Latest date": "2022-08-19",
+    "Description": "Alias of B.1.1.529.2.3.14, South Korea lineage"
+  },
+  {
+    "Lineage": "BA.2.3.15",
+    "Earliest date": "2022-01-03",
+    "Latest date": "2022-11-08",
+    "Description": "Alias of B.1.1.529.2.3.15, Italy and Spain lineage"
+  },
+  {
+    "Lineage": "BA.2.3.16",
+    "Earliest date": "2022-01-07",
+    "Latest date": "2022-09-27",
+    "Description": "Alias of B.1.1.529.2.3.16, Papua New Guinea lineage, from #524"
+  },
+  {
+    "Lineage": "BP.1",
+    "Earliest date": "2022-07-22",
+    "Latest date": "2022-09-27",
+    "Description": "Alias of B.1.1.529.2.3.16.1, Oceania/South East Asia lineage, from #1009"
+  },
+  {
+    "Lineage": "BA.2.3.17",
+    "Earliest date": "2022-01-11",
+    "Latest date": "2022-07-19",
+    "Description": "Alias of B.1.1.529.2.3.17, Northern Mariana Islands and USA lineage, from #677"
+  },
+  {
+    "Lineage": "BA.2.3.18",
+    "Earliest date": "2022-01-19",
+    "Latest date": "2022-08-19",
+    "Description": "Alias of B.1.1.529.2.3.18, Japan lineage, from #687"
+  },
+  {
+    "Lineage": "BA.2.3.19",
+    "Earliest date": "2022-04-16",
+    "Latest date": "2022-07-05",
+    "Description": "Alias of B.1.1.529.2.3.19, found Brunei, from #824"
+  },
+  {
+    "Lineage": "BA.2.3.20",
+    "Earliest date": "2022-07-26",
+    "Latest date": "2023-05-23",
+    "Description": "Alias of B.1.1.529.2.3.20, found globally, unclear origin, from #1013"
+  },
+  {
+    "Lineage": "CM.1",
+    "Earliest date": "2022-08-23",
+    "Latest date": "2023-04-03",
+    "Description": "Alias of B.1.1.529.2.3.20.1, S:N17S, from #1129"
+  },
+  {
+    "Lineage": "CM.2",
+    "Earliest date": "2022-08-26",
+    "Latest date": "2023-03-13",
+    "Description": "Alias of B.1.1.529.2.3.20.2, international, ORF1a:S2103F"
+  },
+  {
+    "Lineage": "CM.2.1",
+    "Earliest date": "2022-10-30",
+    "Latest date": "2023-06-06",
+    "Description": "Alias of B.1.1.529.2.3.20.2.1, Indonesia/Australia, S:F486S, from #1356"
+  },
+  {
+    "Lineage": "CM.3",
+    "Earliest date": "2022-09-10",
+    "Latest date": "2023-02-26",
+    "Description": "Alias of B.1.1.529.2.3.20.3, USA/South Korea/Australia, S:G485D"
+  },
+  {
+    "Lineage": "CM.4",
+    "Earliest date": "2022-09-04",
+    "Latest date": "2023-03-27",
+    "Description": "Alias of B.1.1.529.2.3.20.4, USA/Singapore/SouthKorea, ORF1b:D146G"
+  },
+  {
+    "Lineage": "CM.4.1",
+    "Earliest date": "2022-09-25",
+    "Latest date": "2023-06-23",
+    "Description": "Alias of B.1.1.529.2.3.20.4.1, S:K478R, Philippines/Japan/USA"
+  },
+  {
+    "Lineage": "CM.5",
+    "Earliest date": "2022-01-10",
+    "Latest date": "2023-04-06",
+    "Description": "Alias of B.1.1.529.2.3.20.5, global, 10802T"
+  },
+  {
+    "Lineage": "CM.5.1",
+    "Earliest date": "2022-09-10",
+    "Latest date": "2023-02-23",
+    "Description": "Alias of B.1.1.529.2.3.20.5.1, S:Q675R"
+  },
+  {
+    "Lineage": "CM.5.2",
+    "Earliest date": "2022-10-14",
+    "Latest date": "2023-03-04",
+    "Description": "Alias of B.1.1.529.2.3.20.5.2, S:G485D, USA/Australia, from #1386"
+  },
+  {
+    "Lineage": "CM.6",
+    "Earliest date": "2022-08-28",
+    "Latest date": "2022-11-26",
+    "Description": "Alias of B.1.1.529.2.3.20.6, global, ORF1a:G30A"
+  },
+  {
+    "Lineage": "CM.6.1",
+    "Earliest date": "2022-09-23",
+    "Latest date": "2023-02-22",
+    "Description": "Alias of B.1.1.529.2.3.20.6.1, S:A348S, from #1165"
+  },
+  {
+    "Lineage": "CM.7",
+    "Earliest date": "2022-10-11",
+    "Latest date": "2023-03-15",
+    "Description": "Alias of B.1.1.529.2.3.20.7, Japan/Singapore, S:F486S"
+  },
+  {
+    "Lineage": "CM.7.1",
+    "Earliest date": "2022-10-23",
+    "Latest date": "2023-02-17",
+    "Description": "Alias of B.1.1.529.2.3.20.7.1, S:K147E, Europe, from sars-cov-2-variants/lineage-proposals#37"
+  },
+  {
+    "Lineage": "CM.7.1.1",
+    "Earliest date": "2023-03-22",
+    "Latest date": "2024-03-27",
+    "Description": "Alias of B.1.1.529.2.3.20.7.1, S:R403K, Europe, from sars-cov-2-variants/lineage-proposals#37"
+  },
+  {
+    "Lineage": "CM.8",
+    "Earliest date": "2022-09-14",
+    "Latest date": "2023-03-13",
+    "Description": "Alias of B.1.1.529.2.3.20.8, S:G446S"
+  },
+  {
+    "Lineage": "CM.8.1",
+    "Earliest date": "2022-10-16",
+    "Latest date": "2023-11-24",
+    "Description": "Alias of B.1.1.529.2.3.20.8.1, Australia/England, S:F486S"
+  },
+  {
+    "Lineage": "CM.8.1.1",
+    "Earliest date": "2022-12-12",
+    "Latest date": "2023-06-19",
+    "Description": "Alias of B.1.1.529.2.3.20.8.1.1, Singapore/Malaysia, S:K147N"
+  },
+  {
+    "Lineage": "FV.1",
+    "Earliest date": "2023-01-29",
+    "Latest date": "2023-10-18",
+    "Description": "Alias of B.1.1.529.2.3.20.8.1.1.1, S:R346T, M:E11Q, Singapore/SouthKorea/Japan/Philippines/HK"
+  },
+  {
+    "Lineage": "CM.8.1.2",
+    "Earliest date": "2022-12-15",
+    "Latest date": "2023-07-21",
+    "Description": "Alias of B.1.1.529.2.3.20.8.1.2, Germany/USA, S:K147I"
+  },
+  {
+    "Lineage": "CM.8.1.3",
+    "Earliest date": "2022-01-04",
+    "Latest date": "2023-02-02",
+    "Description": "Alias of B.1.1.529.2.3.20.8.1.3, USA, S:Y1272H"
+  },
+  {
+    "Lineage": "CM.8.1.4",
+    "Earliest date": "2022-10-26",
+    "Latest date": "2023-04-20",
+    "Description": "Alias of B.1.1.529.2.3.20.8.1.4, ORF1b:N1790D, Philippines, from #1554"
+  },
+  {
+    "Lineage": "CM.8.1.5",
+    "Earliest date": "2023-01-10",
+    "Latest date": "2023-05-24",
+    "Description": "Alias of B.1.1.529.2.3.20.8.1.5, S:K150E, S:Y248H, N:A155V, Philippines, from sars-cov-2-variants/lineage-proposals#293"
+  },
+  {
+    "Lineage": "CM.9",
+    "Earliest date": "2022-10-08",
+    "Latest date": "2022-12-30",
+    "Description": "Alias of B.1.1.529.2.3.20.9, USA/Canada/Israel, S:S256L"
+  },
+  {
+    "Lineage": "CM.10",
+    "Earliest date": "2022-11-01",
+    "Latest date": "2023-06-16",
+    "Description": "Alias of B.1.1.529.2.3.20.10, USA/South Korea/Singapore, S:K478T reversion, S:V445A"
+  },
+  {
+    "Lineage": "CM.11",
+    "Earliest date": "2022-11-07",
+    "Latest date": "2023-03-18",
+    "Description": "Alias of B.1.1.529.2.3.20.11, USA/South Korea, S:R346T, S:F486S, from #1509"
+  },
+  {
+    "Lineage": "CM.12",
+    "Earliest date": "2022-10-06",
+    "Latest date": "2023-04-25",
+    "Description": "Alias of B.1.1.529.2.3.20.12, Hong Kong, USA, Australia, Japan, ORF8:T12I, from #1481"
+  },
+  {
+    "Lineage": "BA.2.3.21",
+    "Earliest date": "2022-02-16",
+    "Latest date": "2023-05-10",
+    "Description": "Alias of B.1.1.529.2.3.21, Philippines, S:P9L and 493 reversion"
+  },
+  {
+    "Lineage": "DD.1",
+    "Earliest date": "2022-08-11",
+    "Latest date": "2022-10-14",
+    "Description": "Alias of B.1.1.529.2.3.21.1, Philippines/Australia, Δ69-70, Δ144, V213E, G339N, R346T, Y449N, N460K, N481K, Q493L, K1205N, from #1287"
+  },
+  {
+    "Lineage": "BA.2.3.22",
+    "Earliest date": "2022-09-20",
+    "Latest date": "2023-01-27",
+    "Description": "Alias of B.1.1.529.2.3.22, Philippines/Qatar/Germany, Δ69-70, W152L, N211-, L212I, S255F, R346T, K417T, F490A, A942S, from #1462"
+  },
+  {
+    "Lineage": "BA.2.4",
+    "Earliest date": "2021-12-30",
+    "Latest date": "2022-06-22",
+    "Description": "Alias of B.1.1.529.2.4, Singapore lineage"
+  },
+  {
+    "Lineage": "BA.2.5",
+    "Earliest date": "2021-05-03",
+    "Latest date": "2022-12-15",
+    "Description": "Alias of B.1.1.529.2.5, lineage in Portugal and other countries"
+  },
+  {
+    "Lineage": "BA.2.6",
+    "Earliest date": "2021-11-15",
+    "Latest date": "2022-12-17",
+    "Description": "Alias of B.1.1.529.2.6, lineage in France and other countries"
+  },
+  {
+    "Lineage": "BA.2.7",
+    "Earliest date": "2021-11-15",
+    "Latest date": "2022-10-21",
+    "Description": "Alias of B.1.1.529.2.7, USA lineage"
+  },
+  {
+    "Lineage": "BA.2.8",
+    "Earliest date": "2022-02-05",
+    "Latest date": "2022-07-20",
+    "Description": "Alias of B.1.1.529.2.8, UK lineage, from #486"
+  },
+  {
+    "Lineage": "BA.2.9",
+    "Earliest date": "2020-07-21",
+    "Latest date": "2023-10-30",
+    "Description": "Alias of B.1.1.529.2.9, European lineage, from #432"
+  },
+  {
+    "Lineage": "BA.2.9.1",
+    "Earliest date": "2022-02-26",
+    "Latest date": "2022-07-13",
+    "Description": "Alias of B.1.1.529.2.9.1, UK lineage, from #530"
+  },
+  {
+    "Lineage": "BA.2.9.2",
+    "Earliest date": "2021-12-22",
+    "Latest date": "2022-12-17",
+    "Description": "Alias of B.1.1.529.2.9.2, USA lineage"
+  },
+  {
+    "Lineage": "BA.2.9.3",
+    "Earliest date": "2020-07-01",
+    "Latest date": "2024-03-18",
+    "Description": "Alias of B.1.1.529.2.9.3, mainly found in France, England, and Germany, from #630"
+  },
+  {
+    "Lineage": "BA.2.9.4",
+    "Earliest date": "2022-02-25",
+    "Latest date": "2022-08-22",
+    "Description": "Alias of B.1.1.529.2.9.4, mainly found in France, from #635"
+  },
+  {
+    "Lineage": "BA.2.9.5",
+    "Earliest date": "2022-01-12",
+    "Latest date": "2023-12-12",
+    "Description": "Alias of B.1.1.529.2.9.5, Thailand lineage"
+  },
+  {
+    "Lineage": "BA.2.9.6",
+    "Earliest date": "2022-03-16",
+    "Latest date": "2022-08-07",
+    "Description": "Alias of B.1.1.529.2.9.6, mainly found in Spain, Denmark and Germany, from #671"
+  },
+  {
+    "Lineage": "BA.2.9.7",
+    "Earliest date": "2022-04-11",
+    "Latest date": "2022-08-28",
+    "Description": "Alias of B.1.1.529.2.9.7, found mainly in USA, from #864"
+  },
+  {
+    "Lineage": "BA.2.10",
+    "Earliest date": "2020-04-03",
+    "Latest date": "2023-08-31",
+    "Description": "Alias of B.1.1.529.2.10, lineage, from #496"
+  },
+  {
+    "Lineage": "BA.2.10.1",
+    "Earliest date": "2021-07-16",
+    "Latest date": "2024-01-19",
+    "Description": "Alias of B.1.1.529.2.10.1, lineage in Singapore and other countries"
+  },
+  {
+    "Lineage": "BJ.1",
+    "Earliest date": "2022-06-29",
+    "Latest date": "2022-10-31",
+    "Description": "Alias of B.1.1.529.2.10.1.1, mainly found in India (West Bengal), from #915"
+  },
+  {
+    "Lineage": "BA.2.10.2",
+    "Earliest date": "2021-12-30",
+    "Latest date": "2022-08-19",
+    "Description": "Alias of B.1.1.529.2.10.2, mainly found in Japan, from #569"
+  },
+  {
+    "Lineage": "BA.2.10.3",
+    "Earliest date": "2021-12-26",
+    "Latest date": "2022-07-21",
+    "Description": "Alias of B.1.1.529.2.10.3, mainly found in England, India and Bangladesh, from #609"
+  },
+  {
+    "Lineage": "BA.2.10.4",
+    "Earliest date": "2022-06-24",
+    "Latest date": "2022-10-03",
+    "Description": "Alias of B.1.1.529.2.10.4, mainly found in India, from #898"
+  },
+  {
+    "Lineage": "BA.2.11",
+    "Earliest date": "2022-02-24",
+    "Latest date": "2022-08-13",
+    "Description": "Alias of B.1.1.529.2.11, France lineage, from #491"
+  },
+  {
+    "Lineage": "BA.2.12",
+    "Earliest date": "2021-12-06",
+    "Latest date": "2022-12-10",
+    "Description": "Alias of B.1.1.529.2.12, North America and Europe lineage, from #499"
+  },
+  {
+    "Lineage": "BA.2.12.1",
+    "Earliest date": "2020-04-15",
+    "Latest date": "2024-06-05",
+    "Description": "Alias of B.1.1.529.2.12.1, USA and Canada lineage, from #499"
+  },
+  {
+    "Lineage": "BG.1",
+    "Earliest date": "2022-04-15",
+    "Latest date": "2022-08-29",
+    "Description": "Alias of B.1.1.529.2.12.1.1, Peru lineage, from #679"
+  },
+  {
+    "Lineage": "BG.2",
+    "Earliest date": "2022-02-26",
+    "Latest date": "2023-04-05",
+    "Description": "Alias of B.1.1.529.2.12.1.2, mainly found in USA, and Denmark, from #767"
+  },
+  {
+    "Lineage": "BG.3",
+    "Earliest date": "2022-05-03",
+    "Latest date": "2022-08-17",
+    "Description": "Alias of B.1.1.529.2.12.1.3, mainly found in Peru, from #784"
+  },
+  {
+    "Lineage": "BG.4",
+    "Earliest date": "2022-05-01",
+    "Latest date": "2022-12-17",
+    "Description": "Alias of B.1.1.529.2.12.1.4, Israel lineage"
+  },
+  {
+    "Lineage": "BG.5",
+    "Earliest date": "2022-04-09",
+    "Latest date": "2022-09-05",
+    "Description": "Alias of B.1.1.529.2.12.1.5, mainly found in USA, from #763"
+  },
+  {
+    "Lineage": "BG.6",
+    "Earliest date": "2022-05-10",
+    "Latest date": "2022-08-08",
+    "Description": "Alias of B.1.1.529.2.12.1.6, Peru lineage, from #836"
+  },
+  {
+    "Lineage": "BG.7",
+    "Earliest date": "2022-06-22",
+    "Latest date": "2022-08-09",
+    "Description": "Alias of B.1.1.529.2.12.1.7, found in Peru, from #1157"
+  },
+  {
+    "Lineage": "BA.2.12.2",
+    "Earliest date": "2022-02-05",
+    "Latest date": "2022-09-11",
+    "Description": "Alias of B.1.1.529.2.12.2, mainly found in Australia, from #686"
+  },
+  {
+    "Lineage": "BA.2.13",
+    "Earliest date": "2022-01-01",
+    "Latest date": "2023-05-24",
+    "Description": "Alias of B.1.1.529.2.13, Europe lineage, from #531"
+  },
+  {
+    "Lineage": "BA.2.13.1",
+    "Earliest date": "2022-04-09",
+    "Latest date": "2022-10-07",
+    "Description": "Alias of B.1.1.529.2.13.1, mainly found in USA, Canada and Colombia, from #785"
+  },
+  {
+    "Lineage": "BA.2.14",
+    "Earliest date": "2022-01-13",
+    "Latest date": "2023-03-25",
+    "Description": "Alias of B.1.1.529.2.14, Denmark lineage, from #512"
+  },
+  {
+    "Lineage": "BA.2.15",
+    "Earliest date": "2022-01-03",
+    "Latest date": "2022-06-28",
+    "Description": "Alias of B.1.1.529.2.15, South Africa lineage, from #533"
+  },
+  {
+    "Lineage": "BA.2.16",
+    "Earliest date": "2022-01-08",
+    "Latest date": "2022-06-07",
+    "Description": "Alias of B.1.1.529.2.16, UK lineage, from #534"
+  },
+  {
+    "Lineage": "BA.2.17",
+    "Earliest date": "2022-01-20",
+    "Latest date": "2022-08-12",
+    "Description": "Alias of B.1.1.529.2.17, Vietnam and Japan lineage, from #520"
+  },
+  {
+    "Lineage": "BA.2.18",
+    "Earliest date": "2021-11-15",
+    "Latest date": "2022-12-17",
+    "Description": "Alias of B.1.1.529.2.18, UK lineage, from #528"
+  },
+  {
+    "Lineage": "BA.2.19",
+    "Earliest date": "2022-01-17",
+    "Latest date": "2022-06-18",
+    "Description": "Alias of B.1.1.529.2.19, Germany lineage, from #535"
+  },
+  {
+    "Lineage": "BA.2.20",
+    "Earliest date": "2022-01-07",
+    "Latest date": "2022-07-19",
+    "Description": "Alias of B.1.1.529.2.20, Canada lineage, from #544"
+  },
+  {
+    "Lineage": "BA.2.21",
+    "Earliest date": "2022-01-24",
+    "Latest date": "2022-11-16",
+    "Description": "Alias of B.1.1.529.2.21, Canada and USA lineage, from #547"
+  },
+  {
+    "Lineage": "BA.2.22",
+    "Earliest date": "2022-01-30",
+    "Latest date": "2022-07-31",
+    "Description": "Alias of B.1.1.529.2.22, UK lineage, from #562"
+  },
+  {
+    "Lineage": "BA.2.23",
+    "Earliest date": "2020-10-11",
+    "Latest date": "2023-04-02",
+    "Description": "Alias of B.1.1.529.2.23, UK lineage, from #546"
+  },
+  {
+    "Lineage": "BA.2.23.1",
+    "Earliest date": "2022-02-22",
+    "Latest date": "2022-08-08",
+    "Description": "Alias of B.1.1.529.2.23.1, mainly found in England, USA and Denmark, from #532"
+  },
+  {
+    "Lineage": "BA.2.24",
+    "Earliest date": "2022-01-21",
+    "Latest date": "2022-09-15",
+    "Description": "Alias of B.1.1.529.2.24, Japan lineage, from #600"
+  },
+  {
+    "Lineage": "BA.2.25",
+    "Earliest date": "2022-01-03",
+    "Latest date": "2022-07-15",
+    "Description": "Alias of B.1.1.529.2.25, Sweden lineage"
+  },
+  {
+    "Lineage": "BA.2.25.1",
+    "Earliest date": "2022-02-08",
+    "Latest date": "2022-06-20",
+    "Description": "Alias of B.1.1.529.2.25.1, Slovakia lineage"
+  },
+  {
+    "Lineage": "BA.2.26",
+    "Earliest date": "2022-02-09",
+    "Latest date": "2022-06-23",
+    "Description": "Alias of B.1.1.529.2.26, USA lineage"
+  },
+  {
+    "Lineage": "BA.2.27",
+    "Earliest date": "2021-12-31",
+    "Latest date": "2022-11-04",
+    "Description": "Alias of B.1.1.529.2.27, Thailand lineage"
+  },
+  {
+    "Lineage": "BA.2.28",
+    "Earliest date": "2022-01-13",
+    "Latest date": "2022-07-15",
+    "Description": "Alias of B.1.1.529.2.28, Singapore lineage"
+  },
+  {
+    "Lineage": "BA.2.29",
+    "Earliest date": "2022-01-17",
+    "Latest date": "2023-05-25",
+    "Description": "Alias of B.1.1.529.2.29, Japan lineage"
+  },
+  {
+    "Lineage": "BA.2.30",
+    "Earliest date": "2022-01-27",
+    "Latest date": "2022-11-04",
+    "Description": "Alias of B.1.1.529.2.30, Curacao lineage"
+  },
+  {
+    "Lineage": "BA.2.31",
+    "Earliest date": "2022-01-03",
+    "Latest date": "2022-10-07",
+    "Description": "Alias of B.1.1.529.2.31, Israel lineage"
+  },
+  {
+    "Lineage": "BA.2.31.1",
+    "Earliest date": "2022-01-10",
+    "Latest date": "2023-04-12",
+    "Description": "Alias of B.1.1.529.2.31.1, mainly found in Uganda, defined by S:68T, from #819"
+  },
+  {
+    "Lineage": "BA.2.32",
+    "Earliest date": "2022-01-06",
+    "Latest date": "2022-09-26",
+    "Description": "Alias of B.1.1.529.2.32, Indonesia lineage"
+  },
+  {
+    "Lineage": "BA.2.33",
+    "Earliest date": "2022-02-06",
+    "Latest date": "2023-01-10",
+    "Description": "Alias of B.1.1.529.2.33, Australia lineage"
+  },
+  {
+    "Lineage": "BA.2.34",
+    "Earliest date": "2022-01-05",
+    "Latest date": "2022-08-30",
+    "Description": "Alias of B.1.1.529.2.34, Norway lineage"
+  },
+  {
+    "Lineage": "BA.2.35",
+    "Earliest date": "2022-03-01",
+    "Latest date": "2023-09-28",
+    "Description": "Alias of B.1.1.529.2.35, Predominantly Portugal lineage, from #554"
+  },
+  {
+    "Lineage": "BA.2.36",
+    "Earliest date": "2021-11-15",
+    "Latest date": "2023-11-20",
+    "Description": "Alias of B.1.1.529.2.36, mainly found in Germany, Belgium, England and Denmark, from #565"
+  },
+  {
+    "Lineage": "BA.2.37",
+    "Earliest date": "2021-12-06",
+    "Latest date": "2022-11-07",
+    "Description": "Alias of B.1.1.529.2.37, mainly found in England, Scotland, Wales, from #572"
+  },
+  {
+    "Lineage": "BA.2.38",
+    "Earliest date": "2022-01-07",
+    "Latest date": "2023-08-04",
+    "Description": "Alias of B.1.1.529.2.38, lineage in India and other countries, from #541"
+  },
+  {
+    "Lineage": "BA.2.38.1",
+    "Earliest date": "2022-02-07",
+    "Latest date": "2022-10-06",
+    "Description": "Alias of B.1.1.529.2.38.1, India lineage, from #809"
+  },
+  {
+    "Lineage": "BA.2.38.2",
+    "Earliest date": "2022-05-04",
+    "Latest date": "2022-09-28",
+    "Description": "Alias of B.1.1.529.2.38.2, mainly found in India, from #828"
+  },
+  {
+    "Lineage": "BA.2.38.3",
+    "Earliest date": "2022-05-31",
+    "Latest date": "2022-09-07",
+    "Description": "Alias of B.1.1.529.2.38.3, mainly found in India, from #840"
+  },
+  {
+    "Lineage": "BA.2.38.4",
+    "Earliest date": "2022-05-06",
+    "Latest date": "2022-08-15",
+    "Description": "Alias of B.1.1.529.2.38.4, mainly found in India, from #746"
+  },
+  {
+    "Lineage": "BH.1",
+    "Earliest date": "2022-06-23",
+    "Latest date": "2022-10-23",
+    "Description": "Alias of B.1.1.529.2.38.3.1, mainly found in India, from #913"
+  },
+  {
+    "Lineage": "BA.2.39",
+    "Earliest date": "2022-01-17",
+    "Latest date": "2022-10-30",
+    "Description": "Alias of B.1.1.529.2.39, mainly found in England, from #575"
+  },
+  {
+    "Lineage": "BA.2.40",
+    "Earliest date": "2022-02-03",
+    "Latest date": "2022-07-27",
+    "Description": "Alias of B.1.1.529.2.40, mainly found in Malaysia, England, Denmark and Germany, from #542"
+  },
+  {
+    "Lineage": "BA.2.40.1",
+    "Earliest date": "2022-02-11",
+    "Latest date": "2024-01-08",
+    "Description": "Alias of B.1.1.529.2.40.1, mainly found in Malaysia, England, Germany and Denmark, from #542"
+  },
+  {
+    "Lineage": "BA.2.41",
+    "Earliest date": "2022-01-31",
+    "Latest date": "2022-07-25",
+    "Description": "Alias of B.1.1.529.2.41, mainly found in England and Scotland, from #586"
+  },
+  {
+    "Lineage": "BA.2.42",
+    "Earliest date": "2022-03-17",
+    "Latest date": "2022-09-18",
+    "Description": "Alias of B.1.1.529.2.42, mainly found in Australia, from #610"
+  },
+  {
+    "Lineage": "BA.2.43",
+    "Earliest date": "2022-03-10",
+    "Latest date": "2022-08-01",
+    "Description": "Alias of B.1.1.529.2.43, mainly found in India, from #612"
+  },
+  {
+    "Lineage": "BA.2.44",
+    "Earliest date": "2021-11-15",
+    "Latest date": "2022-09-19",
+    "Description": "Alias of B.1.1.529.2.44, mainly found in Belgium and Luxembourg, from #613"
+  },
+  {
+    "Lineage": "BA.2.45",
+    "Earliest date": "2022-01-01",
+    "Latest date": "2022-07-27",
+    "Description": "Alias of B.1.1.529.2.45, mainly found in Sweden and Denmark, from #616"
+  },
+  {
+    "Lineage": "BA.2.46",
+    "Earliest date": "2022-03-02",
+    "Latest date": "2022-06-21",
+    "Description": "Alias of B.1.1.529.2.46, mainly found in Scotland, from #626"
+  },
+  {
+    "Lineage": "BA.2.47",
+    "Earliest date": "2022-01-03",
+    "Latest date": "2022-08-24",
+    "Description": "Alias of B.1.1.529.2.47, mainly found in Denmark, England, and USA, from #631"
+  },
+  {
+    "Lineage": "BA.2.48",
+    "Earliest date": "2022-01-19",
+    "Latest date": "2022-09-06",
+    "Description": "Alias of B.1.1.529.2.48, ORF1a:T1322I, S:Y248S, T4579A, mainly found in USA, Scotland and England, from #634"
+  },
+  {
+    "Lineage": "BA.2.49",
+    "Earliest date": "2021-12-22",
+    "Latest date": "2022-12-17",
+    "Description": "Alias of B.1.1.529.2.49, mainly found in France, England and USA, from #640"
+  },
+  {
+    "Lineage": "BA.2.50",
+    "Earliest date": "2022-01-21",
+    "Latest date": "2022-08-05",
+    "Description": "Alias of B.1.1.529.2.50, mainly found in Scotland and England, from #641"
+  },
+  {
+    "Lineage": "BA.2.51",
+    "Earliest date": "2021-12-31",
+    "Latest date": "2022-07-10",
+    "Description": "Alias of B.1.1.529.2.51, mainly found in Denmark, from #644"
+  },
+  {
+    "Lineage": "BA.2.52",
+    "Earliest date": "2021-11-15",
+    "Latest date": "2022-12-17",
+    "Description": "Alias of B.1.1.529.2.52, mainly found in Italy, Germany, Denmark and USA, from #648"
+  },
+  {
+    "Lineage": "BA.2.53",
+    "Earliest date": "2022-03-08",
+    "Latest date": "2022-12-17",
+    "Description": "Alias of B.1.1.529.2.53, mainly found in Denmark, from #651"
+  },
+  {
+    "Lineage": "BA.2.54",
+    "Earliest date": "2021-11-15",
+    "Latest date": "2022-10-28",
+    "Description": "Alias of B.1.1.529.2.54, mainly found in Germany, Spain and Denmark, from #658"
+  },
+  {
+    "Lineage": "BA.2.55",
+    "Earliest date": "2022-02-13",
+    "Latest date": "2022-08-25",
+    "Description": "Alias of B.1.1.529.2.55, mainly found in England, USA and Scotland, from #660"
+  },
+  {
+    "Lineage": "BA.2.56",
+    "Earliest date": "2020-06-16",
+    "Latest date": "2023-08-29",
+    "Description": "Alias of B.1.1.529.2.56, mainly found in Europe, from #668"
+  },
+  {
+    "Lineage": "BA.2.56.1",
+    "Earliest date": "2022-03-27",
+    "Latest date": "2022-08-11",
+    "Description": "Alias of B.1.1.529.2.56.1, mainly found in Japan, from #745"
+  },
+  {
+    "Lineage": "BA.2.57",
+    "Earliest date": "2022-01-15",
+    "Latest date": "2022-09-05",
+    "Description": "Alias of B.1.1.529.2.57, Malaysia, Singapore and Australia lineage"
+  },
+  {
+    "Lineage": "BA.2.58",
+    "Earliest date": "2021-06-30",
+    "Latest date": "2022-08-13",
+    "Description": "Alias of B.1.1.529.2.58, Reunion lineage"
+  },
+  {
+    "Lineage": "BA.2.59",
+    "Earliest date": "2022-03-06",
+    "Latest date": "2022-09-25",
+    "Description": "Alias of B.1.1.529.2.59, mainly found in USA, from #672"
+  },
+  {
+    "Lineage": "BA.2.60",
+    "Earliest date": "2022-04-07",
+    "Latest date": "2022-06-28",
+    "Description": "Alias of B.1.1.529.2.60, Peru and Chile lineage, from #683"
+  },
+  {
+    "Lineage": "BA.2.61",
+    "Earliest date": "2022-03-07",
+    "Latest date": "2023-01-31",
+    "Description": "Alias of B.1.1.529.2.61, Singapore lineage"
+  },
+  {
+    "Lineage": "BA.2.62",
+    "Earliest date": "2022-01-20",
+    "Latest date": "2022-10-28",
+    "Description": "Alias of B.1.1.529.2.62, Australia lineage"
+  },
+  {
+    "Lineage": "BA.2.63",
+    "Earliest date": "2022-01-28",
+    "Latest date": "2022-07-29",
+    "Description": "Alias of B.1.1.529.2.63, Greece lineage"
+  },
+  {
+    "Lineage": "BA.2.64",
+    "Earliest date": "2022-01-17",
+    "Latest date": "2022-12-26",
+    "Description": "Alias of B.1.1.529.2.64, Indonesia lineage"
+  },
+  {
+    "Lineage": "BA.2.65",
+    "Earliest date": "2021-10-11",
+    "Latest date": "2023-01-04",
+    "Description": "Alias of B.1.1.529.2.65, Canada and USA lineage"
+  },
+  {
+    "Lineage": "BA.2.66",
+    "Earliest date": "2022-03-02",
+    "Latest date": "2022-10-03",
+    "Description": "Alias of B.1.1.529.2.66, Canada lineage"
+  },
+  {
+    "Lineage": "BA.2.67",
+    "Earliest date": "2021-11-09",
+    "Latest date": "2022-12-26",
+    "Description": "Alias of B.1.1.529.2.67, Slovakia lineage"
+  },
+  {
+    "Lineage": "BA.2.68",
+    "Earliest date": "2022-02-06",
+    "Latest date": "2022-08-28",
+    "Description": "Alias of B.1.1.529.2.68, South Korea lineage"
+  },
+  {
+    "Lineage": "BA.2.69",
+    "Earliest date": "2022-01-05",
+    "Latest date": "2022-07-14",
+    "Description": "Alias of B.1.1.529.2.69, Martinique lineage"
+  },
+  {
+    "Lineage": "BA.2.70",
+    "Earliest date": "2022-02-18",
+    "Latest date": "2022-07-28",
+    "Description": "Alias of B.1.1.529.2.70, Croatia lineage"
+  },
+  {
+    "Lineage": "BA.2.71",
+    "Earliest date": "2021-11-15",
+    "Latest date": "2022-08-29",
+    "Description": "Alias of B.1.1.529.2.71, mainly found in Norway, Sweden and Denmark, from #695"
+  },
+  {
+    "Lineage": "BA.2.72",
+    "Earliest date": "2020-12-11",
+    "Latest date": "2022-09-13",
+    "Description": "Alias of B.1.1.529.2.72, mainly found in USA, Germany and Switzerland, from #698"
+  },
+  {
+    "Lineage": "BA.2.73",
+    "Earliest date": "2020-12-11",
+    "Latest date": "2022-11-02",
+    "Description": "Alias of B.1.1.529.2.73, Puerto Rico and USA lineage, from #632"
+  },
+  {
+    "Lineage": "BA.2.74",
+    "Earliest date": "2022-01-05",
+    "Latest date": "2022-11-10",
+    "Description": "Alias of B.1.1.529.2.74, mainly found in India, from #775"
+  },
+  {
+    "Lineage": "BA.2.75",
+    "Earliest date": "2020-08-08",
+    "Latest date": "2023-04-17",
+    "Description": "Alias of B.1.1.529.2.75, mainly found in India, from #773"
+  },
+  {
+    "Lineage": "BA.2.75.1",
+    "Earliest date": "2022-01-01",
+    "Latest date": "2023-04-22",
+    "Description": "Alias of B.1.1.529.2.75.1, mainly found in India, from #856"
+  },
+  {
+    "Lineage": "BL.1",
+    "Earliest date": "2022-01-03",
+    "Latest date": "2023-06-15",
+    "Description": "Alias of B.1.1.529.2.75.1.1, mainly found in India, S:R346T on polytomy, from #944"
+  },
+  {
+    "Lineage": "BL.1.1",
+    "Earliest date": "2022-08-27",
+    "Latest date": "2022-11-28",
+    "Description": "Alias of B.1.1.529.2.75.1.1.1, defined by S:G614S, from #1079"
+  },
+  {
+    "Lineage": "BL.1.2",
+    "Earliest date": "2022-08-24",
+    "Latest date": "2022-10-31",
+    "Description": "Alias of B.1.1.529.2.75.1.1.2, mainly Austria, defined by S:G261D, S:V308L, from #1066"
+  },
+  {
+    "Lineage": "BL.1.3",
+    "Earliest date": "2022-07-20",
+    "Latest date": "2022-11-23",
+    "Description": "Alias of B.1.1.529.2.75.1.1.3, Switzerland, Israel, Canada, defined by S:F490L, from #1124"
+  },
+  {
+    "Lineage": "BL.1.4",
+    "Earliest date": "2022-08-23",
+    "Latest date": "2022-12-30",
+    "Description": "Alias of B.1.1.529.2.75.1.1.4, India/England/New Zealand, defined by S:F490V"
+  },
+  {
+    "Lineage": "BL.1.5",
+    "Earliest date": "2022-09-14",
+    "Latest date": "2023-02-22",
+    "Description": "Alias of B.1.1.529.2.75.1.1.5, Japan, S:A475V"
+  },
+  {
+    "Lineage": "BL.2",
+    "Earliest date": "2022-06-09",
+    "Latest date": "2023-03-25",
+    "Description": "Alias of B.1.1.529.2.75.1.2, mainly found in India, defined by S:R346T on A26612T branch"
+  },
+  {
+    "Lineage": "BL.2.1",
+    "Earliest date": "2022-09-20",
+    "Latest date": "2022-10-12",
+    "Description": "Alias of B.1.1.529.2.75.1.2.1, Australia/Belgium, defined by S:K182E"
+  },
+  {
+    "Lineage": "BL.3",
+    "Earliest date": "2022-06-09",
+    "Latest date": "2022-12-06",
+    "Description": "Alias of B.1.1.529.2.75.1.3, mainly found in India, defined by ORF1a:P2685S on A26612T branch"
+  },
+  {
+    "Lineage": "BL.4",
+    "Earliest date": "2022-06-09",
+    "Latest date": "2022-12-14",
+    "Description": "Alias of B.1.1.529.2.75.1.4, mainly found in India, defined by ORF7a:P45L with 11224T and 22720G branch"
+  },
+  {
+    "Lineage": "BL.5",
+    "Earliest date": "2022-08-02",
+    "Latest date": "2022-11-19",
+    "Description": "Alias of B.1.1.529.2.75.1.5, mainly found in Denmark, from #1105"
+  },
+  {
+    "Lineage": "BL.6",
+    "Earliest date": "2022-09-02",
+    "Latest date": "2023-03-23",
+    "Description": "Alias of B.1.1.529.2.75.1.6, mainly South Korea, S:R346T, S:V445A, from #1531"
+  },
+  {
+    "Lineage": "BA.2.75.2",
+    "Earliest date": "2022-01-01",
+    "Latest date": "2023-09-09",
+    "Description": "Alias of B.1.1.529.2.75.2, mainly found in Asia and Australia, from #963"
+  },
+  {
+    "Lineage": "CA.1",
+    "Earliest date": "2022-08-26",
+    "Latest date": "2023-01-27",
+    "Description": "Alias of B.1.1.529.2.75.2.1, USA lineage, defined by S:604I and S:452R, from #1063"
+  },
+  {
+    "Lineage": "CA.2",
+    "Earliest date": "2022-07-25",
+    "Latest date": "2022-12-20",
+    "Description": "Alias of B.1.1.529.2.75.2.2, international lineage, defined by S:S494P"
+  },
+  {
+    "Lineage": "CA.3",
+    "Earliest date": "2022-07-27",
+    "Latest date": "2023-01-31",
+    "Description": "Alias of B.1.1.529.2.75.2.3, India, defined by N:M101I, from #1136"
+  },
+  {
+    "Lineage": "CA.3.1",
+    "Earliest date": "2022-09-28",
+    "Latest date": "2023-04-20",
+    "Description": "Alias of B.1.1.529.2.75.2.3.1, USA, S:K444M, S:L452R"
+  },
+  {
+    "Lineage": "CA.4",
+    "Earliest date": "2022-08-23",
+    "Latest date": "2023-01-11",
+    "Description": "Alias of B.1.1.529.2.75.2.4, New Zealand, S:F486L, from #1181"
+  },
+  {
+    "Lineage": "CA.5",
+    "Earliest date": "2022-08-24",
+    "Latest date": "2023-02-03",
+    "Description": "Alias of B.1.1.529.2.75.2.5, USA, S:A260D, S:Q613H"
+  },
+  {
+    "Lineage": "CA.6",
+    "Earliest date": "2022-08-06",
+    "Latest date": "2022-11-16",
+    "Description": "Alias of B.1.1.529.2.75.2.6, India, ORF1a:Y196H"
+  },
+  {
+    "Lineage": "CA.7",
+    "Earliest date": "2022-09-27",
+    "Latest date": "2023-04-18",
+    "Description": "Alias of B.1.1.529.2.75.2.7, S:L452R after ORF1a:L3776I"
+  },
+  {
+    "Lineage": "BA.2.75.3",
+    "Earliest date": "2022-05-20",
+    "Latest date": "2023-03-25",
+    "Description": "Alias of B.1.1.529.2.75.3, mainly found in India, from #965"
+  },
+  {
+    "Lineage": "BM.1",
+    "Earliest date": "2020-08-12",
+    "Latest date": "2023-02-14",
+    "Description": "Alias of B.1.1.529.2.75.3.1, mainly found in India, from #965"
+  },
+  {
+    "Lineage": "BM.1.1",
+    "Earliest date": "2022-07-01",
+    "Latest date": "2023-05-19",
+    "Description": "Alias of B.1.1.529.2.75.3.1.1, mainly found in India (West Bengal), defined by S:346T"
+  },
+  {
+    "Lineage": "BM.1.1.1",
+    "Earliest date": "2022-07-12",
+    "Latest date": "2023-01-31",
+    "Description": "Alias of B.1.1.529.2.75.3.1.1.1, mainly found in India (West Bengal), defined by S:490S, from #1043"
+  },
+  {
+    "Lineage": "CJ.1",
+    "Earliest date": "2022-09-20",
+    "Latest date": "2023-04-27",
+    "Description": "Alias of B.1.1.529.2.75.3.1.1.1.1, S:S486P, from #1171"
+  },
+  {
+    "Lineage": "CJ.1.1",
+    "Earliest date": "2022-10-12",
+    "Latest date": "2023-03-07",
+    "Description": "Alias of B.1.1.529.2.75.3.1.1.1.1.1, S:V445A, Singapore/Malaysia/Japan, from #1384"
+  },
+  {
+    "Lineage": "CJ.1.2",
+    "Earliest date": "2022-01-04",
+    "Latest date": "2023-04-18",
+    "Description": "Alias of B.1.1.529.2.75.3.1.1.1.1.2, ORF1a:L2609F, Sweden/France/England"
+  },
+  {
+    "Lineage": "CJ.1.3",
+    "Earliest date": "2022-11-03",
+    "Latest date": "2023-06-16",
+    "Description": "Alias of B.1.1.529.2.75.3.1.1.1.1.3, A261G reversion, G4960A, C14790T, South Korea"
+  },
+  {
+    "Lineage": "CJ.1.3.1",
+    "Earliest date": "2023-03-17",
+    "Latest date": "2023-09-22",
+    "Description": "Alias of B.1.1.529.2.75.3.1.1.1.1.3.1, S:R214S, ORF1a:G3578S, South Korea/Japan, from sars-cov-2-variants/lineage-proposals#287"
+  },
+  {
+    "Lineage": "CJ.1.3.2",
+    "Earliest date": "2022-11-13",
+    "Latest date": "2023-06-01",
+    "Description": "Alias of B.1.1.529.2.75.3.1.1.1.1.3.2, S:D936H, South Korea, from sars-cov-2-variants/lineage-proposals#287"
+  },
+  {
+    "Lineage": "BM.1.1.2",
+    "Earliest date": "2022-09-16",
+    "Latest date": "2022-10-12",
+    "Description": "Alias of B.1.1.529.2.75.3.1.1.2, England, S:T883I, S:S939F, S:P1079T"
+  },
+  {
+    "Lineage": "BM.1.1.3",
+    "Earliest date": "2021-03-01",
+    "Latest date": "2023-02-17",
+    "Description": "Alias of B.1.1.529.2.75.3.1.1.3, India, defined by ORF10:A8V"
+  },
+  {
+    "Lineage": "CV.1",
+    "Earliest date": "2022-09-16",
+    "Latest date": "2023-04-03",
+    "Description": "Alias of B.1.1.529.2.75.3.1.1.3.1, Ireland, S:L452R"
+  },
+  {
+    "Lineage": "CV.2",
+    "Earliest date": "2022-09-11",
+    "Latest date": "2023-01-23",
+    "Description": "Alias of B.1.1.529.2.75.3.1.1.3.2, Chile, S:486P, from #1374"
+  },
+  {
+    "Lineage": "BM.1.1.4",
+    "Earliest date": "2022-10-11",
+    "Latest date": "2023-03-26",
+    "Description": "Alias of B.1.1.529.2.75.3.1.1.4, S:K356T & S:T572I, from #1438"
+  },
+  {
+    "Lineage": "EP.1",
+    "Earliest date": "2022-12-12",
+    "Latest date": "2023-05-31",
+    "Description": "Alias of B.1.1.529.2.75.3.1.1.4.1, S:L452R, Bhutan, from #1676"
+  },
+  {
+    "Lineage": "EP.1.1",
+    "Earliest date": "2023-01-04",
+    "Latest date": "2023-07-04",
+    "Description": "Alias of B.1.1.529.2.75.3.1.1.4.1.1, ORF1a:P4120S, ORF8:Q18H, Bhutan"
+  },
+  {
+    "Lineage": "EP.1.1.1",
+    "Earliest date": "2023-03-08",
+    "Latest date": "2023-09-10",
+    "Description": "Alias of B.1.1.529.2.75.3.1.1.4.1.1.1, S:T22N, S:T76I, S:T1006A, Bhutan/Thailand/Singapore"
+  },
+  {
+    "Lineage": "EP.2",
+    "Earliest date": "2022-11-15",
+    "Latest date": "2023-05-15",
+    "Description": "Alias of B.1.1.529.2.75.3.1.1.4.2, S:S1147L, N:G212S, Belgium/Europe"
+  },
+  {
+    "Lineage": "BM.1.1.5",
+    "Earliest date": "2022-10-25",
+    "Latest date": "2023-02-21",
+    "Description": "Alias of B.1.1.529.2.75.3.1.1.5, England/Belgium/France, S:N185S & S:L452R"
+  },
+  {
+    "Lineage": "BM.2",
+    "Earliest date": "2022-06-21",
+    "Latest date": "2023-02-19",
+    "Description": "Alias of B.1.1.529.2.75.3.2, mainly found in India (Telangana), defined by S:346T"
+  },
+  {
+    "Lineage": "BM.2.1",
+    "Earliest date": "2022-07-27",
+    "Latest date": "2023-01-17",
+    "Description": "Alias of B.1.1.529.2.75.3.2.1, India, defined by S:F486V"
+  },
+  {
+    "Lineage": "BM.2.2",
+    "Earliest date": "2022-08-02",
+    "Latest date": "2022-11-07",
+    "Description": "Alias of B.1.1.529.2.75.3.2.2, Japan/Israel, defined by S:L455S"
+  },
+  {
+    "Lineage": "BM.2.3",
+    "Earliest date": "2022-07-18",
+    "Latest date": "2022-11-11",
+    "Description": "Alias of B.1.1.529.2.75.3.2.3, India/Singapore, defined by S:F486I"
+  },
+  {
+    "Lineage": "BM.3",
+    "Earliest date": "2022-06-23",
+    "Latest date": "2022-09-19",
+    "Description": "Alias of B.1.1.529.2.75.3.3, found in Nepal and globally, defined by ORF1b:P1652S"
+  },
+  {
+    "Lineage": "BM.4",
+    "Earliest date": "2022-06-20",
+    "Latest date": "2023-01-30",
+    "Description": "Alias of B.1.1.529.2.75.3.4, mainly found in India, defined by ORF1a:Q1198K, from #957"
+  },
+  {
+    "Lineage": "BM.4.1",
+    "Earliest date": "2022-06-09",
+    "Latest date": "2022-12-04",
+    "Description": "Alias of B.1.1.529.2.75.3.4.1, mainly found in India, defined by S:F486S, from #957"
+  },
+  {
+    "Lineage": "BM.4.1.1",
+    "Earliest date": "2022-07-20",
+    "Latest date": "2024-08-11",
+    "Description": "Alias of B.1.1.529.2.75.3.4.1.1, mainly found in India, defined by S:346T"
+  },
+  {
+    "Lineage": "CH.1",
+    "Earliest date": "2022-08-17",
+    "Latest date": "2023-03-27",
+    "Description": "Alias of B.1.1.529.2.75.3.4.1.1.1, defined by S:K444T, from #1113"
+  },
+  {
+    "Lineage": "CH.1.1",
+    "Earliest date": "2022-02-10",
+    "Latest date": "2023-12-20",
+    "Description": "Alias of B.1.1.529.2.75.3.4.1.1.1.1, defined by S:L452R, from #1113"
+  },
+  {
+    "Lineage": "CH.1.1.1",
+    "Earliest date": "2022-10-15",
+    "Latest date": "2024-02-14",
+    "Description": "Alias of B.1.1.529.2.75.3.4.1.1.1.1.1, defined by S:N185D"
+  },
+  {
+    "Lineage": "DV.1",
+    "Earliest date": "2022-12-05",
+    "Latest date": "2023-07-13",
+    "Description": "Alias of B.1.1.529.2.75.3.4.1.1.1.1.1.1, UK, defined by S:L176F"
+  },
+  {
+    "Lineage": "DV.1.1",
+    "Earliest date": "2022-11-28",
+    "Latest date": "2023-07-28",
+    "Description": "Alias of B.1.1.529.2.75.3.4.1.1.1.1.1.1.1, defined by S:Q613H and N:T265I, from #1720"
+  },
+  {
+    "Lineage": "DV.2",
+    "Earliest date": "2022-11-20",
+    "Latest date": "2023-04-29",
+    "Description": "Alias of B.1.1.529.2.75.3.4.1.1.1.1.1.2, UK, defined by S:I569V"
+  },
+  {
+    "Lineage": "DV.3",
+    "Earliest date": "2022-11-11",
+    "Latest date": "2023-06-06",
+    "Description": "Alias of B.1.1.529.2.75.3.4.1.1.1.1.1.3, UK, defined by ORF1a:E377K"
+  },
+  {
+    "Lineage": "DV.3.1",
+    "Earliest date": "2022-11-25",
+    "Latest date": "2023-05-28",
+    "Description": "Alias of B.1.1.529.2.75.3.4.1.1.1.1.1.3.1 found mainly in Portugal and UK, from #1626"
+  },
+  {
+    "Lineage": "DV.4",
+    "Earliest date": "2022-12-01",
+    "Latest date": "2023-06-05",
+    "Description": "Alias of B.1.1.529.2.75.3.4.1.1.1.1.1.4, Malaysia/Singapore, S:I714V, from #1617"
+  },
+  {
+    "Lineage": "DV.5",
+    "Earliest date": "2023-01-06",
+    "Latest date": "2023-10-10",
+    "Description": "Alias of B.1.1.529.2.75.3.4.1.1.1.1.1.5, England/Australia, ORF1a:R24C, S:613H, from #1753"
+  },
+  {
+    "Lineage": "DV.6",
+    "Earliest date": "2022-11-10",
+    "Latest date": "2023-07-24",
+    "Description": "Alias of B.1.1.529.2.75.3.4.1.1.1.1.1.6, T15591C"
+  },
+  {
+    "Lineage": "DV.6.1",
+    "Earliest date": "2023-01-20",
+    "Latest date": "2023-08-29",
+    "Description": "Alias of B.1.1.529.2.75.3.4.1.1.1.1.1.6.1, S:Q613H, T15591C, Central Europe"
+  },
+  {
+    "Lineage": "DV.6.2",
+    "Earliest date": "2023-02-13",
+    "Latest date": "2023-11-07",
+    "Description": "Alias of B.1.1.529.2.75.3.4.1.1.1.1.1.6.2, S:Q613H, C6628T, Asia, from #2045"
+  },
+  {
+    "Lineage": "DV.7",
+    "Earliest date": "2023-01-19",
+    "Latest date": "2023-11-08",
+    "Description": "Alias of B.1.1.529.2.75.3.4.1.1.1.1.1.7, S:L858I, ORF1a:A3548V, England, from #2038"
+  },
+  {
+    "Lineage": "DV.7.1",
+    "Earliest date": "2023-05-11",
+    "Latest date": "2024-02-05",
+    "Description": "Alias of B.1.1.529.2.75.3.4.1.1.1.1.1.7.1, S:L455F (G22927T), S:F456L (T22928C), Spain/Austria, from sars-cov-2-variants/lineage-proposals#135"
+  },
+  {
+    "Lineage": "DV.7.1.1",
+    "Earliest date": "2023-07-26",
+    "Latest date": "2024-03-25",
+    "Description": "Alias of B.1.1.529.2.75.3.4.1.1.1.1.1.7.1.1, S:K679R, on branch ORF1a:K3353R Spain, from sars-cov-2-variants/lineage-proposals#732"
+  },
+  {
+    "Lineage": "DV.7.1.2",
+    "Earliest date": "2023-06-17",
+    "Latest date": "2024-01-26",
+    "Description": "Alias of B.1.1.529.2.75.3.4.1.1.1.1.1.7.1.2, ORF1a:A4162V, Spain/England, from #2258"
+  },
+  {
+    "Lineage": "JV.1",
+    "Earliest date": "2023-07-24",
+    "Latest date": "2023-12-14",
+    "Description": "Alias of B.1.1.529.2.75.3.4.1.1.1.1.1.7.1.2.1, S:G485R, France, from sars-cov-2-variants/lineage-proposals#760"
+  },
+  {
+    "Lineage": "JV.2",
+    "Earliest date": "2023-08-29",
+    "Latest date": "2023-12-11",
+    "Description": "Alias of B.1.1.529.2.75.3.4.1.1.1.1.1.7.1.2.2, S:V772I, France/Spain"
+  },
+  {
+    "Lineage": "DV.7.1.3",
+    "Earliest date": "2023-08-07",
+    "Latest date": "2024-02-01",
+    "Description": "Alias of B.1.1.529.2.75.3.4.1.1.1.1.1.7.1.3, S:A262S, on branch ORF1a:K3353R, from sars-cov-2-variants/lineage-proposals#851"
+  },
+  {
+    "Lineage": "DV.7.1.4",
+    "Earliest date": "2023-06-20",
+    "Latest date": "2024-02-06",
+    "Description": "Alias of B.1.1.529.2.75.3.4.1.1.1.1.1.7.1.4, G28001T, on branch ORF1a:K3353R"
+  },
+  {
+    "Lineage": "DV.7.1.5",
+    "Earliest date": "2023-06-03",
+    "Latest date": "2024-03-05",
+    "Description": "Alias of B.1.1.529.2.75.3.4.1.1.1.1.1.7.1.5, N:T135A, Spain, from sars-cov-2-variants/lineage-proposals#729"
+  },
+  {
+    "Lineage": "KG.1",
+    "Earliest date": "2022-10-18",
+    "Latest date": "2023-12-20",
+    "Description": "Alias of B.1.1.529.2.75.3.4.1.1.1.1.1.7.1.5.1, S:M153I, from sars-cov-2-variants/lineage-proposals#951"
+  },
+  {
+    "Lineage": "KG.2",
+    "Earliest date": "2023-10-05",
+    "Latest date": "2023-12-28",
+    "Description": "Alias of B.1.1.529.2.75.3.4.1.1.1.1.1.7.1.5.2, S:H49Y, S:A264D, S:G485R, Spain/Canada"
+  },
+  {
+    "Lineage": "DV.7.1.6",
+    "Earliest date": "2023-07-18",
+    "Latest date": "2023-11-28",
+    "Description": "Alias of B.1.1.529.2.75.3.4.1.1.1.1.1.7.1.6, S:Q183K, N:A217S, from sars-cov-2-variants/lineage-proposals#765"
+  },
+  {
+    "Lineage": "DV.7.1.7",
+    "Earliest date": "2023-08-13",
+    "Latest date": "2023-11-20",
+    "Description": "Alias of B.1.1.529.2.75.3.4.1.1.1.1.1.7.1.7, S:V90I"
+  },
+  {
+    "Lineage": "DV.7.1.8",
+    "Earliest date": "2023-07-18",
+    "Latest date": "2023-12-04",
+    "Description": "Alias of B.1.1.529.2.75.3.4.1.1.1.1.1.7.1.8, S:T961M, Spain, from sars-cov-2-variants/lineage-proposals#860"
+  },
+  {
+    "Lineage": "DV.7.1.9",
+    "Earliest date": "2023-08-04",
+    "Latest date": "2024-01-25",
+    "Description": "Alias of B.1.1.529.2.75.3.4.1.1.1.1.1.7.1.9, S:R1185H, Australia"
+  },
+  {
+    "Lineage": "DV.7.2",
+    "Earliest date": "2023-03-14",
+    "Latest date": "2023-09-03",
+    "Description": "Alias of B.1.1.529.2.75.3.4.1.1.1.1.1.7.2, C703T, England"
+  },
+  {
+    "Lineage": "DV.8",
+    "Earliest date": "2023-01-07",
+    "Latest date": "2023-07-12",
+    "Description": "Alias of B.1.1.529.2.75.3.4.1.1.1.1.1.8, S:Q613H, C8299T, C19602T, Sweden"
+  },
+  {
+    "Lineage": "CH.1.1.2",
+    "Earliest date": "2022-10-23",
+    "Latest date": "2023-09-06",
+    "Description": "Alias of B.1.1.529.2.75.3.4.1.1.1.1.2, defined by S:T883I, ORF1a:Y1846C, ORF1a:G2294S on T27576C branch"
+  },
+  {
+    "Lineage": "CH.1.1.3",
+    "Earliest date": "2022-10-18",
+    "Latest date": "2023-07-17",
+    "Description": "Alias of B.1.1.529.2.75.3.4.1.1.1.1.3, S:S255P, New Zealand/Australia/Hong Kong, from #1405"
+  },
+  {
+    "Lineage": "GQ.1",
+    "Earliest date": "2023-02-21",
+    "Latest date": "2023-08-24",
+    "Description": "Alias of B.1.1.529.2.75.3.4.1.1.1.1.3.1, S:486P, ORF1a:H1545Q, ORF1b:V1520L, Australia/New Zealand, from #1872"
+  },
+  {
+    "Lineage": "GQ.1.1",
+    "Earliest date": "2023-04-21",
+    "Latest date": "2023-10-13",
+    "Description": "Alias of B.1.1.529.2.75.3.4.1.1.1.1.3.1.1, S:G213E, New Zealand, from sars-cov-2-variants/lineage-proposals#343"
+  },
+  {
+    "Lineage": "CH.1.1.4",
+    "Earliest date": "2022-11-09",
+    "Latest date": "2023-03-09",
+    "Description": "Alias of B.1.1.529.2.75.3.4.1.1.1.1.4, S:H681R, Austria, from #1370"
+  },
+  {
+    "Lineage": "CH.1.1.5",
+    "Earliest date": "2022-11-09",
+    "Latest date": "2023-05-04",
+    "Description": "Alias of B.1.1.529.2.75.3.4.1.1.1.1.5, ORF3a:P104S, found mainly in Denmark and UK, from #1539"
+  },
+  {
+    "Lineage": "CH.1.1.6",
+    "Earliest date": "2022-11-15",
+    "Latest date": "2023-05-18",
+    "Description": "Alias of B.1.1.529.2.75.3.4.1.1.1.1.6, UK, defined by S:T732I"
+  },
+  {
+    "Lineage": "CH.1.1.7",
+    "Earliest date": "2022-10-05",
+    "Latest date": "2023-09-08",
+    "Description": "Alias of B.1.1.529.2.75.3.4.1.1.1.1.7, New Zealand/Australia, defined by ORF1a:F143C"
+  },
+  {
+    "Lineage": "CH.1.1.8",
+    "Earliest date": "2022-11-05",
+    "Latest date": "2023-05-12",
+    "Description": "Alias of B.1.1.529.2.75.3.4.1.1.1.1.8, Ireland, defined by S:A846V"
+  },
+  {
+    "Lineage": "CH.1.1.9",
+    "Earliest date": "2022-11-15",
+    "Latest date": "2023-05-12",
+    "Description": "Alias of B.1.1.529.2.75.3.4.1.1.1.1.9, England, defined by S:I1232V"
+  },
+  {
+    "Lineage": "CH.1.1.10",
+    "Earliest date": "2022-10-23",
+    "Latest date": "2023-04-27",
+    "Description": "Alias of B.1.1.529.2.75.3.4.1.1.1.1.10, Ireland, ORF1a:G442S"
+  },
+  {
+    "Lineage": "CH.1.1.11",
+    "Earliest date": "2022-03-03",
+    "Latest date": "2023-10-24",
+    "Description": "Alias of B.1.1.529.2.75.3.4.1.1.1.1.11, ORF1a:A1176T"
+  },
+  {
+    "Lineage": "GP.1",
+    "Earliest date": "2022-11-27",
+    "Latest date": "2023-10-02",
+    "Description": "Alias of B.1.1.529.2.75.3.4.1.1.1.1.11.1, S:Q52H, ORF7a:T28I, Europe"
+  },
+  {
+    "Lineage": "GP.2",
+    "Earliest date": "2022-08-01",
+    "Latest date": "2023-06-13",
+    "Description": "Alias of B.1.1.529.2.75.3.4.1.1.1.1.11.2, ORF6:S41F, T13450C, Europe"
+  },
+  {
+    "Lineage": "GP.3",
+    "Earliest date": "2022-11-07",
+    "Latest date": "2023-07-03",
+    "Description": "Alias of B.1.1.529.2.75.3.4.1.1.1.1.11.3, T5218C, A16878G, A26519G, C29236T, Ireland"
+  },
+  {
+    "Lineage": "CH.1.1.12",
+    "Earliest date": "2022-11-25",
+    "Latest date": "2023-07-07",
+    "Description": "Alias of B.1.1.529.2.75.3.4.1.1.1.1.12, S:L858I on ORF1a:A486V branch, Denmark"
+  },
+  {
+    "Lineage": "FS.1",
+    "Earliest date": "2022-12-30",
+    "Latest date": "2023-08-20",
+    "Description": "Alias of B.1.1.529.2.75.3.4.1.1.1.1.12.1, found mainly in Denmark, from #1816"
+  },
+  {
+    "Lineage": "CH.1.1.13",
+    "Earliest date": "2022-12-02",
+    "Latest date": "2023-05-08",
+    "Description": "Alias of B.1.1.529.2.75.3.4.1.1.1.1.13, ORF3a:S171L"
+  },
+  {
+    "Lineage": "CH.1.1.14",
+    "Earliest date": "2022-10-19",
+    "Latest date": "2023-07-10",
+    "Description": "Alias of B.1.1.529.2.75.3.4.1.1.1.1.14, N:T362I"
+  },
+  {
+    "Lineage": "CH.1.1.15",
+    "Earliest date": "2022-11-24",
+    "Latest date": "2023-09-08",
+    "Description": "Alias of B.1.1.529.2.75.3.4.1.1.1.1.15, found mainly in Lithuania, Germany and UK, from #1726"
+  },
+  {
+    "Lineage": "CH.1.1.16",
+    "Earliest date": "2022-12-07",
+    "Latest date": "2023-10-16",
+    "Description": "Alias of B.1.1.529.2.75.3.4.1.1.1.1.16, S:613H, ORF3a:S26L, on C193T branch, Germany/Sweden, from #1753"
+  },
+  {
+    "Lineage": "CH.1.1.17",
+    "Earliest date": "2022-10-13",
+    "Latest date": "2023-06-27",
+    "Description": "Alias of B.1.1.529.2.75.3.4.1.1.1.1.17, M:S212G, on C21811T branch, from #1753"
+  },
+  {
+    "Lineage": "FK.1",
+    "Earliest date": "2023-01-28",
+    "Latest date": "2023-10-25",
+    "Description": "Alias of B.1.1.529.2.75.3.4.1.1.1.1.17.1, found mainly in New Zealand and Australia, from #1718"
+  },
+  {
+    "Lineage": "FK.1.1",
+    "Earliest date": "2023-02-08",
+    "Latest date": "2024-04-27",
+    "Description": "Alias of B.1.1.529.2.75.3.4.1.1.1.1.17.1.1, ORF1a:A1060T, on C27804T>ORF1b:L2580I>N:G34E branch, New Zealand, from #1881"
+  },
+  {
+    "Lineage": "FK.1.1.1",
+    "Earliest date": "2023-04-23",
+    "Latest date": "2023-08-04",
+    "Description": "Alias of B.1.1.529.2.75.3.4.1.1.1.1.17.1.1.1, S:V445A, Australia, from sars-cov-2-variants/lineage-proposals#368"
+  },
+  {
+    "Lineage": "FK.1.1.2",
+    "Earliest date": "2023-03-04",
+    "Latest date": "2023-11-17",
+    "Description": "Alias of B.1.1.529.2.75.3.4.1.1.1.1.17.1.1.2, C9223T, T23071G"
+  },
+  {
+    "Lineage": "FK.1.2",
+    "Earliest date": "2023-01-22",
+    "Latest date": "2023-09-04",
+    "Description": "Alias of B.1.1.529.2.75.3.4.1.1.1.1.17.1.2, ORF1a:L384F, ORF1a:R550H"
+  },
+  {
+    "Lineage": "FK.1.2.1",
+    "Earliest date": "2023-02-04",
+    "Latest date": "2023-09-05",
+    "Description": "Alias of B.1.1.529.2.75.3.4.1.1.1.1.17.1.2.1, ORF1a:T891I, Germany/Denmark/Finland/Austria"
+  },
+  {
+    "Lineage": "FK.1.2.2",
+    "Earliest date": "2023-02-15",
+    "Latest date": "2023-07-03",
+    "Description": "Alias of B.1.1.529.2.75.3.4.1.1.1.1.17.1.2.2, ORF1a:D139N, ORF1a:R226K, ORF1a:Q556K, ORF3a:T64N, T11737C, Australia/NZ"
+  },
+  {
+    "Lineage": "FK.1.3",
+    "Earliest date": "2023-02-18",
+    "Latest date": "2023-08-24",
+    "Description": "Alias of B.1.1.529.2.75.3.4.1.1.1.1.17.1.3, ORF1b:M1839I, on C27804T>ORF1b:L2580I>N:G34E branch, Australia"
+  },
+  {
+    "Lineage": "FK.1.3.1",
+    "Earliest date": "2023-02-20",
+    "Latest date": "2023-07-19",
+    "Description": "Alias of B.1.1.529.2.75.3.4.1.1.1.1.17.1.3.1, S:E583D, Australia"
+  },
+  {
+    "Lineage": "FK.1.3.2",
+    "Earliest date": "2023-03-09",
+    "Latest date": "2023-11-22",
+    "Description": "Alias of B.1.1.529.2.75.3.4.1.1.1.1.17.1.3.2, C9391T, T13596C, Australia/Japan"
+  },
+  {
+    "Lineage": "JL.1",
+    "Earliest date": "2023-05-29",
+    "Latest date": "2023-12-18",
+    "Description": "Alias of B.1.1.529.2.75.3.4.1.1.1.1.17.1.3.2.1, S:E1111Q, Japan, from #2168"
+  },
+  {
+    "Lineage": "FK.1.4",
+    "Earliest date": "2023-02-01",
+    "Latest date": "2023-11-12",
+    "Description": "Alias of B.1.1.529.2.75.3.4.1.1.1.1.17.1.4, S:S704L, on C27804>ORF7a:Y40H branch, Australia"
+  },
+  {
+    "Lineage": "FK.1.4.1",
+    "Earliest date": "2023-04-01",
+    "Latest date": "2023-10-13",
+    "Description": "Alias of B.1.1.529.2.75.3.4.1.1.1.1.17.1.4.1, S:G181A, Australia/Puerto Rico, from sars-cov-2-variants/lineage-proposals#88"
+  },
+  {
+    "Lineage": "FK.1.5",
+    "Earliest date": "2023-02-20",
+    "Latest date": "2023-09-16",
+    "Description": "Alias of B.1.1.529.2.75.3.4.1.1.1.1.17.1.5, G5155A, C12439T, Australia/New Zealand"
+  },
+  {
+    "Lineage": "CH.1.1.18",
+    "Earliest date": "2022-10-03",
+    "Latest date": "2023-08-14",
+    "Description": "Alias of B.1.1.529.2.75.3.4.1.1.1.1.18, S:K187T, from #1747"
+  },
+  {
+    "Lineage": "CH.1.1.19",
+    "Earliest date": "2022-11-14",
+    "Latest date": "2023-05-30",
+    "Description": "Alias of B.1.1.529.2.75.3.4.1.1.1.1.19, C2773T, Europe"
+  },
+  {
+    "Lineage": "FJ.1",
+    "Earliest date": "2022-12-08",
+    "Latest date": "2023-09-15",
+    "Description": "Alias of B.1.1.529.2.75.3.4.1.1.1.1.19.1, ORF1a:A1204V, England"
+  },
+  {
+    "Lineage": "CH.1.1.20",
+    "Earliest date": "2023-02-01",
+    "Latest date": "2023-06-27",
+    "Description": "Alias of B.1.1.529.2.75.3.4.1.1.1.1.20, England, T299I, R403K, D1165G, from #1736"
+  },
+  {
+    "Lineage": "CH.1.1.21",
+    "Earliest date": "2022-12-16",
+    "Latest date": "2023-05-02",
+    "Description": "Alias of B.1.1.529.2.75.3.4.1.1.1.1.21, England, S:N481Y, from #1799"
+  },
+  {
+    "Lineage": "CH.1.1.22",
+    "Earliest date": "2023-01-25",
+    "Latest date": "2023-05-24",
+    "Description": "Alias of B.1.1.529.2.75.3.4.1.1.1.1.22, found mainly in Denmark, from #1670"
+  },
+  {
+    "Lineage": "CH.1.1.23",
+    "Earliest date": "2023-01-04",
+    "Latest date": "2023-05-07",
+    "Description": "Alias of B.1.1.529.2.75.3.4.1.1.1.1.23, found mainly in UK, from #1862"
+  },
+  {
+    "Lineage": "CH.1.1.24",
+    "Earliest date": "2022-07-31",
+    "Latest date": "2023-07-09",
+    "Description": "Alias of B.1.1.529.2.75.3.4.1.1.1.1.24, T931C, T6676C"
+  },
+  {
+    "Lineage": "CH.1.1.25",
+    "Earliest date": "2022-10-21",
+    "Latest date": "2023-04-21",
+    "Description": "Alias of B.1.1.529.2.75.3.4.1.1.1.1.25, ORF1a:S330L, ORF1a:P4197S, US"
+  },
+  {
+    "Lineage": "CH.1.1.26",
+    "Earliest date": "2022-10-24",
+    "Latest date": "2023-05-25",
+    "Description": "Alias of B.1.1.529.2.75.3.4.1.1.1.1.26, C29296T, Japan"
+  },
+  {
+    "Lineage": "CH.1.1.27",
+    "Earliest date": "2022-11-01",
+    "Latest date": "2023-05-26",
+    "Description": "Alias of B.1.1.529.2.75.3.4.1.1.1.1.27, ORF1a:S538L, New Zealand"
+  },
+  {
+    "Lineage": "CH.1.1.28",
+    "Earliest date": "2022-01-09",
+    "Latest date": "2023-06-29",
+    "Description": "Alias of B.1.1.529.2.75.3.4.1.1.1.1.28, ORF1b:V1092F, Europe"
+  },
+  {
+    "Lineage": "CH.1.1.29",
+    "Earliest date": "2023-03-19",
+    "Latest date": "2023-07-21",
+    "Description": "Alias of B.1.1.529.2.75.3.4.1.1.1.1.29, S:613H, ORF1a:P371S, Europe/Canada"
+  },
+  {
+    "Lineage": "CH.1.1.30",
+    "Earliest date": "2022-12-06",
+    "Latest date": "2023-05-19",
+    "Description": "Alias of B.1.1.529.2.75.3.4.1.1.1.1.30, ORF1a:Y2968H, C17913T, Germany/Netherlands/Austria"
+  },
+  {
+    "Lineage": "CH.1.1.31",
+    "Earliest date": "2023-01-10",
+    "Latest date": "2023-04-11",
+    "Description": "Alias of B.1.1.529.2.75.3.4.1.1.1.1.31, ORF1a:N593S, ORF1a:P1497S, ORF1a:T2791I, ORF1b:D1024N, South Africa"
+  },
+  {
+    "Lineage": "JP.1",
+    "Earliest date": "2023-02-27",
+    "Latest date": "2023-10-10",
+    "Description": "Alias of B.1.1.529.2.75.3.4.1.1.1.1.31.1, S:R403K, S:V36I, S:G181E, South Africa, from sars-cov-2-variants/lineage-proposals#655"
+  },
+  {
+    "Lineage": "JP.1.1",
+    "Earliest date": "2023-06-05",
+    "Latest date": "2024-01-03",
+    "Description": "Alias of B.1.1.529.2.75.3.4.1.1.1.1.31.1.1, S:G1219V, ORF1a:T1542I, South Africa"
+  },
+  {
+    "Lineage": "CH.1.1.32",
+    "Earliest date": "2023-01-20",
+    "Latest date": "2023-10-24",
+    "Description": "Alias of B.1.1.529.2.75.3.4.1.1.1.1.32, S:L858I, N:P80Q, ORF1a:E974A, from #2150"
+  },
+  {
+    "Lineage": "CH.2",
+    "Earliest date": "2022-08-11",
+    "Latest date": "2022-11-17",
+    "Description": "Alias of B.1.1.529.2.75.3.4.1.1.2, defined by S:Q183H"
+  },
+  {
+    "Lineage": "CH.3",
+    "Earliest date": "2022-10-25",
+    "Latest date": "2023-01-11",
+    "Description": "Alias of B.1.1.529.2.75.3.4.1.1.3, defined by S:486P on ORF1b:Q2425R branch, from #1375"
+  },
+  {
+    "Lineage": "CH.3.1",
+    "Earliest date": "2022-11-08",
+    "Latest date": "2023-02-17",
+    "Description": "Alias of B.1.1.529.2.75.3.4.1.1.3.1, S:S494P, Australia/Indonesia, from #1421"
+  },
+  {
+    "Lineage": "BM.5",
+    "Earliest date": "2022-07-13",
+    "Latest date": "2022-11-25",
+    "Description": "Alias of B.1.1.529.2.75.3.5, mainly found in India, defined by S:L455S, from #1047"
+  },
+  {
+    "Lineage": "BM.6",
+    "Earliest date": "2022-06-13",
+    "Latest date": "2022-10-17",
+    "Description": "Alias of B.1.1.529.2.75.3.6, India, defined by S:G75V followed by S:L455S"
+  },
+  {
+    "Lineage": "BA.2.75.4",
+    "Earliest date": "2022-06-09",
+    "Latest date": "2023-02-25",
+    "Description": "Alias of B.1.1.529.2.75.4, mainly found in India, from #935"
+  },
+  {
+    "Lineage": "BR.1",
+    "Earliest date": "2022-01-20",
+    "Latest date": "2023-08-30",
+    "Description": "Alias of B.1.1.529.2.75.4.1, mainly found in India (Karnataka), defined by S:K444M"
+  },
+  {
+    "Lineage": "BR.1.1",
+    "Earliest date": "2022-09-13",
+    "Latest date": "2022-09-26",
+    "Description": "Alias of B.1.1.529.2.75.4.1.1, Austria/Australia, S:T307S"
+  },
+  {
+    "Lineage": "BR.1.2",
+    "Earliest date": "2022-09-20",
+    "Latest date": "2023-02-20",
+    "Description": "Alias of B.1.1.529.2.75.4.1.2, Italy/USA, S:F486S"
+  },
+  {
+    "Lineage": "BR.2",
+    "Earliest date": "2022-09-05",
+    "Latest date": "2023-05-12",
+    "Description": "Alias of B.1.1.529.2.75.4.2, found in Australia, defined by S:R346T and S:486I, from #1063"
+  },
+  {
+    "Lineage": "BR.2.1",
+    "Earliest date": "2022-01-11",
+    "Latest date": "2023-09-22",
+    "Description": "Alias of B.1.1.529.2.75.4.2.1, found mainly in Australia, from #1292"
+  },
+  {
+    "Lineage": "BR.3",
+    "Earliest date": "2022-08-16",
+    "Latest date": "2023-03-15",
+    "Description": "Alias of B.1.1.529.2.75.4.3, India, Australia, Austria, defined by S:R346T, from #1063"
+  },
+  {
+    "Lineage": "BR.4",
+    "Earliest date": "2022-08-01",
+    "Latest date": "2023-01-19",
+    "Description": "Alias of B.1.1.529.2.75.4.4, S:K444T and S:G446S reversion, from #1179"
+  },
+  {
+    "Lineage": "BR.5",
+    "Earliest date": "2022-09-05",
+    "Latest date": "2023-06-07",
+    "Description": "Alias of B.1.1.529.2.75.4.5 found mainly in SouthKorea and usa, from #1345"
+  },
+  {
+    "Lineage": "BR.5.1",
+    "Earliest date": "2022-11-04",
+    "Latest date": "2023-05-30",
+    "Description": "Alias of B.1.1.529.2.75.4.5.1 ORF1a:K2029N, ORF1b:T1522I, A20289G, South Korea"
+  },
+  {
+    "Lineage": "BA.2.75.5",
+    "Earliest date": "2020-08-11",
+    "Latest date": "2023-11-07",
+    "Description": "Alias of B.1.1.529.2.75.5, mainly found in India, from #947"
+  },
+  {
+    "Lineage": "BN.1",
+    "Earliest date": "2021-07-16",
+    "Latest date": "2024-03-19",
+    "Description": "Alias of B.1.1.529.2.75.5.1, mainly found in India, from #994"
+  },
+  {
+    "Lineage": "BN.1.1",
+    "Earliest date": "2022-08-09",
+    "Latest date": "2024-01-04",
+    "Description": "Alias of B.1.1.529.2.75.5.1.1, India/Austria, S:S494P, from #1176"
+  },
+  {
+    "Lineage": "BN.1.1.1",
+    "Earliest date": "2022-01-07",
+    "Latest date": "2023-06-19",
+    "Description": "Alias of B.1.1.529.2.75.5.1.1.1, Austria, S:N185D"
+  },
+  {
+    "Lineage": "BN.1.2",
+    "Earliest date": "2022-01-24",
+    "Latest date": "2024-07-17",
+    "Description": "Alias of B.1.1.529.2.75.5.1.2, Singapore/England, E:D72G"
+  },
+  {
+    "Lineage": "BN.1.2.1",
+    "Earliest date": "2022-09-21",
+    "Latest date": "2023-05-19",
+    "Description": "Alias of B.1.1.529.2.75.5.1.2.1, England/Portugal, S:T470N, from #1238"
+  },
+  {
+    "Lineage": "BN.1.2.2",
+    "Earliest date": "2022-09-29",
+    "Latest date": "2023-09-04",
+    "Description": "Alias of B.1.1.529.2.75.5.1.2.2, C29546T"
+  },
+  {
+    "Lineage": "BN.1.2.3",
+    "Earliest date": "2022-09-16",
+    "Latest date": "2023-06-15",
+    "Description": "Alias of B.1.1.529.2.75.5.1.2.3, C1471T"
+  },
+  {
+    "Lineage": "FR.1",
+    "Earliest date": "2022-12-15",
+    "Latest date": "2023-11-24",
+    "Description": "Alias of B.1.1.529.2.75.5.1.2.3.1, S:K187E, N:T366I, Japan/Taiwan/USA, from #1814"
+  },
+  {
+    "Lineage": "FR.1.1",
+    "Earliest date": "2023-04-07",
+    "Latest date": "2023-11-18",
+    "Description": "Alias of B.1.1.529.2.75.5.1.2.3.1.1, S:P82H, ORF1a:L293F, China, from #2006"
+  },
+  {
+    "Lineage": "FR.1.2",
+    "Earliest date": "2023-01-18",
+    "Latest date": "2023-08-05",
+    "Description": "Alias of B.1.1.529.2.75.5.1.2.3.1.2, S:R190M, China, from #2028"
+  },
+  {
+    "Lineage": "FR.1.3",
+    "Earliest date": "2023-04-01",
+    "Latest date": "2023-12-08",
+    "Description": "Alias of B.1.1.529.2.75.5.1.2.3.1.3, ORF1a:A206V, ORF1b:A517V, N:G34E, China, from #2039"
+  },
+  {
+    "Lineage": "FR.1.4",
+    "Earliest date": "2023-04-06",
+    "Latest date": "2024-01-04",
+    "Description": "Alias of B.1.1.529.2.75.5.1.2.3.1.4, A3715G, C15960T, on shared T2372C, C7318T, ORF1a:L293F branch with FR.1.1, China, from sars-cov-2-variants/lineage-proposals#256"
+  },
+  {
+    "Lineage": "FR.1.5",
+    "Earliest date": "2023-03-01",
+    "Latest date": "2024-04-03",
+    "Description": "Alias of B.1.1.529.2.75.5.1.2.3.1.5, ORF1a:V116M, ORF1a:S2242F, ORF1a:M4071T, Japan"
+  },
+  {
+    "Lineage": "FR.2",
+    "Earliest date": "2022-11-17",
+    "Latest date": "2023-10-02",
+    "Description": "Alias of B.1.1.529.2.75.5.1.2.3.2, ORF1a:Y1920H, ORF1b:I1799S, South Korea"
+  },
+  {
+    "Lineage": "BN.1.2.4",
+    "Earliest date": "2022-10-10",
+    "Latest date": "2023-05-13",
+    "Description": "Alias of B.1.1.529.2.75.5.1.2.4, ORF1b:D1746H"
+  },
+  {
+    "Lineage": "BN.1.2.5",
+    "Earliest date": "2022-10-20",
+    "Latest date": "2023-06-17",
+    "Description": "Alias of B.1.1.529.2.75.5.1.2.5, C3241T, C16833T, G22225A, South Korea"
+  },
+  {
+    "Lineage": "BN.1.2.6",
+    "Earliest date": "2022-11-07",
+    "Latest date": "2023-06-22",
+    "Description": "Alias of B.1.1.529.2.75.5.1.2.6, ORF1b:A1326S, South Korea"
+  },
+  {
+    "Lineage": "BN.1.2.7",
+    "Earliest date": "2022-11-23",
+    "Latest date": "2023-11-18",
+    "Description": "Alias of B.1.1.529.2.75.5.1.2.7, N:N8S, C16332T, Taiwan, from #1923"
+  },
+  {
+    "Lineage": "BN.1.2.8",
+    "Earliest date": "2022-11-11",
+    "Latest date": "2023-07-02",
+    "Description": "Alias of B.1.1.529.2.75.5.1.2.8, S:N703K, Russia"
+  },
+  {
+    "Lineage": "BN.1.3",
+    "Earliest date": "2022-01-02",
+    "Latest date": "2024-03-26",
+    "Description": "Alias of B.1.1.529.2.75.5.1.3, India, ORF3a:T229I"
+  },
+  {
+    "Lineage": "BN.1.3.1",
+    "Earliest date": "2022-03-11",
+    "Latest date": "2023-12-01",
+    "Description": "Alias of B.1.1.529.2.75.5.1.3.1, found mainly in Israel, England and Denmark, from #1257"
+  },
+  {
+    "Lineage": "DS.1",
+    "Earliest date": "2022-12-02",
+    "Latest date": "2023-05-20",
+    "Description": "Alias of B.1.1.529.2.75.5.1.3.1.1, USA/Ireland/Austria, S:F486S, S:R403K"
+  },
+  {
+    "Lineage": "DS.2",
+    "Earliest date": "2022-10-26",
+    "Latest date": "2024-03-09",
+    "Description": "Alias of B.1.1.529.2.75.5.1.3.1.2, Germany, S:T572I"
+  },
+  {
+    "Lineage": "DS.3",
+    "Earliest date": "2022-10-27",
+    "Latest date": "2023-03-27",
+    "Description": "Alias of B.1.1.529.2.75.5.1.3.1.3, Denmark, ORF3a:G254V"
+  },
+  {
+    "Lineage": "BN.1.3.2",
+    "Earliest date": "2022-11-07",
+    "Latest date": "2023-10-13",
+    "Description": "Alias of B.1.1.529.2.75.5.1.3.2, S:V445A found mainly in Japan, from #1397"
+  },
+  {
+    "Lineage": "BN.1.3.3",
+    "Earliest date": "2022-08-01",
+    "Latest date": "2023-04-03",
+    "Description": "Alias of B.1.1.529.2.75.5.1.3.3, S:E147Q, mainly Europe"
+  },
+  {
+    "Lineage": "BN.1.3.4",
+    "Earliest date": "2022-10-09",
+    "Latest date": "2023-07-12",
+    "Description": "Alias of B.1.1.529.2.75.5.1.3.4, S:V445A, Japan/England/NZ/Russia"
+  },
+  {
+    "Lineage": "BN.1.3.5",
+    "Earliest date": "2022-01-02",
+    "Latest date": "2024-05-12",
+    "Description": "Alias of B.1.1.529.2.75.5.1.3.5 ORF7b:C41W, found mainly in SouthKorea, Japan and USA, from #1516"
+  },
+  {
+    "Lineage": "BN.1.3.6",
+    "Earliest date": "2022-04-10",
+    "Latest date": "2023-05-26",
+    "Description": "Alias of B.1.1.529.2.75.5.1.3.6 M:R174Q"
+  },
+  {
+    "Lineage": "BN.1.3.7",
+    "Earliest date": "2022-09-22",
+    "Latest date": "2023-06-09",
+    "Description": "Alias of B.1.1.529.2.75.5.1.3.7 ORF1a:T1429I"
+  },
+  {
+    "Lineage": "BN.1.3.8",
+    "Earliest date": "2022-10-03",
+    "Latest date": "2023-05-03",
+    "Description": "Alias of B.1.1.529.2.75.5.1.3.8 S:D1139H"
+  },
+  {
+    "Lineage": "EJ.1",
+    "Earliest date": "2022-10-10",
+    "Latest date": "2023-05-04",
+    "Description": "Alias of B.1.1.529.2.75.5.1.3.8.1, S:I1225V"
+  },
+  {
+    "Lineage": "EJ.2",
+    "Earliest date": "2022-07-17",
+    "Latest date": "2023-07-24",
+    "Description": "Alias of B.1.1.529.2.75.5.1.3.8.2, ORF1a:T4355I"
+  },
+  {
+    "Lineage": "EJ.3",
+    "Earliest date": "2022-10-14",
+    "Latest date": "2023-04-23",
+    "Description": "Alias of B.1.1.529.2.75.5.1.3.8.3, C2509T, C3241T, C17004T, South Korea"
+  },
+  {
+    "Lineage": "BN.1.3.9",
+    "Earliest date": "2022-10-07",
+    "Latest date": "2023-05-03",
+    "Description": "Alias of B.1.1.529.2.75.5.1.3.9 S:V83F, from #1748"
+  },
+  {
+    "Lineage": "BN.1.3.10",
+    "Earliest date": "2022-10-20",
+    "Latest date": "2023-05-02",
+    "Description": "Alias of B.1.1.529.2.75.5.1.3.10 ORF1a:Q1918R, C13608T, Asia/Oceania"
+  },
+  {
+    "Lineage": "BN.1.3.11",
+    "Earliest date": "2022-10-21",
+    "Latest date": "2023-06-08",
+    "Description": "Alias of B.1.1.529.2.75.5.1.3.11 ORF1a:T568I, ORF1a:V1211F, South Korea"
+  },
+  {
+    "Lineage": "BN.1.3.12",
+    "Earliest date": "2022-08-01",
+    "Latest date": "2023-08-07",
+    "Description": "Alias of B.1.1.529.2.75.5.1.3.12 C14358T, T22672C, South Korea/Thailand/Germany"
+  },
+  {
+    "Lineage": "BN.1.3.13",
+    "Earliest date": "2023-01-28",
+    "Latest date": "2023-10-18",
+    "Description": "Alias of B.1.1.529.2.75.5.1.3.13 S:V445A, C3817T, C17818T, Taiwan/Japan/South Korea, from sars-cov-2-variants/lineage-proposals#218"
+  },
+  {
+    "Lineage": "BN.1.4",
+    "Earliest date": "2022-02-11",
+    "Latest date": "2023-06-08",
+    "Description": "Alias of B.1.1.529.2.75.5.1.4, India, 27501C"
+  },
+  {
+    "Lineage": "BN.1.4.1",
+    "Earliest date": "2022-10-05",
+    "Latest date": "2023-03-18",
+    "Description": "Alias of B.1.1.529.2.75.5.1.4.1, S:G261V & S:T678I, from #1417"
+  },
+  {
+    "Lineage": "BN.1.4.2",
+    "Earliest date": "2022-10-13",
+    "Latest date": "2023-08-11",
+    "Description": "Alias of B.1.1.529.2.75.5.1.4.2, S:Q1113K"
+  },
+  {
+    "Lineage": "BN.1.4.3",
+    "Earliest date": "2022-08-29",
+    "Latest date": "2023-09-30",
+    "Description": "Alias of B.1.1.529.2.75.5.1.4.3, ORF1a:P1096T"
+  },
+  {
+    "Lineage": "BN.1.4.4",
+    "Earliest date": "2022-09-12",
+    "Latest date": "2023-03-23",
+    "Description": "Alias of B.1.1.529.2.75.5.1.4.4, ORF1b:V1149L, ORF1b:V1723M"
+  },
+  {
+    "Lineage": "BN.1.4.5",
+    "Earliest date": "2022-01-30",
+    "Latest date": "2023-03-20",
+    "Description": "Alias of B.1.1.529.2.75.5.1.4.5, ORF1a:T3287I"
+  },
+  {
+    "Lineage": "BN.1.5",
+    "Earliest date": "2022-01-04",
+    "Latest date": "2023-05-15",
+    "Description": "Alias of B.1.1.529.2.75.5.1.5, ORF1a:S2103F"
+  },
+  {
+    "Lineage": "BN.1.5.1",
+    "Earliest date": "2022-10-24",
+    "Latest date": "2023-01-30",
+    "Description": "Alias of B.1.1.529.2.75.5.1.5.1, New Zealand, S:S514T"
+  },
+  {
+    "Lineage": "BN.1.5.2",
+    "Earliest date": "2022-10-12",
+    "Latest date": "2024-02-07",
+    "Description": "Alias of B.1.1.529.2.75.5.1.5.2, S:N481K"
+  },
+  {
+    "Lineage": "BN.1.6",
+    "Earliest date": "2022-09-21",
+    "Latest date": "2023-05-02",
+    "Description": "Alias of B.1.1.529.2.75.5.1.6, S:D1139H"
+  },
+  {
+    "Lineage": "BN.1.7",
+    "Earliest date": "2022-09-14",
+    "Latest date": "2023-05-17",
+    "Description": "Alias of B.1.1.529.2.75.5.1.7, England, S:M177T, S:H1101Y, from #1310"
+  },
+  {
+    "Lineage": "BN.1.8",
+    "Earliest date": "2022-10-07",
+    "Latest date": "2023-02-28",
+    "Description": "Alias of B.1.1.529.2.75.5.1.8, Iceland/USA, S:A475V"
+  },
+  {
+    "Lineage": "BN.1.9",
+    "Earliest date": "2022-01-24",
+    "Latest date": "2023-04-01",
+    "Description": "Alias of B.1.1.529.2.75.5.1.9, found mainly in Indonesia, from #1327"
+  },
+  {
+    "Lineage": "BN.1.10",
+    "Earliest date": "2022-10-10",
+    "Latest date": "2023-05-26",
+    "Description": "Alias of B.1.1.529.2.75.5.1.10, defined by S:Y145H"
+  },
+  {
+    "Lineage": "BN.1.11",
+    "Earliest date": "2022-11-10",
+    "Latest date": "2023-05-08",
+    "Description": "Alias of B.1.1.529.2.75.5.1.11, South Korea, defined by S:L176F, S:D936H"
+  },
+  {
+    "Lineage": "BN.2",
+    "Earliest date": "2022-07-10",
+    "Latest date": "2023-01-26",
+    "Description": "Alias of B.1.1.529.2.75.5.2, mainly found in India, from #1021"
+  },
+  {
+    "Lineage": "BN.2.1",
+    "Earliest date": "2022-08-04",
+    "Latest date": "2023-01-31",
+    "Description": "Alias of B.1.1.529.2.75.5.2.1, mainly USA and Canada lineage, defined by S:H49Y and S:F490S"
+  },
+  {
+    "Lineage": "BN.3",
+    "Earliest date": "2022-08-22",
+    "Latest date": "2023-05-08",
+    "Description": "Alias of B.1.1.529.2.75.5.3, defined by S:N450D on ORF1a:392D branch"
+  },
+  {
+    "Lineage": "BN.3.1",
+    "Earliest date": "2022-01-02",
+    "Latest date": "2023-06-11",
+    "Description": "Alias of B.1.1.529.2.75.5.3.1, South Korea/Austria/Israel/Belgium, defined by S:F490S"
+  },
+  {
+    "Lineage": "BN.4",
+    "Earliest date": "2022-08-23",
+    "Latest date": "2023-01-09",
+    "Description": "Alias of B.1.1.529.2.75.5.4, Netherlands/Germany, defined by S:F490S on ORF1a:392D branch"
+  },
+  {
+    "Lineage": "BN.5",
+    "Earliest date": "2022-01-31",
+    "Latest date": "2023-01-18",
+    "Description": "Alias of B.1.1.529.2.75.5.5, India, defined by ORF1a:V2995M"
+  },
+  {
+    "Lineage": "BN.6",
+    "Earliest date": "2022-06-25",
+    "Latest date": "2023-03-20",
+    "Description": "Alias of B.1.1.529.2.75.5.6, India, defined by ORF1a:T3959A"
+  },
+  {
+    "Lineage": "BA.2.75.6",
+    "Earliest date": "2022-06-16",
+    "Latest date": "2023-08-05",
+    "Description": "Alias of B.1.1.529.2.75.6, mainly found in India, defined by S:R346T on the BA.2.75 polytomy"
+  },
+  {
+    "Lineage": "BY.1",
+    "Earliest date": "2022-01-01",
+    "Latest date": "2023-08-02",
+    "Description": "Alias of B.1.1.529.2.75.6.1, mainly found in India, defined by S:F486S on BA.2.75.6"
+  },
+  {
+    "Lineage": "BY.1.1",
+    "Earliest date": "2022-08-22",
+    "Latest date": "2023-02-28",
+    "Description": "Alias of B.1.1.529.2.75.6.1.1, S:L452R"
+  },
+  {
+    "Lineage": "BY.1.1.1",
+    "Earliest date": "2022-09-13",
+    "Latest date": "2023-04-03",
+    "Description": "Alias of B.1.1.529.2.75.6.1.1.1, Europe, S:N185D, S:H207R,"
+  },
+  {
+    "Lineage": "BY.1.2",
+    "Earliest date": "2022-08-20",
+    "Latest date": "2023-01-06",
+    "Description": "Alias of B.1.1.529.2.75.6.1.2, Europe, 26828T"
+  },
+  {
+    "Lineage": "BY.1.2.1",
+    "Earliest date": "2022-09-19",
+    "Latest date": "2022-10-18",
+    "Description": "Alias of B.1.1.529.2.75.6.1.2.1, Austria/England, S:S494P, from #1184"
+  },
+  {
+    "Lineage": "BA.2.75.7",
+    "Earliest date": "2022-06-23",
+    "Latest date": "2022-12-07",
+    "Description": "Alias of B.1.1.529.2.75.7, mainly found in India, defined by S:F486S on the BA.2.75 polytomy"
+  },
+  {
+    "Lineage": "BA.2.75.8",
+    "Earliest date": "2022-08-27",
+    "Latest date": "2022-12-12",
+    "Description": "Alias of B.1.1.529.2.75.8, Singapore/Australia, defined by S:L452Q, from #1085"
+  },
+  {
+    "Lineage": "BA.2.75.9",
+    "Earliest date": "2022-07-24",
+    "Latest date": "2022-11-16",
+    "Description": "Alias of B.1.1.529.2.75.9, India, defined by S:R346T after 17679T, from #1098"
+  },
+  {
+    "Lineage": "CB.1",
+    "Earliest date": "2021-12-21",
+    "Latest date": "2023-01-18",
+    "Description": "Alias of B.1.1.529.2.75.9.1, England, defined by S:486V, from #1098"
+  },
+  {
+    "Lineage": "BA.2.75.10",
+    "Earliest date": "2022-06-08",
+    "Latest date": "2023-01-11",
+    "Description": "Alias of B.1.1.529.2.75.10, India, ORF1a:T3959A"
+  },
+  {
+    "Lineage": "BA.2.76",
+    "Earliest date": "2020-08-08",
+    "Latest date": "2023-03-13",
+    "Description": "Alias of B.1.1.529.2.76, mainly found in India and USA, from #787"
+  },
+  {
+    "Lineage": "BA.2.76.1",
+    "Earliest date": "2022-06-19",
+    "Latest date": "2022-08-20",
+    "Description": "Alias of B.1.1.529.2.76.1, mainly found in India, from #899"
+  },
+  {
+    "Lineage": "BA.2.76.2",
+    "Earliest date": "2022-06-23",
+    "Latest date": "2022-08-16",
+    "Description": "Alias of B.1.1.529.2.76.2, found in Japan, from #939"
+  },
+  {
+    "Lineage": "BA.2.77",
+    "Earliest date": "2022-04-27",
+    "Latest date": "2022-07-17",
+    "Description": "Alias of B.1.1.529.2.77, mainly found in Ireland, England and USA, from #732"
+  },
+  {
+    "Lineage": "BA.2.78",
+    "Earliest date": "2021-10-20",
+    "Latest date": "2022-08-23",
+    "Description": "Alias of B.1.1.529.2.78, mainly found in India, from #814"
+  },
+  {
+    "Lineage": "BA.2.79",
+    "Earliest date": "2022-04-13",
+    "Latest date": "2022-11-10",
+    "Description": "Alias of B.1.1.529.2.79, Kuwait and Israel lineage, from #812"
+  },
+  {
+    "Lineage": "BA.2.79.1",
+    "Earliest date": "2022-05-05",
+    "Latest date": "2022-08-15",
+    "Description": "Alias of B.1.1.529.2.79.1, India lineage, from #814"
+  },
+  {
+    "Lineage": "BA.2.80",
+    "Earliest date": "2022-05-04",
+    "Latest date": "2022-08-15",
+    "Description": "Alias of B.1.1.529.2.80, found in Denmark, from #733"
+  },
+  {
+    "Lineage": "BA.2.81",
+    "Earliest date": "2022-03-11",
+    "Latest date": "2022-09-02",
+    "Description": "Alias of B.1.1.529.2.81, Brazil lineage"
+  },
+  {
+    "Lineage": "BA.2.82",
+    "Earliest date": "2022-04-28",
+    "Latest date": "2023-03-13",
+    "Description": "Alias of B.1.1.529.2.82, mainly found in Australia, Israel and Japan, from #874"
+  },
+  {
+    "Lineage": "BA.2.83",
+    "Earliest date": "2022-07-11",
+    "Latest date": "2022-10-08",
+    "Description": "Alias of B.1.1.529.2.83, mainly found in India, from #1053"
+  },
+  {
+    "Lineage": "BA.2.85",
+    "Earliest date": "2022-03-07",
+    "Latest date": "2022-08-26",
+    "Description": "Alias of B.1.1.529.2.85, mainly found in Japan, from #983"
+  },
+  {
+    "Lineage": "BA.2.86",
+    "Earliest date": "2023-03-11",
+    "Latest date": "2024-06-27",
+    "Description": "Alias of B.1.1.529.2.86, from #2183"
+  },
+  {
+    "Lineage": "BA.2.86.1",
+    "Earliest date": "2023-01-03",
+    "Latest date": "2024-08-18",
+    "Description": "Alias of B.1.1.529.2.86.1, ORF1a:K1973R, mostly with C12815T, mainly Europe, from #2236"
+  },
+  {
+    "Lineage": "JN.1",
+    "Earliest date": "2020-01-20",
+    "Latest date": "2024-08-21",
+    "Description": "Alias of B.1.1.529.2.86.1.1, S:L455S, ORF1a:R3821K, ORF7b:F19L, Europe"
+  },
+  {
+    "Lineage": "JN.1.1",
+    "Earliest date": "2021-07-16",
+    "Latest date": "2024-08-25",
+    "Description": "Alias of B.1.1.529.2.86.1.1.1, ORF1a:F499L, C11747T, France, from sars-cov-2-variants/lineage-proposals#987"
+  },
+  {
+    "Lineage": "JN.1.1.1",
+    "Earliest date": "2023-09-25",
+    "Latest date": "2024-08-09",
+    "Description": "Alias of B.1.1.529.2.86.1.1.1.1, S:T572I on C9142T branch, France/Sweden/Poland, from sars-cov-2-variants/lineage-proposals#1097"
+  },
+  {
+    "Lineage": "JN.1.1.2",
+    "Earliest date": "2023-10-30",
+    "Latest date": "2024-03-08",
+    "Description": "Alias of B.1.1.529.2.86.1.1.1.2, S:G181E, France, from sars-cov-2-variants/lineage-proposals#1147"
+  },
+  {
+    "Lineage": "JN.1.1.3",
+    "Earliest date": "2023-11-04",
+    "Latest date": "2024-07-03",
+    "Description": "Alias of B.1.1.529.2.86.1.1.1.3, S:R346T, from sars-cov-2-variants/lineage-proposals#1089"
+  },
+  {
+    "Lineage": "LT.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.1.3.1, S:F456V, L176F, USA/Canada"
+  },
+  {
+    "Lineage": "JN.1.1.4",
+    "Earliest date": "2023-11-09",
+    "Latest date": "2024-05-06",
+    "Description": "Alias of B.1.1.529.2.86.1.1.1.4, S:V1264L on C9142T branch, from #2476"
+  },
+  {
+    "Lineage": "JN.1.1.5",
+    "Earliest date": "2023-01-29",
+    "Latest date": "2024-08-01",
+    "Description": "Alias of B.1.1.529.2.86.1.1.1.5, S:R346T on C9142T branch, from #2492"
+  },
+  {
+    "Lineage": "KR.1",
+    "Earliest date": "2024-01-06",
+    "Latest date": "2024-08-17",
+    "Description": "Alias of B.1.1.529.2.86.1.1.1.5.1, S:F456L (22928C), after C28498T, from sars-cov-2-variants/lineage-proposals#1253"
+  },
+  {
+    "Lineage": "KR.1.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.1.5.1.1, S:F59L, from sars-cov-2-variants/lineage-proposals#1545"
+  },
+  {
+    "Lineage": "KR.1.2",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.1.5.1.2, S:R683Q"
+  },
+  {
+    "Lineage": "KR.1.3",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.1.5.1.3, S:K304Q, S:S60P, Philippines"
+  },
+  {
+    "Lineage": "KR.3",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.1.5.3, S:F456L (22930A), from sars-cov-2-variants/lineage-proposals#1253"
+  },
+  {
+    "Lineage": "KR.4",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.1.5.4, S:Q218E"
+  },
+  {
+    "Lineage": "KR.4.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.1.5.4.1, S:F456L (22928C), S:K478T, South Africa"
+  },
+  {
+    "Lineage": "KR.5",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.1.5.5, ORF1a:L642F, ORF1a:T2087I, Brazil"
+  },
+  {
+    "Lineage": "JN.1.1.6",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.1.6, S:F456L, from sars-cov-2-variants/lineage-proposals#1253"
+  },
+  {
+    "Lineage": "KZ.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.1.6.1, ORF1b:V1092F"
+  },
+  {
+    "Lineage": "KZ.1.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.1.6.1.1, S:R346T from #2548"
+  },
+  {
+    "Lineage": "KZ.1.1.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.1.6.1.1.1, S:T572I from #2548"
+  },
+  {
+    "Lineage": "JN.1.1.7",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.1.7, S:S31F, from sars-cov-2-variants/lineage-proposals#1157"
+  },
+  {
+    "Lineage": "LC.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.1.7.1, S:R346T"
+  },
+  {
+    "Lineage": "JN.1.1.8",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.1.8, S:F456L (T22930A), S:H445P, ORF1a:S2083I, C850T, from sars-cov-2-variants/lineage-proposals#1521"
+  },
+  {
+    "Lineage": "JN.1.1.9",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.1.9, G2035A, on C9142T branch, China, from sars-cov-2-variants/lineage-proposals#1525"
+  },
+  {
+    "Lineage": "JN.1.1.10",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.1.10, C23557T, Ukraine"
+  },
+  {
+    "Lineage": "JN.1.2",
+    "Earliest date": "2023-01-03",
+    "Latest date": "2024-07-31",
+    "Description": "Alias of B.1.1.529.2.86.1.1.2, S:M1229I, USA/Canada, from sars-cov-2-variants/lineage-proposals#1087"
+  },
+  {
+    "Lineage": "JN.1.2.1",
+    "Earliest date": "2023-11-27",
+    "Latest date": "2024-02-22",
+    "Description": "Alias of B.1.1.529.2.86.1.1.2.1, S:H1101Y, Ireland, from sars-cov-2-variants/lineage-proposals#1322"
+  },
+  {
+    "Lineage": "JN.1.3",
+    "Earliest date": "2023-03-04",
+    "Latest date": "2024-07-29",
+    "Description": "Alias of B.1.1.529.2.86.1.1.3, ORF8:Q18*, Netherlands"
+  },
+  {
+    "Lineage": "JN.1.4",
+    "Earliest date": "2023-02-14",
+    "Latest date": "2024-08-08",
+    "Description": "Alias of B.1.1.529.2.86.1.1.4, ORF1a:T170I, Denmark/Singapore, from #2381"
+  },
+  {
+    "Lineage": "JN.1.4.1",
+    "Earliest date": "2023-11-27",
+    "Latest date": "2024-05-08",
+    "Description": "Alias of B.1.1.529.2.86.1.1.4.1, S:E654V, Ireland, from sars-cov-2-variants/lineage-proposals#1175"
+  },
+  {
+    "Lineage": "JN.1.4.2",
+    "Earliest date": "2023-11-17",
+    "Latest date": "2024-07-23",
+    "Description": "Alias of B.1.1.529.2.86.1.1.4.2, S:N185D, after T18453C, USA, from #2462"
+  },
+  {
+    "Lineage": "LL.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.4.2.1, S:F456L (T22930A), S:S680F, USA, from sars-cov-2-variants/lineage-proposals#1253"
+  },
+  {
+    "Lineage": "JN.1.4.3",
+    "Earliest date": "2023-11-14",
+    "Latest date": "2024-07-06",
+    "Description": "Alias of B.1.1.529.2.86.1.1.4.3, S:T572I, USA, from #2487"
+  },
+  {
+    "Lineage": "KQ.1",
+    "Earliest date": "2024-01-04",
+    "Latest date": "2024-07-31",
+    "Description": "Alias of B.1.1.529.2.86.1.1.4.3.1, S:R346T, USA from #2487"
+  },
+  {
+    "Lineage": "JN.1.4.4",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.4.4, S:R346T, from sars-cov-2-variants/lineage-proposals#1089"
+  },
+  {
+    "Lineage": "JN.1.4.5",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.4.5, ORF8:S103L, after T18453C, from #2426"
+  },
+  {
+    "Lineage": "KV.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.4.5.1, S:S680F, after C28948T then A2356T"
+  },
+  {
+    "Lineage": "KV.2",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.4.5.2, S:T572I, ORF1a:P971L, C11956T, USA, from sars-cov-2-variants/lineage-proposals#1097"
+  },
+  {
+    "Lineage": "JN.1.4.6",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.4.6, S:T572I, after T18453C, from sars-cov-2-variants/lineage-proposals#1097"
+  },
+  {
+    "Lineage": "JN.1.4.7",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.4.7, ORF3a:G18D"
+  },
+  {
+    "Lineage": "LE.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.4.7.1, S:R346T, Africa, from sars-cov-2-variants/lineage-proposals#1089"
+  },
+  {
+    "Lineage": "LE.1.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.4.7.1.1, S:F456V, from sars-cov-2-variants/lineage-proposals#1089"
+  },
+  {
+    "Lineage": "LE.1.2",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.4.7.1.2, S:K304N"
+  },
+  {
+    "Lineage": "LE.1.3",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.4.7.1.3, S:L84V, ORF7a:T120I, Kenya"
+  },
+  {
+    "Lineage": "LE.1.3.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.4.7.1.3.1, S:Q173K, S:F456L (T22928C), ORF7a:A66V, from sars-cov-2-variants/lineage-proposals#1612"
+  },
+  {
+    "Lineage": "LE.2",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.4.7.2, S:R346S, C7423T"
+  },
+  {
+    "Lineage": "JN.1.4.8",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.4.8, S:S60P, T13578C, USA，from #2625"
+  },
+  {
+    "Lineage": "JN.1.4.9",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.4.9, S:F456L, on branch with JN.1.4.2/5/6 (T18453C), from #2577"
+  },
+  {
+    "Lineage": "JN.1.5",
+    "Earliest date": "2023-10-30",
+    "Latest date": "2024-07-13",
+    "Description": "Alias of B.1.1.529.2.86.1.1.5, ORF1b:V1271T, Singapore/Malaysia/Indonesia, from #2419"
+  },
+  {
+    "Lineage": "JN.1.6",
+    "Earliest date": "2023-10-11",
+    "Latest date": "2024-08-13",
+    "Description": "Alias of B.1.1.529.2.86.1.1.6, G22627A"
+  },
+  {
+    "Lineage": "JN.1.6.1",
+    "Earliest date": "2023-11-26",
+    "Latest date": "2024-06-11",
+    "Description": "Alias of B.1.1.529.2.86.1.1.6.1, S:R346T, Sweden, from sars-cov-2-variants/lineage-proposals#1089"
+  },
+  {
+    "Lineage": "JN.1.7",
+    "Earliest date": "2022-10-18",
+    "Latest date": "2024-08-15",
+    "Description": "Alias of B.1.1.529.2.86.1.1.7, S:T572I, S:E1150D, USA/France, from sars-cov-2-variants/lineage-proposals#1097"
+  },
+  {
+    "Lineage": "JN.1.7.1",
+    "Earliest date": "2023-12-31",
+    "Latest date": "2024-07-21",
+    "Description": "Alias of B.1.1.529.2.86.1.1.7.1, S:R346K, England, from sars-cov-2-variants/lineage-proposals#1371"
+  },
+  {
+    "Lineage": "JN.1.7.2",
+    "Earliest date": "2023-12-09",
+    "Latest date": "2024-08-05",
+    "Description": "Alias of B.1.1.529.2.86.1.1.7.2, ORF1b:C1563F, Americas"
+  },
+  {
+    "Lineage": "JN.1.7.3",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.7.3, S:R346T, from sars-cov-2-variants/lineage-proposals#1343"
+  },
+  {
+    "Lineage": "JN.1.7.4",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.7.4, S:F456L (T22928C), from sars-cov-2-variants/lineage-proposals#1253"
+  },
+  {
+    "Lineage": "JN.1.7.5",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.7.5, ORF1a:H3395Y, from sars-cov-2-variants/lineage-proposals#1374"
+  },
+  {
+    "Lineage": "LK.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.7.5.1, S:445P, ORF1a:R1170C, USA/Canada, from sars-cov-2-variants/lineage-proposals#1374"
+  },
+  {
+    "Lineage": "LK.2",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.7.5.2, S:R346T"
+  },
+  {
+    "Lineage": "LK.2.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.7.5.2.1, S:S455A, S:T547K, Central America"
+  },
+  {
+    "Lineage": "JN.1.7.6",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.7.6, S:S60P, ORF1a:P1609S, Wales"
+  },
+  {
+    "Lineage": "JN.1.7.7",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.7.7, ORF1b:K2557R "
+  },
+  {
+    "Lineage": "JN.1.7.8",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.7.8, S:F456L (22930A), S:185-189del, N:365L, Central America"
+  },
+  {
+    "Lineage": "MQ.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.7.8.1, S:T95I, S:R346T, from #2710"
+  },
+  {
+    "Lineage": "MQ.2",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.7.8.2, S:T678I"
+  },
+  {
+    "Lineage": "JN.1.7.9",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.7.9, G347A, C1057T, C7834T, S:F456L (22930A)"
+  },
+  {
+    "Lineage": "JN.1.8",
+    "Earliest date": "2023-02-26",
+    "Latest date": "2024-08-16",
+    "Description": "Alias of B.1.1.529.2.86.1.1.8, ORF7a:T28I"
+  },
+  {
+    "Lineage": "JN.1.8.1",
+    "Earliest date": "2023-02-26",
+    "Latest date": "2024-08-05",
+    "Description": "Alias of B.1.1.529.2.86.1.1.8.1, S:T572I, after A12928G, USA/Denmark, from sars-cov-2-variants/lineage-proposals#1097"
+  },
+  {
+    "Lineage": "JN.1.8.2",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.8.2, S:R346T, after A12928G, from sars-cov-2-variants/lineage-proposals#1089"
+  },
+  {
+    "Lineage": "KY.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.8.2.1, ORF1a:N3774D, Nigeria"
+  },
+  {
+    "Lineage": "JN.1.8.3",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.8.3, C13821T, C14925T"
+  },
+  {
+    "Lineage": "JN.1.8.4",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.8.4, S:G946R"
+  },
+  {
+    "Lineage": "JN.1.9",
+    "Earliest date": "2023-10-03",
+    "Latest date": "2024-08-25",
+    "Description": "Alias of B.1.1.529.2.86.1.1.9, S:Q183H, USA/UK/Canada, from #2410"
+  },
+  {
+    "Lineage": "JN.1.9.1",
+    "Earliest date": "2023-12-04",
+    "Latest date": "2024-08-14",
+    "Description": "Alias of B.1.1.529.2.86.1.1.9.1, S:T572I, ORF1a:A3143V, from sars-cov-2-variants/lineage-proposals#1097"
+  },
+  {
+    "Lineage": "JN.1.9.2",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.9.2, S:R346T"
+  },
+  {
+    "Lineage": "LB.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.9.2.1, S:F456L (T22928C), from sars-cov-2-variants/lineage-proposals#1089"
+  },
+  {
+    "Lineage": "LB.1.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.9.2.1.1, S:V1104L, Canada"
+  },
+  {
+    "Lineage": "LB.1.2",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.9.2.1.2, ORF1b:G2068R"
+  },
+  {
+    "Lineage": "LB.1.2.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.9.2.1.2.1, S:R190T, from sars-cov-2-variants/lineage-proposals#1559"
+  },
+  {
+    "Lineage": "LB.1.2.2",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.9.2.1.2.2, S:T572I, C22075T"
+  },
+  {
+    "Lineage": "LB.1.2.3",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.9.2.1.2.3, S:F175L, ORF1a:I1568F"
+  },
+  {
+    "Lineage": "LB.1.3",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.9.2.1.3, ORF1b:T1555I"
+  },
+  {
+    "Lineage": "LB.1.3.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.9.2.1.3.1, S:445P, N:T379I, from sars-cov-2-variants/lineage-proposals#1620"
+  },
+  {
+    "Lineage": "LB.1.3.2",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.9.2.1.3.2, C25413T"
+  },
+  {
+    "Lineage": "MH.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.9.2.1.3.2.1, S:T572I"
+  },
+  {
+    "Lineage": "LB.1.3.3",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.9.2.1.3.3, S:K182R, from #2723"
+  },
+  {
+    "Lineage": "LB.1.4",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.9.2.1.4, ORF1a:A1473V"
+  },
+  {
+    "Lineage": "LB.1.4.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.9.2.1.4.1, S:R190S"
+  },
+  {
+    "Lineage": "LB.1.4.2",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.9.2.1.4.2, S:A879S, ORF1a:E472D, USA"
+  },
+  {
+    "Lineage": "LB.1.4.3",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.9.2.1.4.3, S:A845S, USA"
+  },
+  {
+    "Lineage": "LB.1.5",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.9.2.1.5, S:L1143F, ORF1b:T1621I, Asia，from sars-cov-2-variants/lineage-proposals#1557"
+  },
+  {
+    "Lineage": "LB.1.6",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.9.2.1.6, S:I670M, England/Canada"
+  },
+  {
+    "Lineage": "LB.1.7",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.9.2.1.7, ORF1a:L1507F, G21123T"
+  },
+  {
+    "Lineage": "LB.1.7.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.9.2.1.7.1, S:N148T, USA-NY"
+  },
+  {
+    "Lineage": "LB.1.7.2",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.9.2.1.7.2, S:S680P"
+  },
+  {
+    "Lineage": "LB.1.7.3",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.9.2.1.7.3, S:R34C"
+  },
+  {
+    "Lineage": "LB.1.8",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.9.2.1.8, ORF1a:I785V"
+  },
+  {
+    "Lineage": "LB.1.9",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.9.2.1.9, S:K478T (reversion), G20931T, T29194C, C15960T, India"
+  },
+  {
+    "Lineage": "JN.1.10",
+    "Earliest date": "2023-11-07",
+    "Latest date": "2024-08-10",
+    "Description": "Alias of B.1.1.529.2.86.1.1.10, S:T95I, USA/Canada, from sars-cov-2-variants/lineage-proposals#1135"
+  },
+  {
+    "Lineage": "JN.1.11",
+    "Earliest date": "2023-12-07",
+    "Latest date": "2024-08-21",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11, S:V1104L, G17334T, India, from #2446"
+  },
+  {
+    "Lineage": "JN.1.11.1",
+    "Earliest date": "2023-08-11",
+    "Latest date": "2024-08-29",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1, S:F456L (T22928C), after ORF1a:T2283I, India, from sars-cov-2-variants/lineage-proposals#1253"
+  },
+  {
+    "Lineage": "KP.1",
+    "Earliest date": "2023-12-30",
+    "Latest date": "2024-08-16",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.1, S:K1086R, from sars-cov-2-variants/lineage-proposals#1364"
+  },
+  {
+    "Lineage": "KP.1.1",
+    "Earliest date": "2024-01-27",
+    "Latest date": "2024-08-22",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.1.1, S:R346T, from sars-cov-2-variants/lineage-proposals#1089"
+  },
+  {
+    "Lineage": "KP.1.1.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.1.1.1, S:K182N, after ORF1b:L2213F, from #2510"
+  },
+  {
+    "Lineage": "MG.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.1.1.1.1, S:T572I, S:679N, ORF1a:V3091I"
+  },
+  {
+    "Lineage": "KP.1.1.2",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.1.1.2, S:P1162S, T2152C, from sars-cov-2-variants/lineage-proposals#1541"
+  },
+  {
+    "Lineage": "KP.1.1.3",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.1.1.3, C4999T, many with S:S31del, from sars-cov-2-variants/lineage-proposals#1502"
+  },
+  {
+    "Lineage": "LP.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.1.1.3.1, S:M1229I,from sars-cov-2-variants/lineage-proposals#1591"
+  },
+  {
+    "Lineage": "LP.1.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.1.1.3.1.1, S:S255F, Dominican Republic, from sars-cov-2-variants/lineage-proposals#1633"
+  },
+  {
+    "Lineage": "LP.1.2",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.1.1.3.1.2, S:R190S, T18300A, USA"
+  },
+  {
+    "Lineage": "LP.2",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.1.1.3.2, S:S71Y, ORF1b:T2286I"
+  },
+  {
+    "Lineage": "LP.3",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.1.1.3.3, S:K182E, ORF1b:R276S, Singapore"
+  },
+  {
+    "Lineage": "LP.4",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.1.1.3.4, S:T572I, ORF8:A65V"
+  },
+  {
+    "Lineage": "KP.1.1.4",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.1.1.4, S:R214H, C11866T, C23929T,from sars-cov-2-variants/lineage-proposals#1593"
+  },
+  {
+    "Lineage": "KP.1.1.5",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.1.1.5, S:F59S"
+  },
+  {
+    "Lineage": "MU.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.1.1.5.1, S:T572I, ORF1a:P4339T, ORF1b:T1902I"
+  },
+  {
+    "Lineage": "KP.1.2",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.1.2, S:T572I, from sars-cov-2-variants/lineage-proposals#1097"
+  },
+  {
+    "Lineage": "KP.2",
+    "Earliest date": "2023-07-05",
+    "Latest date": "2024-08-26",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.2, S:R346T on JN.1.11.1 polytomy, from sars-cov-2-variants/lineage-proposals#1089"
+  },
+  {
+    "Lineage": "KP.2.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.2.1, S:Q1201K, from sars-cov-2-variants/lineage-proposals#1440"
+  },
+  {
+    "Lineage": "KP.2.2",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.2.2, S:F59L, S:K1266R, from sars-cov-2-variants/lineage-proposals#1446"
+  },
+  {
+    "Lineage": "KP.2.3",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.2.3, S:H146Q, ORF3a:K67N, S:31del, from sars-cov-2-variants/lineage-proposals#1459"
+  },
+  {
+    "Lineage": "KP.2.3.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.2.3.1, S:A475V, from sars-cov-2-variants/lineage-proposals#1548"
+  },
+  {
+    "Lineage": "KP.2.3.2",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.2.3.2, S:G184V"
+  },
+  {
+    "Lineage": "KP.2.3.3",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.2.3.3, S:N185T"
+  },
+  {
+    "Lineage": "KP.2.3.4",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.2.3.4, S:445P, A15759G, C27804T, from sars-cov-2-variants/lineage-proposals#1596"
+  },
+  {
+    "Lineage": "KP.2.3.5",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.2.3.5, S:K535T, A1087G"
+  },
+  {
+    "Lineage": "KP.2.3.6",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.2.3.6, S:T572I on a C28714T branch"
+  },
+  {
+    "Lineage": "KP.2.3.7",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.2.3.7, ORF1a:T2121A"
+  },
+  {
+    "Lineage": "MW.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.2.3.7.1, S:Q239R, ORF1a:I785V, ORF6:L16I"
+  },
+  {
+    "Lineage": "KP.2.4",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.2.4, S:T250N, from sars-cov-2-variants/lineage-proposals#1524"
+  },
+  {
+    "Lineage": "KP.2.5",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.2.5, S:N185D, from sars-cov-2-variants/lineage-proposals#1527"
+  },
+  {
+    "Lineage": "KP.2.6",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.2.6, S:W64R, S:F32del"
+  },
+  {
+    "Lineage": "KP.2.7",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.2.7, S:S31F, after T22795G"
+  },
+  {
+    "Lineage": "KP.2.8",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.2.8, S:S60P, from sars-cov-2-variants/lineage-proposals#1546"
+  },
+  {
+    "Lineage": "KP.2.9",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.2.9, S:T572I, from sars-cov-2-variants/lineage-proposals#1089"
+  },
+  {
+    "Lineage": "KP.2.10",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.2.10, S:F59S, Singapore, from sars-cov-2-variants/lineage-proposals#1553"
+  },
+  {
+    "Lineage": "KP.2.11",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.2.11, S:F56V, ORF1a:T2093I, England, from sars-cov-2-variants/lineage-proposals#1520"
+  },
+  {
+    "Lineage": "KP.2.12",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.2.12, S:V1176F, G25088T, Australia, from sars-cov-2-variants/lineage-proposals#1550"
+  },
+  {
+    "Lineage": "KP.2.13",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.2.13, S:K478E, N:P6T, C9565T, C24553T, USA/Canada"
+  },
+  {
+    "Lineage": "KP.2.14",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.2.14, S:T22N, S:S31F, S:G184V, from sars-cov-2-variants/lineage-proposals#1578"
+  },
+  {
+    "Lineage": "KP.2.15",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.2.15, A10861G, S:31del, USA/Canada"
+  },
+  {
+    "Lineage": "KP.2.15.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.2.15.1, S:T572I, from #2711"
+  },
+  {
+    "Lineage": "KP.2.16",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.2.16, ORF8:F6S"
+  },
+  {
+    "Lineage": "KP.2.17",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.2.17, S:G35R, C23758T, C7765T, T14418C, Singapore"
+  },
+  {
+    "Lineage": "KP.2.18",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.2.18, S:T22N, on T22795G branch"
+  },
+  {
+    "Lineage": "KP.2.19",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.2.19, S:S31del, ORF1a:V28I, Guatemala, from #2720"
+  },
+  {
+    "Lineage": "KP.2.20",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.2.20, ORF1b:D436N, Asia"
+  },
+  {
+    "Lineage": "KP.2.20.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.2.20.1, S:T572I, S:K1266R, Australia"
+  },
+  {
+    "Lineage": "KP.2.22",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.2.22, S:S31del, ORF1a:V3718F"
+  },
+  {
+    "Lineage": "KP.2.23",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.2.23, S:S31del, ORF3a:A110S, ORF8:G77S"
+  },
+  {
+    "Lineage": "KP.2.24",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.2.24, S:S31del, C9286T, C14919T"
+  },
+  {
+    "Lineage": "KP.3",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.3, S:Q493E, from sars-cov-2-variants/lineage-proposals#1410"
+  },
+  {
+    "Lineage": "KP.3.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.3.1, G15372T, A19722G"
+  },
+  {
+    "Lineage": "KP.3.1.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.3.1.1, ORF1a:S4286C, C12616T, S:S31del, Spain, from sars-cov-2-variants/lineage-proposals#1563"
+  },
+  {
+    "Lineage": "MC.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.3.1.1.1, S:T572I, from sars-cov-2-variants/lineage-proposals#1638"
+  },
+  {
+    "Lineage": "MC.2",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.3.1.1.2, S:A845S"
+  },
+  {
+    "Lineage": "MC.2.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.3.1.1.2.1, S:R237K"
+  },
+  {
+    "Lineage": "MC.3",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.3.1.1.3, S:G72R, Spain"
+  },
+  {
+    "Lineage": "MC.4",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.3.1.1.4, S:S98F, Spain"
+  },
+  {
+    "Lineage": "MC.5",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.3.1.1.5, S:G1219C, Spain"
+  },
+  {
+    "Lineage": "MC.6",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.3.1.1.6, ORF1a:P769S, ORF1a:G2091S"
+  },
+  {
+    "Lineage": "MC.7",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.3.1.1.7, S:A397V"
+  },
+  {
+    "Lineage": "MC.8",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.3.1.1.8, C9803T"
+  },
+  {
+    "Lineage": "MC.8.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.3.1.1.8.1, S:T572I"
+  },
+  {
+    "Lineage": "MC.9",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.3.1.1.9, ORF3a:K75N, ORF1b:A1219S"
+  },
+  {
+    "Lineage": "MC.10",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.3.1.1.10, C16332T"
+  },
+  {
+    "Lineage": "MC.11",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.3.1.1.11, C17430T"
+  },
+  {
+    "Lineage": "MC.11.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.3.1.1.11.1, S:S256L, Europe"
+  },
+  {
+    "Lineage": "MC.12",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.3.1.1.12, S:G72E"
+  },
+  {
+    "Lineage": "MC.13",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.3.1.1.13, C10681T"
+  },
+  {
+    "Lineage": "MC.13.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.3.1.1.13.1, S:S254F, USA"
+  },
+  {
+    "Lineage": "MC.14",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.3.1.1.14, S:T259R"
+  },
+  {
+    "Lineage": "MC.15",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.3.1.1.15, S:K182R"
+  },
+  {
+    "Lineage": "MC.16",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.3.1.1.16, G2890A"
+  },
+  {
+    "Lineage": "KP.3.1.2",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.3.1.2, S:S151I，from sars-cov-2-variants/lineage-proposals#1589"
+  },
+  {
+    "Lineage": "KP.3.1.3",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.3.1.3, S:S31F,from sars-cov-2-variants/lineage-proposals#1576"
+  },
+  {
+    "Lineage": "KP.3.1.4",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.3.1.4, ORF1b:P1675S,from #2627"
+  },
+  {
+    "Lineage": "MM.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.3.1.4.1, S:S680P, Europe"
+  },
+  {
+    "Lineage": "MM.2",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.3.1.4.2, S:G35R, S:N185D"
+  },
+  {
+    "Lineage": "KP.3.1.5",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.3.1.5, S:N556K, ORF1a:Q998H, ORF3a:I186V, England, from sars-cov-2-variants/lineage-proposals#1614"
+  },
+  {
+    "Lineage": "KP.3.1.6",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.3.1.6, T19305C"
+  },
+  {
+    "Lineage": "MK.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.3.1.6.1, S:S31F, UK"
+  },
+  {
+    "Lineage": "MK.2",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.3.1.6.2, S:D745G, after E:L21F"
+  },
+  {
+    "Lineage": "MK.3",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.3.1.6.3, S:R346T, S:H445R"
+  },
+  {
+    "Lineage": "KP.3.1.7",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.3.1.7, S:L84I, from #2709"
+  },
+  {
+    "Lineage": "KP.3.1.8",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.3.1.8, S:F59S, A9235G, Georgia"
+  },
+  {
+    "Lineage": "MY.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.3.1.8.1, S:P174S, ORF3a:T64I, Georgia"
+  },
+  {
+    "Lineage": "KP.3.2",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.3.2, A2611C, C22858T"
+  },
+  {
+    "Lineage": "KP.3.2.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.3.2.1, S:A263V, Australia/Singapore, from sars-cov-2-variants/lineage-proposals#1556"
+  },
+  {
+    "Lineage": "KP.3.2.2",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.3.2.2, S:W258R"
+  },
+  {
+    "Lineage": "KP.3.2.3",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.3.2.3, ORF3a:S40P, C11518T"
+  },
+  {
+    "Lineage": "LW.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.3.2.3.1, S:K182E, England"
+  },
+  {
+    "Lineage": "LW.1.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.3.2.3.1.1, S:T33I"
+  },
+  {
+    "Lineage": "LW.1.2",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.3.2.3.1.1, S:T22N"
+  },
+  {
+    "Lineage": "KP.3.2.4",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.3.2.4, ORF3a:L73F"
+  },
+  {
+    "Lineage": "KP.3.2.5",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.3.2.5, S:V62F, from sars-cov-2-variants/lineage-proposals#1604"
+  },
+  {
+    "Lineage": "KP.3.3",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.3.3, N:R204P, from sars-cov-2-variants/lineage-proposals#1531"
+  },
+  {
+    "Lineage": "KP.3.3.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.3.3.1, S:T547K, ORF3a:F87S, from sars-cov-2-variants/lineage-proposals#1651"
+  },
+  {
+    "Lineage": "KP.3.3.2",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.3.3.2, S:A435S, ORF1a:N4134T, England/Canada"
+  },
+  {
+    "Lineage": "KP.3.3.3",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.3.3.3, G9424T, Japan/Canada"
+  },
+  {
+    "Lineage": "ML.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.3.3.3.1, S:681H"
+  },
+  {
+    "Lineage": "ML.2",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.3.3.3.2, S:Q677H, USA"
+  },
+  {
+    "Lineage": "KP.3.3.4",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.3.3.4, ORF1a:I1367L, from #2707"
+  },
+  {
+    "Lineage": "MR.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.3.3.4.1, S:S31del, ORF1a:V1236I, from #2704"
+  },
+  {
+    "Lineage": "KP.3.4",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.3.4, ORF3a:L73F, C25521T, Asia"
+  },
+  {
+    "Lineage": "KP.3.4.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.3.4.1, S:S31F, N:A134V, ORF1a:E1192K"
+  },
+  {
+    "Lineage": "KP.3.5",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.3.5, S:G213E, most with C1420T, America"
+  },
+  {
+    "Lineage": "KP.3.6",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.3.6, S:T22N, Canada"
+  },
+  {
+    "Lineage": "KP.4",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.4, C6070T, India"
+  },
+  {
+    "Lineage": "KP.4.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.4.1, S:R346T, C19884T, from sars-cov-2-variants/lineage-proposals#1089"
+  },
+  {
+    "Lineage": "KP.4.1.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.4.1.1, S:W258R, India from #2521"
+  },
+  {
+    "Lineage": "KP.4.1.2",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.4.1.2, S:L441V, from sars-cov-2-variants/lineage-proposals#1611"
+  },
+  {
+    "Lineage": "KP.4.1.3",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.4.1.3, ORF1a:M598V, A5245G, S:31del "
+  },
+  {
+    "Lineage": "KP.4.2",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.4.2, S:R346T, S:K187R, from sars-cov-2-variants/lineage-proposals#1089"
+  },
+  {
+    "Lineage": "KP.4.2.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.4.2.1, S:S31F"
+  },
+  {
+    "Lineage": "KP.4.2.2",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.4.2.2, S:F59I"
+  },
+  {
+    "Lineage": "KP.4.2.3",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.4.2.3, S:G35R, ORF1a:G519S, ORF1a:I2227V"
+  },
+  {
+    "Lineage": "KP.5",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.5, S:T572I, from sars-cov-2-variants/lineage-proposals#1097"
+  },
+  {
+    "Lineage": "KP.6",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.11.1.6, S:R346I"
+  },
+  {
+    "Lineage": "JN.1.12",
+    "Earliest date": "2023-11-26",
+    "Latest date": "2024-04-12",
+    "Description": "Alias of B.1.1.529.2.86.1.1.12, S:F456V, ORF7a:A8T, from sars-cov-2-variants/lineage-proposals#1253"
+  },
+  {
+    "Lineage": "JN.1.13",
+    "Earliest date": "2023-12-10",
+    "Latest date": "2024-08-13",
+    "Description": "Alias of B.1.1.529.2.86.1.1.13, S:A1087S, after C26894T, C25680T, USA, from #2464"
+  },
+  {
+    "Lineage": "JN.1.13.1",
+    "Earliest date": "2023-12-07",
+    "Latest date": "2024-08-21",
+    "Description": "Alias of B.1.1.529.2.86.1.1.13.1, S:R346T, S:F59S, USA, from sars-cov-2-variants/lineage-proposals/issues/1386"
+  },
+  {
+    "Lineage": "KS.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.13.1.1, S:F456L (T22928C), from sars-cov-2-variants/lineage-proposals#1253"
+  },
+  {
+    "Lineage": "KS.1.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.13.1.1.1, S:T22N, Singapore/Taiwan/Canada, from sars-cov-2-variants/lineage-proposals#1565"
+  },
+  {
+    "Lineage": "KS.1.2",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.13.1.1.2, S:T678I, Russia"
+  },
+  {
+    "Lineage": "KS.1.3",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.13.1.1.3, S:V642A, Dominican Republic"
+  },
+  {
+    "Lineage": "KS.1.4",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.13.1.1.4, C22414T, S:R237K"
+  },
+  {
+    "Lineage": "JN.1.14",
+    "Earliest date": "2023-12-20",
+    "Latest date": "2024-04-04",
+    "Description": "Alias of B.1.1.529.2.86.1.1.14, S:R346S, after C26894T, C25680T, USA"
+  },
+  {
+    "Lineage": "JN.1.15",
+    "Earliest date": "2023-11-09",
+    "Latest date": "2024-08-21",
+    "Description": "Alias of B.1.1.529.2.86.1.1.15, S:A688V"
+  },
+  {
+    "Lineage": "JN.1.15.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.15.1, S:F456L, ORF3a:R122S, Ecuador, from sars-cov-2-variants/lineage-proposals#1253"
+  },
+  {
+    "Lineage": "LU.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.15.1.1, S:R346T, after C19269T, from sars-cov-2-variants/lineage-proposals#1089"
+  },
+  {
+    "Lineage": "LU.2",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.15.1.2, S:R346T, after T20865C, from sars-cov-2-variants/lineage-proposals#1652"
+  },
+  {
+    "Lineage": "LU.2.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.15.1.2.1, S:L176F, Ecuador"
+  },
+  {
+    "Lineage": "LU.2.1.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.15.1.2.1.1, S:S60P, S:K182N, ORF1a:L204F, ORF1a:T1854I, Ecuador"
+  },
+  {
+    "Lineage": "LU.2.2",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.15.1.2.2, S:Q677P, ORF1a:T1000I, Ecuador"
+  },
+  {
+    "Lineage": "JN.1.16",
+    "Earliest date": "2023-07-14",
+    "Latest date": "2024-08-26",
+    "Description": "Alias of B.1.1.529.2.86.1.1.16, S:F456L (T22928C), from sars-cov-2-variants/lineage-proposals#1253"
+  },
+  {
+    "Lineage": "JN.1.16.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.16.1, S:R346T, from sars-cov-2-variants/lineage-proposals#1089"
+  },
+  {
+    "Lineage": "LF.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.16.1.1, ORF1a:A1268T, ORF1a:S2103F"
+  },
+  {
+    "Lineage": "LF.1.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.16.1.1.1, S:P1263L, from sars-cov-2-variants/lineage-proposals#1448"
+  },
+  {
+    "Lineage": "LF.1.1.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.16.1.1.1.1, S:S31-, T19209C,from sars-cov-2-variants/lineage-proposals#1502"
+  },
+  {
+    "Lineage": "LF.2",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.16.1.2, ORF1a:K247R, ORF3a:Y184H, many with S:S31del, from sars-cov-2-variants/lineage-proposals#1502"
+  },
+  {
+    "Lineage": "LF.3",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.16.1.3, ORF1a:A4285V, Peru"
+  },
+  {
+    "Lineage": "LF.3.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.16.1.3.1, S:445P，from sars-cov-2-variants/lineage-proposals#1558"
+  },
+  {
+    "Lineage": "LF.3.1.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.16.1.3.1.1, S:L1143F, USA-CO, from sars-cov-2-variants/lineage-proposals#1558"
+  },
+  {
+    "Lineage": "LF.4",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.16.1.4, N:R385K, ORF1a:T4368I"
+  },
+  {
+    "Lineage": "LF.4.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.16.1.4.1, S:31del, ORF1a:G519S, ORF8:Q29*, from sars-cov-2-variants/lineage-proposals#1590"
+  },
+  {
+    "Lineage": "LF.5",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.16.1.5, S:T33A, S:N185D, C28660T"
+  },
+  {
+    "Lineage": "LF.6",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.16.1.6, T3172G, T17859C, Portugal/Spain, from #2589"
+  },
+  {
+    "Lineage": "LF.7",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.16.1.7, S:T22N, S:S31P, S:K182R, S:R190S, S:K444R, ORF9b:I5T, Senegal, from #2733"
+  },
+  {
+    "Lineage": "LF.8",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.16.1.8, S:M153I, C3244T, A18432T, C27110T"
+  },
+  {
+    "Lineage": "LF.8.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.16.1.8.1, S:S31F"
+  },
+  {
+    "Lineage": "LF.8.1.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.16.1.8.1, S:T22N"
+  },
+  {
+    "Lineage": "LF.9",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.16.1.9, S:S60P"
+  },
+  {
+    "Lineage": "LF.9.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.16.1.9.1, S:N185D"
+  },
+  {
+    "Lineage": "JN.1.16.2",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.16.2, C4777T, from sars-cov-2-variants/lineage-proposals#1253"
+  },
+  {
+    "Lineage": "LA.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.16.2.1, S:R346T, from sars-cov-2-variants/lineage-proposals#1253"
+  },
+  {
+    "Lineage": "LA.2",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.16.2.2, S:R346I, from sars-cov-2-variants/lineage-proposals#1089"
+  },
+  {
+    "Lineage": "JN.1.16.3",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.16.3, S:T572I"
+  },
+  {
+    "Lineage": "JN.1.16.4",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.16.4, S:Q493E, ORF1a:G400S, ORF7a:F59K, East Asia"
+  },
+  {
+    "Lineage": "MT.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.16.4.1, S:S31P, N:P279S"
+  },
+  {
+    "Lineage": "JN.1.16.5",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.16.5, S:T22N, S:Q493E"
+  },
+  {
+    "Lineage": "JN.1.17",
+    "Earliest date": "2023-02-08",
+    "Latest date": "2024-04-04",
+    "Description": "Alias of B.1.1.529.2.86.1.1.17, S:A222V, USA"
+  },
+  {
+    "Lineage": "JN.1.18",
+    "Earliest date": "2023-11-02",
+    "Latest date": "2024-08-22",
+    "Description": "Alias of B.1.1.529.2.86.1.1.18, S:R346T, directly on JN.1 polytomy, from sars-cov-2-variants/lineage-proposals#1089"
+  },
+  {
+    "Lineage": "JN.1.18.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.18.1, S:T250N, from sars-cov-2-variants/lineage-proposals#1414"
+  },
+  {
+    "Lineage": "LQ.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.18.1.1, S:F456L (22928C),from #2596"
+  },
+  {
+    "Lineage": "LQ.1.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.18.1.1.1, S:P272H,from #2596"
+  },
+  {
+    "Lineage": "LQ.2",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.18.1.2, S:N556K, China,from sars-cov-2-variants/lineage-proposals#1414"
+  },
+  {
+    "Lineage": "LQ.3",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.18.1.3, ORF1a:T1761I, Russia"
+  },
+  {
+    "Lineage": "JN.1.18.2",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.18.2, S:F59S, after C4331T, T22321C, from sars-cov-2-variants/lineage-proposals#1441"
+  },
+  {
+    "Lineage": "LZ.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.18.2.1, S:F456L (T22930A), N:A152T, ORF1a:I740V from #2654"
+  },
+  {
+    "Lineage": "LZ.1.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.18.2.1.1, S:P217S, S:N1125S from #2654"
+  },
+  {
+    "Lineage": "LZ.2",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.18.2.2, S:F456L (T22928C), ORF1a:K1226E, China"
+  },
+  {
+    "Lineage": "JN.1.18.3",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.18.3, S:F456V (T22928G), from sars-cov-2-variants/lineage-proposals#1253"
+  },
+  {
+    "Lineage": "MA.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.18.3.1, S:R190S, S:31del, from sars-cov-2-variants/lineage-proposals#1635"
+  },
+  {
+    "Lineage": "MA.1.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.18.3.1.1, S:E780A"
+  },
+  {
+    "Lineage": "MA.1.1.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.18.3.1.1.1, S:H445P"
+  },
+  {
+    "Lineage": "JN.1.18.4",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.18.4, S:F456L (T22930G), ORF6:I60T, T23036C, Ghana from #2567"
+  },
+  {
+    "Lineage": "LH.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.18.4.1, S:K182I from #2567"
+  },
+  {
+    "Lineage": "LH.2",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.18.4.2, S:I197V, S:P251H from #2567"
+  },
+  {
+    "Lineage": "JN.1.18.5",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.18.5, S:F456L (T22930A), from sars-cov-2-variants/lineage-proposals#1089"
+  },
+  {
+    "Lineage": "LS.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.18.5.1, S:Y28H, S:L189A, S:184-188del, ORF1a:E940D"
+  },
+  {
+    "Lineage": "JN.1.18.6",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.18.6, S:F456L (T22928C), S:F59S from #2623"
+  },
+  {
+    "Lineage": "LY.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.18.6.1, S:F65Y, S:Q183P from #2623"
+  },
+  {
+    "Lineage": "LY.2",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.18.6.2, S:Q183H, C2143T"
+  },
+  {
+    "Lineage": "JN.1.18.7",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.18.7, S:T22N, S:F59S, S:D1260Y from #2623"
+  },
+  {
+    "Lineage": "MN.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.18.7.1, S:D80Y, S:P174S, S:S689N, England/Wales"
+  },
+  {
+    "Lineage": "JN.1.18.8",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.18.8, S:S31del, ORF1a:A690V, ORF1b:S2339F, France"
+  },
+  {
+    "Lineage": "JN.1.19",
+    "Earliest date": "2023-10-02",
+    "Latest date": "2024-07-06",
+    "Description": "Alias of B.1.1.529.2.86.1.1.19, ORF8:I71V"
+  },
+  {
+    "Lineage": "JN.1.20",
+    "Earliest date": "2023-01-02",
+    "Latest date": "2024-07-22",
+    "Description": "Alias of B.1.1.529.2.86.1.1.20, S:S31F, directly on JN.1 polytomy"
+  },
+  {
+    "Lineage": "JN.1.21",
+    "Earliest date": "2023-11-08",
+    "Latest date": "2024-05-28",
+    "Description": "Alias of B.1.1.529.2.86.1.1.21, S:H1058Y, from sars-cov-2-variants/lineage-proposals#1162"
+  },
+  {
+    "Lineage": "JN.1.22",
+    "Earliest date": "2023-10-22",
+    "Latest date": "2024-08-12",
+    "Description": "Alias of B.1.1.529.2.86.1.1.22, ORF1a:S505F, C13019T, from #2465"
+  },
+  {
+    "Lineage": "JN.1.23",
+    "Earliest date": "2024-01-01",
+    "Latest date": "2024-07-24",
+    "Description": "Alias of B.1.1.529.2.86.1.1.23, S:K444R, S:Y453F, ORF1a:A307V, ORF1a:P2144L, Brazil, from #2488"
+  },
+  {
+    "Lineage": "JN.1.23.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.23.1, S:V1264L, S:N137K, Brazil, from sars-cov-2-variants/lineage-proposals#1552"
+  },
+  {
+    "Lineage": "JN.1.24",
+    "Earliest date": "2023-11-10",
+    "Latest date": "2024-06-17",
+    "Description": "Alias of B.1.1.529.2.86.1.1.24, S:C1243F, USA"
+  },
+  {
+    "Lineage": "JN.1.24.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.24.1, S:R346T, from sars-cov-2-variants/lineage-proposals#1089"
+  },
+  {
+    "Lineage": "JN.1.25",
+    "Earliest date": "2023-12-12",
+    "Latest date": "2024-03-15",
+    "Description": "Alias of B.1.1.529.2.86.1.1.25, C706T, A7708T, India"
+  },
+  {
+    "Lineage": "JN.1.25.1",
+    "Earliest date": "2023-12-17",
+    "Latest date": "2024-07-15",
+    "Description": "Alias of B.1.1.529.2.86.1.1.25.1, S:R346T, India"
+  },
+  {
+    "Lineage": "LM.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.25.1.1, S:F456L, from sars-cov-2-variants/lineage-proposals#1089"
+  },
+  {
+    "Lineage": "JN.1.26",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.26, S:R346T, after C26894T, USA, from sars-cov-2-variants/lineage-proposals#1089"
+  },
+  {
+    "Lineage": "JN.1.27",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.27, S:M153I, after C26894T, C25680T, USA, from sars-cov-2-variants/lineage-proposals#1403"
+  },
+  {
+    "Lineage": "JN.1.28",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.28, C24034T, A29700G, East Asia/Oceania"
+  },
+  {
+    "Lineage": "JN.1.28.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.28.1, ORF1a:P1640L, C19545T, C24370T, from sars-cov-2-variants/lineage-proposals#1244"
+  },
+  {
+    "Lineage": "KW.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.28.1.1, S:T572I, Australia, from sars-cov-2-variants/lineage-proposals#1244"
+  },
+  {
+    "Lineage": "KW.1.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.28.1.1.1, S:F456L (T22928C), ORF1b:R2009K, Australia/Japan, from sars-cov-2-variants/lineage-proposals#1244"
+  },
+  {
+    "Lineage": "KW.1.1.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.28.1.1.1.1, S:T95S, Australia, from sars-cov-2-variants/lineage-proposals#1504"
+  },
+  {
+    "Lineage": "LG.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.28.1.1.1.1.1, S:R346T, Australia, from sars-cov-2-variants/lineage-proposals#1504"
+  },
+  {
+    "Lineage": "KW.1.2",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.28.1.1.2, S:K529T, Australia"
+  },
+  {
+    "Lineage": "JN.1.29",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.29, ORF1a:T3224A, after C2644T, Brazil"
+  },
+  {
+    "Lineage": "JN.1.29.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.29.1, S:F456L, from sars-cov-2-variants/lineage-proposals#1253"
+  },
+  {
+    "Lineage": "MJ.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.29.1.1, S:R346T, S:S31P, ORF1a:E2070K"
+  },
+  {
+    "Lineage": "JN.1.30",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.30, G21255T"
+  },
+  {
+    "Lineage": "JN.1.30.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.30.1, S:R346T, after T7789C, India, from sars-cov-2-variants/lineage-proposals#1089"
+  },
+  {
+    "Lineage": "KU.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.30.1.1, S:K182Q"
+  },
+  {
+    "Lineage": "KU.2",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.30.1.2, S:F456L (T22928C), from sars-cov-2-variants/lineage-proposals#1089"
+  },
+  {
+    "Lineage": "KU.2.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.30.1.2.1, S:S60P, USA"
+  },
+  {
+    "Lineage": "KU.2.2",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.30.1.2.2, S:G213E, UK"
+  },
+  {
+    "Lineage": "JN.1.31",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.31, ORF3a:V13L, C19186T, from sars-cov-2-variants/lineage-proposals#1319"
+  },
+  {
+    "Lineage": "JN.1.32",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.32, S:T572I, directly on JN.1 polytomy"
+  },
+  {
+    "Lineage": "JN.1.32.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.32.1, S:Q183H, from sars-cov-2-variants/lineage-proposals#1442"
+  },
+  {
+    "Lineage": "JN.1.34",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.34, S:S704L"
+  },
+  {
+    "Lineage": "JN.1.35",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.35, S:S680Y, after T18471C, Australia/New Zealand, from sars-cov-2-variants/lineage-proposals#1362"
+  },
+  {
+    "Lineage": "JN.1.36",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.36, S:Q677H, after A29086T, from sars-cov-2-variants/lineage-proposals#1326"
+  },
+  {
+    "Lineage": "JN.1.36.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.36.1, S:S680F, South Korea, from sars-cov-2-variants/lineage-proposals#1326"
+  },
+  {
+    "Lineage": "JN.1.37",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.37, S:S680F"
+  },
+  {
+    "Lineage": "JN.1.38",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.38, ORF1b:R1736K, USA"
+  },
+  {
+    "Lineage": "JN.1.38.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.38.1, S:G35S, ORF3a:G100S, USA, from #2475"
+  },
+  {
+    "Lineage": "JN.1.39",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.39, G2782T"
+  },
+  {
+    "Lineage": "JN.1.39.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.39.1, S:R346T, S:F456L (T22928C), C21034T, T25631C, A16011G, T6913C, from sars-cov-2-variants/lineage-proposals#1089"
+  },
+  {
+    "Lineage": "JN.1.39.2",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.39.2, S:R346T, T111C"
+  },
+  {
+    "Lineage": "JN.1.39.3",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.39.3, S:A67V, T111C, C5512T, China from #2498 (originally known as JN.1.33)"
+  },
+  {
+    "Lineage": "JN.1.40",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.40, S:S31P, Mexico, from sars-cov-2-variants/lineage-proposals#1451"
+  },
+  {
+    "Lineage": "JN.1.41",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.41, S:S1252F, on A29086T, USA, from sars-cov-2-variants/lineage-proposals#1256"
+  },
+  {
+    "Lineage": "JN.1.42",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.42, C5581A, South America"
+  },
+  {
+    "Lineage": "JN.1.42.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.42.1, S:F59S, from sars-cov-2-variants/lineage-proposals#1474"
+  },
+  {
+    "Lineage": "JN.1.42.2",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.42.2, S:R346T, Peru from #2494"
+  },
+  {
+    "Lineage": "MS.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.42.2.1, S:31del, ORF1a:E940G, USA/Guatemala"
+  },
+  {
+    "Lineage": "JN.1.43",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.43, A25237G"
+  },
+  {
+    "Lineage": "JN.1.43.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.43.1, C19488T, C29218T, Brazil"
+  },
+  {
+    "Lineage": "JN.1.44",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.44, ORF6:P57L, from sars-cov-2-variants/lineage-proposals#987"
+  },
+  {
+    "Lineage": "JN.1.44.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.44.1, S:R346T, Cameroon/France,from sars-cov-2-variants/lineage-proposals#1089"
+  },
+  {
+    "Lineage": "JN.1.45",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.45, G18756T"
+  },
+  {
+    "Lineage": "JN.1.46",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.46, ORF1a:L3116F, T4885C"
+  },
+  {
+    "Lineage": "JN.1.47",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.47, C8074T, C7594T"
+  },
+  {
+    "Lineage": "JN.1.47.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.47.1, S:S221L, USA/Mexico, from sars-cov-2-variants/lineage-proposals#1318"
+  },
+  {
+    "Lineage": "JN.1.47.2",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.47.2, S:T572I, S:R683Q, USA, from sars-cov-2-variants/lineage-proposals#1097"
+  },
+  {
+    "Lineage": "JN.1.48",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.48, G29134T, after T18471C, India"
+  },
+  {
+    "Lineage": "JN.1.48.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.48.1, S:S60P, S:R346T, S:F456L (T22928C), after ORF3a:A99V, on T3913A, C8092T branch from #2547"
+  },
+  {
+    "Lineage": "LD.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.48.1.1, S:T572I from #2547"
+  },
+  {
+    "Lineage": "JN.1.48.2",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.48.2, S:R346T, ORF1a:A427V, A3829G, India, from sars-cov-2-variants/lineage-proposals#1089"
+  },
+  {
+    "Lineage": "JN.1.48.3",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.48.3, S:60P, S:R346T, S:F456L, ORF3a:S60F, ORF1a:T1761I, on T3913A, C8092T branch, South Africa"
+  },
+  {
+    "Lineage": "JN.1.49",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.49, ORF3a:T89I, India"
+  },
+  {
+    "Lineage": "JN.1.49.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.49.1, S:R346T"
+  },
+  {
+    "Lineage": "MB.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.49.1.1, S:F456V (T22928G), S:S31F"
+  },
+  {
+    "Lineage": "MB.1.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.49.1.1.1, S:T22N, S:K182N, from sars-cov-2-variants/lineage-proposals#1659"
+  },
+  {
+    "Lineage": "MB.1.1.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.49.1.1.1.1, ORF1a:T224I, India"
+  },
+  {
+    "Lineage": "MV.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.49.1.1.1.1.1, S:K478T, India"
+  },
+  {
+    "Lineage": "JN.1.49.2",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.49.2, S:F456L (T22930A)"
+  },
+  {
+    "Lineage": "JN.1.50",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.50, S:A67V, S:L249F, S:H445P, S:F456L (T22930G), Europe from #2587"
+  },
+  {
+    "Lineage": "JN.1.50.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.50.1, S:R346T from #2587"
+  },
+  {
+    "Lineage": "JN.1.50.2",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.50.2, ORF1a:N1540S (A4884G, T4885C)"
+  },
+  {
+    "Lineage": "ME.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.50.2.1, S:R346K"
+  },
+  {
+    "Lineage": "JN.1.51",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.51, C4795T"
+  },
+  {
+    "Lineage": "JN.1.51.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.51.1, S:F456L"
+  },
+  {
+    "Lineage": "LJ.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.51.1.1, S:T22N"
+  },
+  {
+    "Lineage": "JN.1.52",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.52, ORF1a:K3353R"
+  },
+  {
+    "Lineage": "JN.1.53",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.53, C15720T, Senegal"
+  },
+  {
+    "Lineage": "JN.1.53.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.53.1, C583T"
+  },
+  {
+    "Lineage": "LN.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.53.1.1, S:R346T"
+  },
+  {
+    "Lineage": "LN.1.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.53.1.1.1, S:F456L, S:478I"
+  },
+  {
+    "Lineage": "JN.1.54",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.54, A9085G"
+  },
+  {
+    "Lineage": "JN.1.54.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.54.1, S:F456L, S:V407I, Spain, from #2584"
+  },
+  {
+    "Lineage": "JN.1.55",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.55, ORF1a:K399R"
+  },
+  {
+    "Lineage": "JN.1.55.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.55.1, S:F456L, ORF1a:T1017I, Thailand, from sars-cov-2-variants/lineage-proposals#1253"
+  },
+  {
+    "Lineage": "JN.1.55.2",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.55.2, S:F456L, ORF1b:P2321H, Brazil, from sars-cov-2-variants/lineage-proposals#1253"
+  },
+  {
+    "Lineage": "JN.1.56",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.56, Orf3a:Q213K"
+  },
+  {
+    "Lineage": "JN.1.56.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.56.1, S:G181R, S:R346T, S:F456V, ORF1a:T1638I, Sinapore/South Korea from #2582"
+  },
+  {
+    "Lineage": "JN.1.57",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.57, ORF1b:A1219S, A11947G"
+  },
+  {
+    "Lineage": "JN.1.57.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.57.1, S:S60P, Taiwan/South Korea,from sars-cov-2-variants/lineage-proposals#1460"
+  },
+  {
+    "Lineage": "JN.1.58",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.58, ORF1b:K2557R"
+  },
+  {
+    "Lineage": "JN.1.58.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.58.1, S:S60P"
+  },
+  {
+    "Lineage": "JN.1.58.2",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.58.2, S:R346T"
+  },
+  {
+    "Lineage": "LR.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.58.2.1, S:F456L (22928C)"
+  },
+  {
+    "Lineage": "LR.2",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.58.2.2, S:F456V"
+  },
+  {
+    "Lineage": "LR.3",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.58.2.3, S:F456L (22930A), USA/Puerto Rico"
+  },
+  {
+    "Lineage": "JN.1.58.3",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.58.3, S:S31F"
+  },
+  {
+    "Lineage": "JN.1.59",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.59, ORF1a:A1204S"
+  },
+  {
+    "Lineage": "JN.1.59.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.59.1, S:S31del, S:R190S, S:R346T, ORF1a:I841V, Americas"
+  },
+  {
+    "Lineage": "JN.1.60",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.60, C4543T"
+  },
+  {
+    "Lineage": "JN.1.61",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.61, S:K444R, Brazil"
+  },
+  {
+    "Lineage": "JN.1.62",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.62, S:F456L (22928C), S:V62F, S:R681H, from sars-cov-2-variants/lineage-proposals#1253"
+  },
+  {
+    "Lineage": "JN.1.63",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.63, ORF1b:K82R"
+  },
+  {
+    "Lineage": "JN.1.63.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.63.1, ORF1a:D1513E, ORF1a:A2529S, Asia"
+  },
+  {
+    "Lineage": "JN.1.64",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.64, ORF1a:N2147S (A6705G) from #2560"
+  },
+  {
+    "Lineage": "JN.1.64.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.64.1, S:R346T from #2560"
+  },
+  {
+    "Lineage": "MD.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.64.1.1, S:F456L (T22930A) from #2560"
+  },
+  {
+    "Lineage": "MD.1.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.64.1.1.1, S:K679R from #2560"
+  },
+  {
+    "Lineage": "MD.2",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.64.1.2, S:F456V, ORF1a:T2800I from #2560"
+  },
+  {
+    "Lineage": "MD.3",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.64.1.3, C1060T, C9319T, C28657T from #2560"
+  },
+  {
+    "Lineage": "MD.3.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.64.1.3.1, S:F456L (T22928C), ORF3a:L106F, C10138T, South Africa from #2560"
+  },
+  {
+    "Lineage": "JN.1.65",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.65, S:T572I, after T23629C, G25647T, A5053G, Spain from #2461"
+  },
+  {
+    "Lineage": "JN.1.65.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.65.1, S:F456L (22928C), A10420G, C5884T, C29149T, C20483T, Spain from #2461"
+  },
+  {
+    "Lineage": "MF.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.65.1.1, S:R346T, T21673C, pre-22981T from #2461"
+  },
+  {
+    "Lineage": "MF.2",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.65.1.2, S:S60P, S:W64L from #2461"
+  },
+  {
+    "Lineage": "JN.1.66",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.66, S:H445P, S:F456L (T22930A), S:T1117I, ORF1a:L2146F, ORF3a:L106F, Iceland/Sweden"
+  },
+  {
+    "Lineage": "JN.1.67",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.67, M:L46F"
+  },
+  {
+    "Lineage": "JN.1.67.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.1.67.1, S:F456L, China"
+  },
+  {
+    "Lineage": "JN.2",
+    "Earliest date": "2022-10-22",
+    "Latest date": "2024-07-02",
+    "Description": "Alias of B.1.1.529.2.86.1.2, ORF1a:Y621C, Europe/North America, from #2284"
+  },
+  {
+    "Lineage": "JN.2.1",
+    "Earliest date": "2023-09-11",
+    "Latest date": "2024-03-30",
+    "Description": "Alias of B.1.1.529.2.86.1.2.1, S:S31F, Sweden/Australia"
+  },
+  {
+    "Lineage": "JN.2.2",
+    "Earliest date": "2023-10-27",
+    "Latest date": "2024-06-24",
+    "Description": "Alias of B.1.1.529.2.86.1.2.2, S:T572I, N:G25C, ORF1a:L3644F, Netherlands, from #2433"
+  },
+  {
+    "Lineage": "JN.2.2.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.2.2.1, S:N487D, Netherlands"
+  },
+  {
+    "Lineage": "JN.2.3",
+    "Earliest date": "2023-10-01",
+    "Latest date": "2024-02-21",
+    "Description": "Alias of B.1.1.529.2.86.1.2.3, S:V193L, from #2442"
+  },
+  {
+    "Lineage": "JN.2.4",
+    "Earliest date": "2023-10-02",
+    "Latest date": "2024-02-12",
+    "Description": "Alias of B.1.1.529.2.86.1.2.4, S:L242F, Sweden"
+  },
+  {
+    "Lineage": "JN.2.5",
+    "Earliest date": "2023-10-30",
+    "Latest date": "2024-05-10",
+    "Description": "Alias of B.1.1.529.2.86.1.2.5, S:L455S, Canada, USA, Lithuania, from sars-cov-2-variants/lineage-proposals#1173"
+  },
+  {
+    "Lineage": "JN.3",
+    "Earliest date": "2022-10-18",
+    "Latest date": "2024-03-26",
+    "Description": "Alias of B.1.1.529.2.86.1.3, ORF1a:T2087I, Europe, from sars-cov-2-variants/lineage-proposals#892"
+  },
+  {
+    "Lineage": "JN.3.1",
+    "Earliest date": "2023-08-27",
+    "Latest date": "2024-01-31",
+    "Description": "Alias of B.1.1.529.2.86.1.3.1, S:L922F, ORF7a:T28I, Spain"
+  },
+  {
+    "Lineage": "JN.3.2",
+    "Earliest date": "2023-09-18",
+    "Latest date": "2024-01-12",
+    "Description": "Alias of B.1.1.529.2.86.1.3.2, N:H300Y, ORF1a:P892S, from #2445"
+  },
+  {
+    "Lineage": "JN.3.2.1",
+    "Earliest date": "2023-11-07",
+    "Latest date": "2024-05-13",
+    "Description": "Alias of B.1.1.529.2.86.1.3.2.1, S:F456V, N:S327L, Germany, from #2445"
+  },
+  {
+    "Lineage": "JN.3.3",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.3.3, A5641G, C14478T, C21676T"
+  },
+  {
+    "Lineage": "JN.4",
+    "Earliest date": "2022-10-18",
+    "Latest date": "2024-04-21",
+    "Description": "Alias of B.1.1.529.2.86.1.4, S:A475V, lacking C12815T of most BA.2.86.1, Belgium/Netherlands/Denmark, from sars-cov-2-variants/lineage-proposals#1009"
+  },
+  {
+    "Lineage": "JN.5",
+    "Earliest date": "2023-08-21",
+    "Latest date": "2024-03-23",
+    "Description": "Alias of B.1.1.529.2.86.1.5, N:T135I"
+  },
+  {
+    "Lineage": "JN.5.1",
+    "Earliest date": "2023-10-19",
+    "Latest date": "2023-12-30",
+    "Description": "Alias of B.1.1.529.2.86.1.5.1, S:A475S, T2950A, A28052G, C29541T, England/Belgium, from sars-cov-2-variants/lineage-proposals#954"
+  },
+  {
+    "Lineage": "JN.6",
+    "Earliest date": "2023-09-12",
+    "Latest date": "2024-06-26",
+    "Description": "Alias of B.1.1.529.2.86.1.6, S:V193L"
+  },
+  {
+    "Lineage": "JN.7",
+    "Earliest date": "2023-08-14",
+    "Latest date": "2024-06-17",
+    "Description": "Alias of B.1.1.529.2.86.1.7, S:G594S, Denmark, from sars-cov-2-variants/lineage-proposals#856"
+  },
+  {
+    "Lineage": "JN.8",
+    "Earliest date": "2023-08-13",
+    "Latest date": "2024-03-12",
+    "Description": "Alias of B.1.1.529.2.86.1.8, S:T299I, Sweden/Denmark"
+  },
+  {
+    "Lineage": "JN.9",
+    "Earliest date": "2023-08-21",
+    "Latest date": "2024-04-07",
+    "Description": "Alias of B.1.1.529.2.86.1.9, S:M1229I, Netherlands"
+  },
+  {
+    "Lineage": "JN.10",
+    "Earliest date": "2022-10-18",
+    "Latest date": "2024-05-01",
+    "Description": "Alias of B.1.1.529.2.86.1.10, S:A475V, on T3565C branch with JN.1, Spain/France, from sars-cov-2-variants/lineage-proposals#954"
+  },
+  {
+    "Lineage": "JN.11",
+    "Earliest date": "2023-04-12",
+    "Latest date": "2024-07-02",
+    "Description": "Alias of B.1.1.529.2.86.1.11, S:V1104L, Asia, from sars-cov-2-variants/lineage-proposals#1303"
+  },
+  {
+    "Lineage": "JN.11.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.11.1, S:L455S, from sars-cov-2-variants/lineage-proposals#1303"
+  },
+  {
+    "Lineage": "JN.12",
+    "Earliest date": "2023-11-09",
+    "Latest date": "2024-04-12",
+    "Description": "Alias of B.1.1.529.2.86.1.12, S:F456V, ORF1a:A498G, from sars-cov-2-variants/lineage-proposals#1102"
+  },
+  {
+    "Lineage": "JN.13",
+    "Earliest date": "2023-10-13",
+    "Latest date": "2024-04-30",
+    "Description": "Alias of B.1.1.529.2.86.1.13, A14397G"
+  },
+  {
+    "Lineage": "JN.13.1",
+    "Earliest date": "2023-10-19",
+    "Latest date": "2024-05-02",
+    "Description": "Alias of B.1.1.529.2.86.1.13.1, S:A475V, USA/Malaysia, from sars-cov-2-variants/lineage-proposals#1386"
+  },
+  {
+    "Lineage": "JN.14",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.14, C29614T, S:S680F, Thailand/Japan，from #2424"
+  },
+  {
+    "Lineage": "JN.15",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.15, C24319T, Japan"
+  },
+  {
+    "Lineage": "JN.16",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.16, ORF3a:T229I, Japan"
+  },
+  {
+    "Lineage": "JN.17",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.17, C12781T, Japan"
+  },
+  {
+    "Lineage": "JN.18",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.18, T11614C"
+  },
+  {
+    "Lineage": "JN.19",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.1.19, A14601G, Japan"
+  },
+  {
+    "Lineage": "BA.2.86.2",
+    "Earliest date": "2023-07-24",
+    "Latest date": "2024-05-23",
+    "Description": "Alias of B.1.1.529.2.86.2, ORF7a:E22D, South Africa/Botswana，from sars-cov-2-variants/lineage-proposals/issues/756"
+  },
+  {
+    "Lineage": "BA.2.86.3",
+    "Earliest date": "2023-08-10",
+    "Latest date": "2024-05-05",
+    "Description": "Alias of B.1.1.529.2.86.3, C222T, C1960T, T12775C, South Africa"
+  },
+  {
+    "Lineage": "JQ.1",
+    "Earliest date": "2023-08-17",
+    "Latest date": "2024-02-19",
+    "Description": "Alias of B.1.1.529.2.86.3.1, S:T95I, Denmark/France/South Africa, from sars-cov-2-variants/lineage-proposals#906"
+  },
+  {
+    "Lineage": "JQ.2",
+    "Earliest date": "2023-09-28",
+    "Latest date": "2024-07-14",
+    "Description": "Alias of B.1.1.529.2.86.3.2, S:R346T, G2944A, South Africa, from #2505"
+  },
+  {
+    "Lineage": "JQ.2.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.3.2.1, S:L455S, South Africa, from sars-cov-2-variants/lineage-proposals#1373"
+  },
+  {
+    "Lineage": "JQ.2.1.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.3.2.1.1, S:F456L (T22928C), South Africa, from sars-cov-2-variants/lineage-proposals#1089"
+  },
+  {
+    "Lineage": "JQ.2.1.2",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.3.2.1.2, S:T572I, ORF1b:Q813H, Southern Africa"
+  },
+  {
+    "Lineage": "BA.2.86.4",
+    "Earliest date": "2023-09-14",
+    "Latest date": "2024-02-12",
+    "Description": "Alias of B.1.1.529.2.86.4, S:A222V, ORF1a:V3892A, from sars-cov-2-variants/lineage-proposals#1032"
+  },
+  {
+    "Lineage": "BA.2.86.5",
+    "Earliest date": "2023-10-02",
+    "Latest date": "2024-01-26",
+    "Description": "Alias of B.1.1.529.2.86.5, S:I197V, C5575T, T6085C, T23278C"
+  },
+  {
+    "Lineage": "BA.2.86.6",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.6, C9226T"
+  },
+  {
+    "Lineage": "LV.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.6.1, ORF1b:D294N"
+  },
+  {
+    "Lineage": "LV.2",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.6.2, S:R346T, S:L455S, S:F456L, ORF1a:E148G, ORF1a:W630C, ORF1a:G1069R, ORF1a:G3546D, ORF1b:A520V"
+  },
+  {
+    "Lineage": "BA.2.86.7",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.7, ORF1b:Y1344H, T10819C, C28720T, South Africa"
+  },
+  {
+    "Lineage": "MP.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.7.1, S:N487D, Southern Africa"
+  },
+  {
+    "Lineage": "MP.1.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of B.1.1.529.2.86.7.1.1, S:R346T, S:A348P, Southern Africa"
+  },
+  {
+    "Lineage": "BA.2.87",
+    "Earliest date": "2021-12-20",
+    "Latest date": "2022-05-16",
+    "Description": "Alias of B.1.1.529.2.87, C18744T, no C9866T"
+  },
+  {
+    "Lineage": "BA.2.87.1",
+    "Earliest date": "2023-09-20",
+    "Latest date": "2023-12-12",
+    "Description": "Alias of B.1.1.529.2.87.1, saltation with 15+ spike AA mutations, South Africa, from #2484"
+  },
+  {
+    "Lineage": "BA.3",
+    "Earliest date": "2021-11-23",
+    "Latest date": "2022-06-29",
+    "Description": "Alias of B.1.1.529.3, from #367"
+  },
+  {
+    "Lineage": "BA.3.1",
+    "Earliest date": "2022-01-01",
+    "Latest date": "2023-03-29",
+    "Description": "Alias of B.1.1.529.3.1, mainly found in Poland, from #540"
+  },
+  {
+    "Lineage": "BA.4",
+    "Earliest date": "2020-07-02",
+    "Latest date": "2023-10-03",
+    "Description": "Alias of B.1.1.529.4, from #517"
+  },
+  {
+    "Lineage": "BA.4.1",
+    "Earliest date": "2021-06-30",
+    "Latest date": "2023-06-24",
+    "Description": "Alias of B.1.1.529.4.1, mainly found in South Africa, from #548"
+  },
+  {
+    "Lineage": "BA.4.1.1",
+    "Earliest date": "2022-03-13",
+    "Latest date": "2022-12-01",
+    "Description": "Alias of B.1.1.529.4.1.1, mainly found in South Africa and Germany, from #667"
+  },
+  {
+    "Lineage": "BA.4.1.2",
+    "Earliest date": "2022-04-19",
+    "Latest date": "2022-08-15",
+    "Description": "Alias of B.1.1.529.4.1.2, Austria lineage, from #614"
+  },
+  {
+    "Lineage": "BA.4.1.3",
+    "Earliest date": "2020-10-14",
+    "Latest date": "2022-10-25",
+    "Description": "Alias of B.1.1.529.4.1.3, Israel lineage"
+  },
+  {
+    "Lineage": "BA.4.1.4",
+    "Earliest date": "2022-05-12",
+    "Latest date": "2022-11-28",
+    "Description": "Alias of B.1.1.529.4.1.4, Israel lineage"
+  },
+  {
+    "Lineage": "BA.4.1.5",
+    "Earliest date": "2022-04-24",
+    "Latest date": "2022-10-28",
+    "Description": "Alias of B.1.1.529.4.1.5, Israel lineage"
+  },
+  {
+    "Lineage": "BA.4.1.6",
+    "Earliest date": "2022-05-07",
+    "Latest date": "2022-11-29",
+    "Description": "Alias of B.1.1.529.4.1.6, USA lineage"
+  },
+  {
+    "Lineage": "BA.4.1.7",
+    "Earliest date": "2022-05-22",
+    "Latest date": "2022-08-22",
+    "Description": "Alias of B.1.1.529.4.1.7, Australia lineage"
+  },
+  {
+    "Lineage": "BA.4.1.8",
+    "Earliest date": "2022-04-19",
+    "Latest date": "2023-06-27",
+    "Description": "Alias of B.1.1.529.4.1.8, mainly found in England, USA, South Africa and Mexico, from #800"
+  },
+  {
+    "Lineage": "BA.4.1.9",
+    "Earliest date": "2021-12-22",
+    "Latest date": "2023-05-19",
+    "Description": "Alias of B.1.1.529.4.1.9, mainly found in Zambia, USA, England and Mexico, from #926"
+  },
+  {
+    "Lineage": "BA.4.1.10",
+    "Earliest date": "2022-06-30",
+    "Latest date": "2022-12-28",
+    "Description": "Alias of B.1.1.529.4.1.10, mainly found in France, defined by S:N354D, S:R346T, from #1073"
+  },
+  {
+    "Lineage": "BA.4.1.11",
+    "Earliest date": "2022-11-09",
+    "Latest date": "2023-06-22",
+    "Description": "Alias of B.1.1.529.4.1.11 found mainly in Denmark, from #1606"
+  },
+  {
+    "Lineage": "CS.1",
+    "Earliest date": "2022-08-14",
+    "Latest date": "2022-10-28",
+    "Description": "Alias of B.1.1.529.4.1.10.1, Denmark, Netherlands, England, defined by S:K444R"
+  },
+  {
+    "Lineage": "BA.4.2",
+    "Earliest date": "2022-01-19",
+    "Latest date": "2023-04-18",
+    "Description": "Alias of B.1.1.529.4.2, USA lineage"
+  },
+  {
+    "Lineage": "BA.4.3",
+    "Earliest date": "2020-10-13",
+    "Latest date": "2022-08-26",
+    "Description": "Alias of B.1.1.529.4.3, Israel lineage"
+  },
+  {
+    "Lineage": "BA.4.4",
+    "Earliest date": "2020-07-20",
+    "Latest date": "2024-02-28",
+    "Description": "Alias of B.1.1.529.4.4, USA lineage"
+  },
+  {
+    "Lineage": "BA.4.5",
+    "Earliest date": "2022-04-12",
+    "Latest date": "2022-11-15",
+    "Description": "Alias of B.1.1.529.4.5, Australia lineage"
+  },
+  {
+    "Lineage": "BA.4.6",
+    "Earliest date": "2020-02-02",
+    "Latest date": "2024-06-24",
+    "Description": "Alias of B.1.1.529.4.6, mainly found in USA, England and Denmark, from #741"
+  },
+  {
+    "Lineage": "BA.4.6.1",
+    "Earliest date": "2022-05-26",
+    "Latest date": "2023-03-07",
+    "Description": "Alias of B.1.1.529.4.6.1, mainly found in UK, USA and Germany, from #900"
+  },
+  {
+    "Lineage": "BA.4.6.2",
+    "Earliest date": "2022-08-11",
+    "Latest date": "2023-03-21",
+    "Description": "Alias of B.1.1.529.4.6.2, Dominican Republic, USA, defined by S:V445A, from #1198"
+  },
+  {
+    "Lineage": "BA.4.6.3",
+    "Earliest date": "2022-07-21",
+    "Latest date": "2023-04-03",
+    "Description": "Alias of B.1.1.529.4.6.3, defined by S:444N, S:460K, S:144-, from #1195"
+  },
+  {
+    "Lineage": "BA.4.6.4",
+    "Earliest date": "2022-05-23",
+    "Latest date": "2023-01-23",
+    "Description": "Alias of B.1.1.529.4.6.4, Oceania, defined by ORF7a:Q62H"
+  },
+  {
+    "Lineage": "BA.4.6.5",
+    "Earliest date": "2022-05-19",
+    "Latest date": "2023-08-16",
+    "Description": "Alias of B.1.1.529.4.6.5, global, defined by ORF9b:N36S"
+  },
+  {
+    "Lineage": "DC.1",
+    "Earliest date": "2022-08-08",
+    "Latest date": "2023-02-14",
+    "Description": "Alias of B.1.1.529.4.6.5.1, global, defined by S:N460S"
+  },
+  {
+    "Lineage": "BA.4.7",
+    "Earliest date": "2020-07-25",
+    "Latest date": "2023-01-16",
+    "Description": "Alias of B.1.1.529.4.7, mainly found in England, South Africa and Scotland, from #777"
+  },
+  {
+    "Lineage": "BA.4.8",
+    "Earliest date": "2020-07-01",
+    "Latest date": "2022-11-05",
+    "Description": "Alias of B.1.1.529.4.8, mainly South Africa and Eswatini, from #670"
+  },
+  {
+    "Lineage": "BA.5",
+    "Earliest date": "2020-07-01",
+    "Latest date": "2024-05-12",
+    "Description": "Alias of B.1.1.529.5, from #517"
+  },
+  {
+    "Lineage": "BA.5.1",
+    "Earliest date": "2020-03-14",
+    "Latest date": "2024-04-22",
+    "Description": "Alias of B.1.1.529.5.1, Portugal lineage"
+  },
+  {
+    "Lineage": "BA.5.1.1",
+    "Earliest date": "2022-02-20",
+    "Latest date": "2023-04-07",
+    "Description": "Alias of B.1.1.529.5.1.1, USA lineage"
+  },
+  {
+    "Lineage": "BA.5.1.2",
+    "Earliest date": "2022-01-31",
+    "Latest date": "2023-04-10",
+    "Description": "Alias of B.1.1.529.5.1.2, mainly found in Denmark, Portugal and Luxembourg, from #790"
+  },
+  {
+    "Lineage": "BA.5.1.3",
+    "Earliest date": "2021-09-17",
+    "Latest date": "2023-04-03",
+    "Description": "Alias of B.1.1.529.5.1.3, mainly found in Germany Portugal and Spain, from #765"
+  },
+  {
+    "Lineage": "BA.5.1.4",
+    "Earliest date": "2022-05-25",
+    "Latest date": "2023-06-12",
+    "Description": "Alias of B.1.1.529.5.1.4, mainly found in Denmark and England, from #801"
+  },
+  {
+    "Lineage": "BA.5.1.5",
+    "Earliest date": "2022-04-26",
+    "Latest date": "2024-05-10",
+    "Description": "Alias of B.1.1.529.5.1.5, mainly found in UK, Denmark, and Belgium, from #835"
+  },
+  {
+    "Lineage": "BA.5.1.6",
+    "Earliest date": "2022-01-25",
+    "Latest date": "2023-11-21",
+    "Description": "Alias of B.1.1.529.5.1.6, Mexico lineage"
+  },
+  {
+    "Lineage": "BA.5.1.7",
+    "Earliest date": "2022-05-15",
+    "Latest date": "2023-01-14",
+    "Description": "Alias of B.1.1.529.5.1.7, Canada lineage"
+  },
+  {
+    "Lineage": "BA.5.1.8",
+    "Earliest date": "2022-05-13",
+    "Latest date": "2022-11-22",
+    "Description": "Alias of B.1.1.529.5.1.8, Peru lineage"
+  },
+  {
+    "Lineage": "BA.5.1.9",
+    "Earliest date": "2022-05-12",
+    "Latest date": "2023-01-11",
+    "Description": "Alias of B.1.1.529.5.1.9, mainly found in England, Luxembourg, Scotland and Ireland, from #786"
+  },
+  {
+    "Lineage": "BA.5.1.10",
+    "Earliest date": "2020-03-31",
+    "Latest date": "2023-08-09",
+    "Description": "Alias of B.1.1.529.5.1.10, mainly found in USA, Italy and England, from #901"
+  },
+  {
+    "Lineage": "BK.1",
+    "Earliest date": "2022-06-09",
+    "Latest date": "2023-05-25",
+    "Description": "Alias of B.1.1.529.5.1.10.1, mainly found in USA, and Canada, from #901"
+  },
+  {
+    "Lineage": "BA.5.1.11",
+    "Earliest date": "2022-05-28",
+    "Latest date": "2022-10-21",
+    "Description": "Alias of B.1.1.529.5.1.11, mainly found in Denmark, from #908"
+  },
+  {
+    "Lineage": "BA.5.1.12",
+    "Earliest date": "2022-02-08",
+    "Latest date": "2023-12-06",
+    "Description": "Alias of B.1.1.529.5.1.12, mainly found in Spain, from #902"
+  },
+  {
+    "Lineage": "BA.5.1.14",
+    "Earliest date": "2022-05-13",
+    "Latest date": "2024-06-11",
+    "Description": "Alias of B.1.1.529.5.1.14, mainly found in Brazil"
+  },
+  {
+    "Lineage": "BA.5.1.15",
+    "Earliest date": "2022-01-24",
+    "Latest date": "2023-07-06",
+    "Description": "Alias of B.1.1.529.5.1.15, Peru and Brazil lineage"
+  },
+  {
+    "Lineage": "DL.1",
+    "Earliest date": "2022-08-16",
+    "Latest date": "2023-07-13",
+    "Description": "Alias of B.1.1.529.5.1.15.1, found mainly in Brazil and USA, from #1376"
+  },
+  {
+    "Lineage": "BA.5.1.16",
+    "Earliest date": "2022-05-18",
+    "Latest date": "2023-01-04",
+    "Description": "Alias of B.1.1.529.5.1.16, Japan lineage"
+  },
+  {
+    "Lineage": "BA.5.1.17",
+    "Earliest date": "2021-11-15",
+    "Latest date": "2024-02-18",
+    "Description": "Alias of B.1.1.529.5.1.17, France lineage"
+  },
+  {
+    "Lineage": "BA.5.1.18",
+    "Earliest date": "2022-06-15",
+    "Latest date": "2023-03-20",
+    "Description": "Alias of B.1.1.529.5.1.18, mainly found in USA, from #930"
+  },
+  {
+    "Lineage": "BA.5.1.19",
+    "Earliest date": "2022-06-05",
+    "Latest date": "2023-02-06",
+    "Description": "Alias of B.1.1.529.5.1.19, mainly found in Netherlands, Germany, USA, and England, from #999"
+  },
+  {
+    "Lineage": "BA.5.1.20",
+    "Earliest date": "2022-06-23",
+    "Latest date": "2023-01-15",
+    "Description": "Alias of B.1.1.529.5.1.20, mainly found in USA and Belgium, from #1000"
+  },
+  {
+    "Lineage": "BA.5.1.21",
+    "Earliest date": "2022-02-08",
+    "Latest date": "2023-01-10",
+    "Description": "Alias of B.1.1.529.5.1.21, mainly found in Gambia and Japan, from #958"
+  },
+  {
+    "Lineage": "BT.1",
+    "Earliest date": "2022-06-07",
+    "Latest date": "2023-01-14",
+    "Description": "Alias of B.1.1.529.5.1.21.1, mainly found in Japan, from #958"
+  },
+  {
+    "Lineage": "BT.2",
+    "Earliest date": "2022-06-19",
+    "Latest date": "2023-01-09",
+    "Description": "Alias of B.1.1.529.5.1.21.2, mainly found in Denmark, Germany and France, from #1192"
+  },
+  {
+    "Lineage": "BA.5.1.22",
+    "Earliest date": "2021-07-16",
+    "Latest date": "2023-06-05",
+    "Description": "Alias of B.1.1.529.5.1.22, mainly found in Europe, defined by ORF1b:S1273L, from #1135"
+  },
+  {
+    "Lineage": "DH.1",
+    "Earliest date": "2022-08-27",
+    "Latest date": "2022-10-27",
+    "Description": "Alias of B.1.1.529.5.1.22.1, found mainly in Denmark, from #1242"
+  },
+  {
+    "Lineage": "BA.5.1.23",
+    "Earliest date": "2020-11-13",
+    "Latest date": "2023-10-20",
+    "Description": "Alias of B.1.1.529.5.1.23, mainly found in Spain, defined by ORF1a:S302F, from #1135"
+  },
+  {
+    "Lineage": "DE.1",
+    "Earliest date": "2022-02-24",
+    "Latest date": "2023-02-01",
+    "Description": "Alias of B.1.1.529.5.1.23.1, S:A694V"
+  },
+  {
+    "Lineage": "DE.2",
+    "Earliest date": "2022-09-16",
+    "Latest date": "2024-01-21",
+    "Description": "Alias of B.1.1.529.5.1.23.2, S:R346T, S:G181V, T4579A"
+  },
+  {
+    "Lineage": "BA.5.1.24",
+    "Earliest date": "2022-04-07",
+    "Latest date": "2023-03-05",
+    "Description": "Alias of B.1.1.529.5.1.24, mainly found in Finland, defined by ORF1b:V1271L, from #1135"
+  },
+  {
+    "Lineage": "BA.5.1.25",
+    "Earliest date": "2020-07-23",
+    "Latest date": "2024-02-28",
+    "Description": "Alias of B.1.1.529.5.1.25, mainly found in Mexico and Peru, defined by ORF7b:H42Y, from #1135"
+  },
+  {
+    "Lineage": "DJ.1",
+    "Earliest date": "2022-06-28",
+    "Latest date": "2022-11-29",
+    "Description": "Alias of B.1.1.529.5.1.25.1, found mainly in Peru, from #1245"
+  },
+  {
+    "Lineage": "DJ.1.1",
+    "Earliest date": "2022-08-04",
+    "Latest date": "2023-04-13",
+    "Description": "Alias of B.1.1.529.5.1.25.1.1, found in Peru, from #1245"
+  },
+  {
+    "Lineage": "DJ.1.1.1",
+    "Earliest date": "2022-09-16",
+    "Latest date": "2023-03-23",
+    "Description": "Alias of B.1.1.529.5.1.25.1.1.1 found mainly in Peru and USA, from #1407"
+  },
+  {
+    "Lineage": "DJ.1.2",
+    "Earliest date": "2022-09-14",
+    "Latest date": "2023-03-13",
+    "Description": "Alias of B.1.1.529.5.1.25.1.2, found mainly in Peru, from #1379"
+  },
+  {
+    "Lineage": "DJ.1.3",
+    "Earliest date": "2022-10-05",
+    "Latest date": "2023-01-24",
+    "Description": "Alias of B.1.1.529.5.1.25.1.3 found mainly in Peru, Colombia and USA, from #1409"
+  },
+  {
+    "Lineage": "BA.5.1.26",
+    "Earliest date": "2022-06-08",
+    "Latest date": "2023-05-12",
+    "Description": "Alias of B.1.1.529.5.1.26, mainly found in Czechia, defined by S:R346T, from #869"
+  },
+  {
+    "Lineage": "CU.1",
+    "Earliest date": "2022-08-05",
+    "Latest date": "2022-12-21",
+    "Description": "Alias of B.1.1.529.5.1.26.1, Central/Eastern Europe, S:T95I, S:T547K"
+  },
+  {
+    "Lineage": "BA.5.1.27",
+    "Earliest date": "2022-07-08",
+    "Latest date": "2023-03-24",
+    "Description": "Alias of B.1.1.529.5.1.27, mainly found in North America, defined by S:R346T"
+  },
+  {
+    "Lineage": "BA.5.1.28",
+    "Earliest date": "2022-06-24",
+    "Latest date": "2023-03-19",
+    "Description": "Alias of B.1.1.529.5.1.28, mainly found in North America, defined by S:R346T (and A18480G)"
+  },
+  {
+    "Lineage": "BA.5.1.29",
+    "Earliest date": "2022-07-09",
+    "Latest date": "2023-01-10",
+    "Description": "Alias of B.1.1.529.5.1.29, mainly found in Russia, Germany and Estonia, from #1060"
+  },
+  {
+    "Lineage": "CL.1",
+    "Earliest date": "2022-07-19",
+    "Latest date": "2023-06-06",
+    "Description": "Alias of B.1.1.529.5.1.29.1, S:150E and S:460K, from #1187"
+  },
+  {
+    "Lineage": "CL.1.1",
+    "Earliest date": "2022-10-13",
+    "Latest date": "2023-04-13",
+    "Description": "Alias of B.1.1.529.5.1.29.1.1, S:P1162L"
+  },
+  {
+    "Lineage": "CL.1.2",
+    "Earliest date": "2022-09-03",
+    "Latest date": "2023-04-20",
+    "Description": "Alias of B.1.1.529.5.1.29.1.2, S:T883I"
+  },
+  {
+    "Lineage": "CL.1.3",
+    "Earliest date": "2022-09-16",
+    "Latest date": "2023-05-02",
+    "Description": "Alias of B.1.1.529.5.1.29.1.3, S:S71F"
+  },
+  {
+    "Lineage": "BA.5.1.30",
+    "Earliest date": "2021-07-16",
+    "Latest date": "2024-03-08",
+    "Description": "Alias of B.1.1.529.5.1.30, ORF6:D6G"
+  },
+  {
+    "Lineage": "BA.5.1.31",
+    "Earliest date": "2022-07-11",
+    "Latest date": "2023-01-10",
+    "Description": "Alias of B.1.1.529.5.1.31, found mainly in France and Denmark, from #991"
+  },
+  {
+    "Lineage": "BA.5.1.32",
+    "Earliest date": "2022-09-26",
+    "Latest date": "2023-04-24",
+    "Description": "Alias of B.1.1.529.5.1.32, found mainly in Germany and China, from #1488"
+  },
+  {
+    "Lineage": "BA.5.1.33",
+    "Earliest date": "2022-05-09",
+    "Latest date": "2023-03-11",
+    "Description": "Alias of B.1.1.529.5.1.33, S:V1264L"
+  },
+  {
+    "Lineage": "EQ.1",
+    "Earliest date": "2022-01-10",
+    "Latest date": "2023-04-18",
+    "Description": "Alias of B.1.1.529.5.1.33.1 S:Q14H, found mainly in Germany, France, Japan and Denmark, from #1522"
+  },
+  {
+    "Lineage": "BA.5.1.34",
+    "Earliest date": "2022-06-06",
+    "Latest date": "2023-04-10",
+    "Description": "Alias of B.1.1.529.5.1.34, Denmark, S:P1162S"
+  },
+  {
+    "Lineage": "BA.5.1.35",
+    "Earliest date": "2022-02-16",
+    "Latest date": "2023-05-29",
+    "Description": "Alias of B.1.1.529.5.1.35, ORF1a:I1525M"
+  },
+  {
+    "Lineage": "EB.1",
+    "Earliest date": "2022-09-04",
+    "Latest date": "2023-02-28",
+    "Description": "Alias of B.1.1.529.5.1.35.1, USA, S:R346T"
+  },
+  {
+    "Lineage": "BA.5.1.36",
+    "Earliest date": "2022-08-29",
+    "Latest date": "2023-01-23",
+    "Description": "Alias of B.1.1.529.5.1.36, USA, S:R346T, S:G261V"
+  },
+  {
+    "Lineage": "BA.5.1.37",
+    "Earliest date": "2022-09-11",
+    "Latest date": "2023-03-21",
+    "Description": "Alias of B.1.1.529.5.1.37, S:R346T, S:Y248N"
+  },
+  {
+    "Lineage": "BA.5.1.38",
+    "Earliest date": "2022-09-26",
+    "Latest date": "2023-08-28",
+    "Description": "Alias of B.1.1.529.5.1.38, Japan, ORF8:S103L, S:R346T"
+  },
+  {
+    "Lineage": "BA.5.2",
+    "Earliest date": "2020-07-02",
+    "Latest date": "2024-08-15",
+    "Description": "Alias of B.1.1.529.5.2, mainly found in South Africa, England and USA, from #551"
+  },
+  {
+    "Lineage": "BA.5.2.1",
+    "Earliest date": "2020-07-06",
+    "Latest date": "2024-04-11",
+    "Description": "Alias of B.1.1.529.5.2.1, mainly found in South Africa, England and USA, from #657"
+  },
+  {
+    "Lineage": "BF.1",
+    "Earliest date": "2020-07-23",
+    "Latest date": "2023-06-03",
+    "Description": "Alias of B.1.1.529.5.2.1.1, mainly found in England, Denmark, Spain and Scotland, from #618"
+  },
+  {
+    "Lineage": "BF.1.1",
+    "Earliest date": "2022-04-28",
+    "Latest date": "2022-09-21",
+    "Description": "Alias of B.1.1.529.5.2.1.1.1, USA lineage"
+  },
+  {
+    "Lineage": "BF.2",
+    "Earliest date": "2022-02-01",
+    "Latest date": "2024-06-04",
+    "Description": "Alias of B.1.1.529.5.2.1.2, Denmark lineage"
+  },
+  {
+    "Lineage": "BF.3",
+    "Earliest date": "2022-05-03",
+    "Latest date": "2022-12-27",
+    "Description": "Alias of B.1.1.529.5.2.1.3, India lineage"
+  },
+  {
+    "Lineage": "BF.3.1",
+    "Earliest date": "2022-06-01",
+    "Latest date": "2022-09-27",
+    "Description": "Alias of B.1.1.529.5.2.1.3.1, mainly found India, Singapore, and USA, from #825"
+  },
+  {
+    "Lineage": "BF.4",
+    "Earliest date": "2022-04-29",
+    "Latest date": "2023-03-03",
+    "Description": "Alias of B.1.1.529.5.2.1.4, mainly found in England, from #788"
+  },
+  {
+    "Lineage": "BF.5",
+    "Earliest date": "2020-07-21",
+    "Latest date": "2023-06-24",
+    "Description": "Alias of B.1.1.529.5.2.1.5, Israel lineage"
+  },
+  {
+    "Lineage": "BF.5.1",
+    "Earliest date": "2022-06-26",
+    "Latest date": "2023-12-28",
+    "Description": "Alias of B.1.1.529.5.2.1.5.1 found mainly in Japan and Israel, from #1475"
+  },
+  {
+    "Lineage": "BF.5.2",
+    "Earliest date": "2022-09-04",
+    "Latest date": "2023-04-10",
+    "Description": "Alias of B.1.1.529.5.2.1.5.2 found mainly in Japan, from #1476"
+  },
+  {
+    "Lineage": "BF.5.3",
+    "Earliest date": "2022-10-24",
+    "Latest date": "2023-01-23",
+    "Description": "Alias of B.1.1.529.5.2.1.5.3 found mainly in Japan, from #1526"
+  },
+  {
+    "Lineage": "BF.5.4",
+    "Earliest date": "2022-06-29",
+    "Latest date": "2023-03-22",
+    "Description": "Alias of B.1.1.529.5.2.1.5.4 Japan, ORF1a:K3839R"
+  },
+  {
+    "Lineage": "BF.5.5",
+    "Earliest date": "2022-06-13",
+    "Latest date": "2023-03-27",
+    "Description": "Alias of B.1.1.529.5.2.1.5.5 Europe, S:K147N"
+  },
+  {
+    "Lineage": "BF.6",
+    "Earliest date": "2022-05-24",
+    "Latest date": "2023-01-03",
+    "Description": "Alias of B.1.1.529.5.2.1.6, mainly found in England and Scotland, from #821"
+  },
+  {
+    "Lineage": "BF.7",
+    "Earliest date": "2022-01-02",
+    "Latest date": "2023-09-27",
+    "Description": "Alias of B.1.1.529.5.2.1.7, mainly found in Belgium, England and Denmark, from #827"
+  },
+  {
+    "Lineage": "BF.7.1",
+    "Earliest date": "2022-01-31",
+    "Latest date": "2023-02-26",
+    "Description": "Alias of B.1.1.529.5.2.1.7.1, mainly found in Germany, S:G261V, from #1132"
+  },
+  {
+    "Lineage": "BF.7.2",
+    "Earliest date": "2022-09-02",
+    "Latest date": "2023-01-16",
+    "Description": "Alias of B.1.1.529.5.2.1.7.2, Denmark, S:H1101Y and S:V486I, from #1216"
+  },
+  {
+    "Lineage": "BF.7.3",
+    "Earliest date": "2022-08-25",
+    "Latest date": "2023-08-02",
+    "Description": "Alias of B.1.1.529.5.2.1.7.3, France/Czechia, S:K182E"
+  },
+  {
+    "Lineage": "BF.7.4",
+    "Earliest date": "2022-06-14",
+    "Latest date": "2023-06-29",
+    "Description": "Alias of B.1.1.529.5.2.1.7.4, Europe, ORF8:H17Y"
+  },
+  {
+    "Lineage": "BF.7.4.1",
+    "Earliest date": "2022-01-06",
+    "Latest date": "2023-09-13",
+    "Description": "Alias of B.1.1.529.5.2.1.7.4.1, found mainly in USA and Netherlands, from #1253"
+  },
+  {
+    "Lineage": "BF.7.4.2",
+    "Earliest date": "2022-07-23",
+    "Latest date": "2023-02-27",
+    "Description": "Alias of B.1.1.529.5.2.1.7.4.2, Europe"
+  },
+  {
+    "Lineage": "BF.7.4.3",
+    "Earliest date": "2022-10-31",
+    "Latest date": "2023-05-29",
+    "Description": "Alias of B.1.1.529.5.2.1.7.4.3, Japan, S:F157L, N:A90S, from #1743"
+  },
+  {
+    "Lineage": "BF.7.5",
+    "Earliest date": "2022-07-12",
+    "Latest date": "2023-08-30",
+    "Description": "Alias of B.1.1.529.5.2.1.7.5, Europe, ORF1b:P1427L"
+  },
+  {
+    "Lineage": "BF.7.5.1",
+    "Earliest date": "2022-09-12",
+    "Latest date": "2023-03-10",
+    "Description": "Alias of B.1.1.529.5.2.1.7.5.1, found mainly in Germany and Denmark, from #1317"
+  },
+  {
+    "Lineage": "BF.7.6",
+    "Earliest date": "2021-02-26",
+    "Latest date": "2023-04-25",
+    "Description": "Alias of B.1.1.529.5.2.1.7.6, Europe, ORF3a:E239D"
+  },
+  {
+    "Lineage": "BF.7.7",
+    "Earliest date": "2022-08-05",
+    "Latest date": "2023-03-30",
+    "Description": "Alias of B.1.1.529.5.2.1.7.7, Europe, S:D80G, from #1147"
+  },
+  {
+    "Lineage": "BF.7.8",
+    "Earliest date": "2022-07-09",
+    "Latest date": "2023-03-08",
+    "Description": "Alias of B.1.1.529.5.2.1.7.8, Europe, S:T883I"
+  },
+  {
+    "Lineage": "BF.7.9",
+    "Earliest date": "2022-07-04",
+    "Latest date": "2023-01-16",
+    "Description": "Alias of B.1.1.529.5.2.1.7.9, Europe, S:Q677H"
+  },
+  {
+    "Lineage": "BF.7.10",
+    "Earliest date": "2022-06-27",
+    "Latest date": "2023-03-02",
+    "Description": "Alias of B.1.1.529.5.2.1.7.10, Europe, S:Q1201K"
+  },
+  {
+    "Lineage": "BF.7.11",
+    "Earliest date": "2022-08-08",
+    "Latest date": "2023-02-06",
+    "Description": "Alias of B.1.1.529.5.2.1.7.11, Europe, S:D1260Y"
+  },
+  {
+    "Lineage": "BF.7.12",
+    "Earliest date": "2022-08-18",
+    "Latest date": "2023-04-03",
+    "Description": "Alias of B.1.1.529.5.2.1.7.12, Europe, S:A942S"
+  },
+  {
+    "Lineage": "BF.7.13",
+    "Earliest date": "2022-06-08",
+    "Latest date": "2023-01-02",
+    "Description": "Alias of B.1.1.529.5.2.1.7.13, Belgium, ORF1a:H388Y, ORF1a:H1160Y,"
+  },
+  {
+    "Lineage": "BF.7.13.1",
+    "Earliest date": "2022-09-15",
+    "Latest date": "2022-11-30",
+    "Description": "Alias of B.1.1.529.5.2.1.7.13.1, Europe, S:T430I, S:P681Y"
+  },
+  {
+    "Lineage": "BF.7.13.2",
+    "Earliest date": "2022-09-09",
+    "Latest date": "2023-11-22",
+    "Description": "Alias of B.1.1.529.5.2.1.7.13.2, Poland, S:A653V"
+  },
+  {
+    "Lineage": "BF.7.14",
+    "Earliest date": "2021-12-16",
+    "Latest date": "2023-11-18",
+    "Description": "Alias of B.1.1.529.5.2.1.7.14, China, S:C1243F, from #1470"
+  },
+  {
+    "Lineage": "BF.7.14.1",
+    "Earliest date": "2022-11-04",
+    "Latest date": "2024-01-26",
+    "Description": "Alias of B.1.1.529.5.2.1.7.14.1 found mainly in China and Japan, contains S:V83F branch, from #1580"
+  },
+  {
+    "Lineage": "BF.7.14.2",
+    "Earliest date": "2022-11-30",
+    "Latest date": "2023-05-09",
+    "Description": "Alias of B.1.1.529.5.2.1.7.14.2 China, S:Q14H"
+  },
+  {
+    "Lineage": "BF.7.14.3",
+    "Earliest date": "2022-11-21",
+    "Latest date": "2023-04-26",
+    "Description": "Alias of B.1.1.529.5.2.1.7.14.3 China, S:A626V, from #1573"
+  },
+  {
+    "Lineage": "BF.7.14.4",
+    "Earliest date": "2022-11-22",
+    "Latest date": "2023-08-11",
+    "Description": "Alias of B.1.1.529.5.2.1.7.14.4 China, ORF1a:T1844I"
+  },
+  {
+    "Lineage": "BF.7.14.5",
+    "Earliest date": "2022-11-24",
+    "Latest date": "2023-05-10",
+    "Description": "Alias of B.1.1.529.5.2.1.7.14.5 China, C20703T, from #1607"
+  },
+  {
+    "Lineage": "BF.7.14.6",
+    "Earliest date": "2022-11-07",
+    "Latest date": "2023-04-24",
+    "Description": "Alias of B.1.1.529.5.2.1.7.14.6 China, C1973T"
+  },
+  {
+    "Lineage": "BF.7.14.7",
+    "Earliest date": "2022-12-17",
+    "Latest date": "2023-04-23",
+    "Description": "Alias of B.1.1.529.5.2.1.7.14.7 found mainly in China, from #1672"
+  },
+  {
+    "Lineage": "BF.7.15",
+    "Earliest date": "2022-01-06",
+    "Latest date": "2023-08-30",
+    "Description": "Alias of B.1.1.529.5.2.1.7.15, Japan, S:G257D & ORF1a:A1812V, from #1358"
+  },
+  {
+    "Lineage": "BF.7.16",
+    "Earliest date": "2022-07-26",
+    "Latest date": "2023-02-02",
+    "Description": "Alias of B.1.1.529.5.2.1.7.16, ORF1a:A498V"
+  },
+  {
+    "Lineage": "BF.7.16.1",
+    "Earliest date": "2022-08-22",
+    "Latest date": "2023-02-26",
+    "Description": "Alias of B.1.1.529.5.2.1.7.16.1, Canada, S:A688V"
+  },
+  {
+    "Lineage": "BF.7.17",
+    "Earliest date": "2022-10-13",
+    "Latest date": "2023-03-11",
+    "Description": "Alias of B.1.1.529.5.2.1.7.17, Japan/Germany, S:A688V, S:G1167S"
+  },
+  {
+    "Lineage": "BF.7.18",
+    "Earliest date": "2022-09-23",
+    "Latest date": "2023-04-23",
+    "Description": "Alias of B.1.1.529.5.2.1.7.18, South Korea, S:K97N"
+  },
+  {
+    "Lineage": "BF.7.19",
+    "Earliest date": "2022-06-06",
+    "Latest date": "2023-04-06",
+    "Description": "Alias of B.1.1.529.5.2.1.7.19, ORF7a:R118S"
+  },
+  {
+    "Lineage": "BF.7.19.1",
+    "Earliest date": "2022-10-11",
+    "Latest date": "2023-05-01",
+    "Description": "Alias of B.1.1.529.5.2.1.7.19.1, Japan, T7111C,C1915T,C16470T,A26219G on ORF8:T87I branch"
+  },
+  {
+    "Lineage": "BF.7.20",
+    "Earliest date": "2022-04-27",
+    "Latest date": "2023-05-25",
+    "Description": "Alias of B.1.1.529.5.2.1.7.20, G15543T"
+  },
+  {
+    "Lineage": "BF.7.21",
+    "Earliest date": "2022-03-11",
+    "Latest date": "2023-09-06",
+    "Description": "Alias of B.1.1.529.5.2.1.7.21, C28603T"
+  },
+  {
+    "Lineage": "BF.7.22",
+    "Earliest date": "2022-08-15",
+    "Latest date": "2023-03-29",
+    "Description": "Alias of B.1.1.529.5.2.1.7.22, ORF8:V81I"
+  },
+  {
+    "Lineage": "BF.7.23",
+    "Earliest date": "2022-06-27",
+    "Latest date": "2023-06-03",
+    "Description": "Alias of B.1.1.529.5.2.1.7.23, ORF1b:T239I"
+  },
+  {
+    "Lineage": "BF.7.24",
+    "Earliest date": "2022-07-11",
+    "Latest date": "2023-10-31",
+    "Description": "Alias of B.1.1.529.5.2.1.7.24, T10939C"
+  },
+  {
+    "Lineage": "BF.7.26",
+    "Earliest date": "2022-05-31",
+    "Latest date": "2023-03-13",
+    "Description": "Alias of B.1.1.529.5.2.1.7.26, G20679A"
+  },
+  {
+    "Lineage": "BF.7.27",
+    "Earliest date": "2022-07-06",
+    "Latest date": "2023-01-25",
+    "Description": "Alias of B.1.1.529.5.2.1.7.27, C8752T, sibling of BF.7.14"
+  },
+  {
+    "Lineage": "BF.8",
+    "Earliest date": "2022-04-27",
+    "Latest date": "2023-04-03",
+    "Description": "Alias of B.1.1.529.5.2.1.8, USA lineage"
+  },
+  {
+    "Lineage": "BF.9",
+    "Earliest date": "2022-05-28",
+    "Latest date": "2023-05-14",
+    "Description": "Alias of B.1.1.529.5.2.1.9, Canada lineage"
+  },
+  {
+    "Lineage": "BF.10",
+    "Earliest date": "2020-07-25",
+    "Latest date": "2023-03-19",
+    "Description": "Alias of B.1.1.529.5.2.1.10, USA lineage"
+  },
+  {
+    "Lineage": "BF.10.1",
+    "Earliest date": "2022-09-07",
+    "Latest date": "2023-01-06",
+    "Description": "Alias of B.1.1.529.5.2.1.10.1, found mainly in USA and Mexico, from #1442"
+  },
+  {
+    "Lineage": "BF.11",
+    "Earliest date": "2022-01-06",
+    "Latest date": "2023-12-11",
+    "Description": "Alias of B.1.1.529.5.2.1.11, mainly found in England, S:R346T, from #837"
+  },
+  {
+    "Lineage": "BF.11.1",
+    "Earliest date": "2022-04-10",
+    "Latest date": "2023-05-22",
+    "Description": "Alias of B.1.1.529.5.2.1.11.1, England, S:S1252F"
+  },
+  {
+    "Lineage": "BF.11.2",
+    "Earliest date": "2022-09-12",
+    "Latest date": "2024-04-11",
+    "Description": "Alias of B.1.1.529.5.2.1.11.2, Wales, S:K147N"
+  },
+  {
+    "Lineage": "BF.11.3",
+    "Earliest date": "2022-07-25",
+    "Latest date": "2024-04-03",
+    "Description": "Alias of B.1.1.529.5.2.1.11.3, ORF1a:L122F"
+  },
+  {
+    "Lineage": "BF.11.4",
+    "Earliest date": "2022-08-11",
+    "Latest date": "2023-02-14",
+    "Description": "Alias of B.1.1.529.5.2.1.11.4, England, S:S704L"
+  },
+  {
+    "Lineage": "BF.11.5",
+    "Earliest date": "2022-08-11",
+    "Latest date": "2023-05-02",
+    "Description": "Alias of B.1.1.529.5.2.1.11.5, England, ORF8:I121L"
+  },
+  {
+    "Lineage": "BF.12",
+    "Earliest date": "2022-05-06",
+    "Latest date": "2023-02-08",
+    "Description": "Alias of B.1.1.529.5.2.1.12, mainly found Austria, Brazil, and England, from #752"
+  },
+  {
+    "Lineage": "BF.13",
+    "Earliest date": "2022-06-09",
+    "Latest date": "2023-07-30",
+    "Description": "Alias of B.1.1.529.5.2.1.13, mainly found in USA, from #883"
+  },
+  {
+    "Lineage": "BF.14",
+    "Earliest date": "2022-01-16",
+    "Latest date": "2024-01-18",
+    "Description": "Alias of B.1.1.529.5.2.1.14, mainly found in Austria, from #843"
+  },
+  {
+    "Lineage": "BF.15",
+    "Earliest date": "2022-06-16",
+    "Latest date": "2023-01-21",
+    "Description": "Alias of B.1.1.529.5.2.1.15, Sri Lanka lineage, from #893"
+  },
+  {
+    "Lineage": "BF.16",
+    "Earliest date": "2022-05-29",
+    "Latest date": "2023-03-18",
+    "Description": "Alias of B.1.1.529.5.2.1.16, found in USA, from #942"
+  },
+  {
+    "Lineage": "BF.17",
+    "Earliest date": "2022-06-01",
+    "Latest date": "2022-12-20",
+    "Description": "Alias of B.1.1.529.5.2.1.17, Australia lineage"
+  },
+  {
+    "Lineage": "BF.18",
+    "Earliest date": "2022-05-17",
+    "Latest date": "2023-04-13",
+    "Description": "Alias of B.1.1.529.5.2.1.18, Australia lineage"
+  },
+  {
+    "Lineage": "BF.19",
+    "Earliest date": "2022-06-05",
+    "Latest date": "2022-12-13",
+    "Description": "Alias of B.1.1.529.5.2.1.19, Greece lineage"
+  },
+  {
+    "Lineage": "BF.20",
+    "Earliest date": "2022-05-24",
+    "Latest date": "2022-12-19",
+    "Description": "Alias of B.1.1.529.5.2.1.20, lineage in Kenya and other countries"
+  },
+  {
+    "Lineage": "BF.21",
+    "Earliest date": "2022-05-12",
+    "Latest date": "2023-07-07",
+    "Description": "Alias of B.1.1.529.5.2.1.21, USA lineage"
+  },
+  {
+    "Lineage": "BF.22",
+    "Earliest date": "2022-06-22",
+    "Latest date": "2023-02-21",
+    "Description": "Alias of B.1.1.529.5.2.1.22, mainly found in Japan, from #1010"
+  },
+  {
+    "Lineage": "BF.23",
+    "Earliest date": "2022-04-02",
+    "Latest date": "2022-12-10",
+    "Description": "Alias of B.1.1.529.5.2.1.23, mainly found in Czechia, from #1036"
+  },
+  {
+    "Lineage": "BF.24",
+    "Earliest date": "2022-05-03",
+    "Latest date": "2023-02-17",
+    "Description": "Alias of B.1.1.529.5.2.1.24, mainly found in Indonesia, defined by ORF1a:G683C on S:1020S branch"
+  },
+  {
+    "Lineage": "BF.25",
+    "Earliest date": "2022-06-18",
+    "Latest date": "2023-06-06",
+    "Description": "Alias of B.1.1.529.5.2.1.25, USA lineage, defined by S:445A and C18657T"
+  },
+  {
+    "Lineage": "BF.26",
+    "Earliest date": "2022-02-08",
+    "Latest date": "2023-04-28",
+    "Description": "Alias of B.1.1.529.5.2.1.26, North America lineage, defined by ORF1b:G376S, on C5284T branch, from #1142"
+  },
+  {
+    "Lineage": "BF.27",
+    "Earliest date": "2022-05-10",
+    "Latest date": "2023-06-08",
+    "Description": "Alias of B.1.1.529.5.2.1.27, Singapore lineage, defined by ORF1a:A2784V, from #1140"
+  },
+  {
+    "Lineage": "BF.28",
+    "Earliest date": "2020-07-22",
+    "Latest date": "2023-03-16",
+    "Description": "Alias of B.1.1.529.5.2.1.28, Singapore lineage, defined by ORF1a:Q44L, from #1141"
+  },
+  {
+    "Lineage": "BF.29",
+    "Earliest date": "2022-06-28",
+    "Latest date": "2023-04-27",
+    "Description": "Alias of B.1.1.529.5.2.1.29, mainly found in Denmark and USA, from #1162"
+  },
+  {
+    "Lineage": "BF.30",
+    "Earliest date": "2022-05-26",
+    "Latest date": "2023-02-02",
+    "Description": "Alias of B.1.1.529.5.2.1.30, South Africa/England, defined by S:R346T after C25916T, C14599T"
+  },
+  {
+    "Lineage": "BF.31",
+    "Earliest date": "2022-05-29",
+    "Latest date": "2023-07-22",
+    "Description": "Alias of B.1.1.529.5.2.1.31, Chile, 23758T"
+  },
+  {
+    "Lineage": "BF.31.1",
+    "Earliest date": "2022-07-27",
+    "Latest date": "2024-06-21",
+    "Description": "Alias of B.1.1.529.5.2.1.31.1, Chile, S:A701V and S:S247N/S:Y248-"
+  },
+  {
+    "Lineage": "BF.32",
+    "Earliest date": "2022-08-06",
+    "Latest date": "2023-02-19",
+    "Description": "Alias of B.1.1.529.5.2.1.32, found mainly in USA, on C5284T branch, from #1250"
+  },
+  {
+    "Lineage": "BF.33",
+    "Earliest date": "2022-08-24",
+    "Latest date": "2022-12-16",
+    "Description": "Alias of B.1.1.529.5.2.1.33, Brazil/France, S:R346I, S:N460K"
+  },
+  {
+    "Lineage": "BF.34",
+    "Earliest date": "2022-08-19",
+    "Latest date": "2023-01-16",
+    "Description": "Alias of B.1.1.529.5.2.1.34, found mainly in UK and Canada, from #1233"
+  },
+  {
+    "Lineage": "BF.35",
+    "Earliest date": "2022-08-04",
+    "Latest date": "2023-02-14",
+    "Description": "Alias of B.1.1.529.5.2.1.35, Japan/Malaysia, S:N450D, ORF1a:L730R"
+  },
+  {
+    "Lineage": "BF.36",
+    "Earliest date": "2021-12-22",
+    "Latest date": "2023-01-23",
+    "Description": "Alias of B.1.1.529.5.2.1.36, ORF1a:S166G,ORF1b:S1273L,ORF1b:A1428V"
+  },
+  {
+    "Lineage": "BF.37",
+    "Earliest date": "2022-08-30",
+    "Latest date": "2023-05-11",
+    "Description": "Alias of B.1.1.529.5.2.1.37, Japan, ORF1a:S944L, S:G446D, on C5284T branch"
+  },
+  {
+    "Lineage": "BF.38",
+    "Earliest date": "2022-05-08",
+    "Latest date": "2023-03-10",
+    "Description": "Alias of B.1.1.529.5.2.1.38, Japan, C17304T"
+  },
+  {
+    "Lineage": "BF.38.1",
+    "Earliest date": "2022-07-04",
+    "Latest date": "2023-07-06",
+    "Description": "Alias of B.1.1.529.5.2.1.38.1, Japan, S:Q1201K"
+  },
+  {
+    "Lineage": "BF.38.2",
+    "Earliest date": "2022-07-27",
+    "Latest date": "2023-02-17",
+    "Description": "Alias of B.1.1.529.5.2.1.38.2, Japan, S:V445A"
+  },
+  {
+    "Lineage": "BF.38.3",
+    "Earliest date": "2022-08-03",
+    "Latest date": "2023-03-17",
+    "Description": "Alias of B.1.1.529.5.2.1.38.3, Japan, S:P1162S"
+  },
+  {
+    "Lineage": "BF.39",
+    "Earliest date": "2022-05-09",
+    "Latest date": "2023-02-16",
+    "Description": "Alias of B.1.1.529.5.2.1.39, S:G181V"
+  },
+  {
+    "Lineage": "BF.39.1",
+    "Earliest date": "2022-09-27",
+    "Latest date": "2023-02-16",
+    "Description": "Alias of B.1.1.529.5.2.1.39.1, Chile/Peru, S:V445A, S:N450D"
+  },
+  {
+    "Lineage": "BF.40",
+    "Earliest date": "2022-07-07",
+    "Latest date": "2023-06-13",
+    "Description": "Alias of B.1.1.529.5.2.1.40, S:V445A, on C5284T branch"
+  },
+  {
+    "Lineage": "BF.41",
+    "Earliest date": "2022-05-10",
+    "Latest date": "2023-02-01",
+    "Description": "Alias of B.1.1.529.5.2.1.41, Brazil, ORF7b:A43V"
+  },
+  {
+    "Lineage": "BF.41.1",
+    "Earliest date": "2022-07-16",
+    "Latest date": "2023-07-31",
+    "Description": "Alias of B.1.1.529.5.2.1.41.1, Brazil, S:R346T"
+  },
+  {
+    "Lineage": "BF.42",
+    "Earliest date": "2023-01-18",
+    "Latest date": "2023-04-04",
+    "Description": "Alias of B.1.1.529.5.2.1.42, found in Japan, from #1855"
+  },
+  {
+    "Lineage": "BA.5.2.2",
+    "Earliest date": "2022-05-02",
+    "Latest date": "2023-10-16",
+    "Description": "Alias of B.1.1.529.5.2.2, France and Martinique lineage"
+  },
+  {
+    "Lineage": "BA.5.2.3",
+    "Earliest date": "2021-07-16",
+    "Latest date": "2023-03-02",
+    "Description": "Alias of B.1.1.529.5.2.3, UK lineage"
+  },
+  {
+    "Lineage": "BZ.1",
+    "Earliest date": "2022-07-11",
+    "Latest date": "2022-10-19",
+    "Description": "Alias of B.1.1.529.5.2.3.1, Denmark lineage, defined by S:Q677H"
+  },
+  {
+    "Lineage": "BZ.2",
+    "Earliest date": "2022-08-11",
+    "Latest date": "2023-02-24",
+    "Description": "Alias of B.1.1.529.5.2.3.2, S:N450D, ORF1a:H2794Y"
+  },
+  {
+    "Lineage": "BA.5.2.4",
+    "Earliest date": "2022-05-15",
+    "Latest date": "2022-12-08",
+    "Description": "Alias of B.1.1.529.5.2.4, Australia lineage"
+  },
+  {
+    "Lineage": "BA.5.2.5",
+    "Earliest date": "2022-06-07",
+    "Latest date": "2022-10-11",
+    "Description": "Alias of B.1.1.529.5.2.5, Indonesia lineage"
+  },
+  {
+    "Lineage": "BA.5.2.6",
+    "Earliest date": "2022-01-02",
+    "Latest date": "2024-01-22",
+    "Description": "Alias of B.1.1.529.5.2.6, global lineage, S:R346T, from #870"
+  },
+  {
+    "Lineage": "CP.1",
+    "Earliest date": "2022-01-05",
+    "Latest date": "2023-04-06",
+    "Description": "Alias of B.1.1.529.5.2.6.1, global lineage, 27360C"
+  },
+  {
+    "Lineage": "CP.1.1",
+    "Earliest date": "2022-08-24",
+    "Latest date": "2023-04-01",
+    "Description": "Alias of B.1.1.529.5.2.6.1.1, Portugal, France, Denmark, UK lineage, S:V445A"
+  },
+  {
+    "Lineage": "CP.1.2",
+    "Earliest date": "2022-09-03",
+    "Latest date": "2023-03-14",
+    "Description": "Alias of B.1.1.529.5.2.6.1.2, England, S:K150N"
+  },
+  {
+    "Lineage": "CP.1.3",
+    "Earliest date": "2022-09-18",
+    "Latest date": "2022-11-20",
+    "Description": "Alias of B.1.1.529.5.2.6.1.3, England, S:G446S"
+  },
+  {
+    "Lineage": "CP.2",
+    "Earliest date": "2022-08-21",
+    "Latest date": "2023-01-16",
+    "Description": "Alias of B.1.1.529.5.2.6.2, Bangladesh, S:N334K"
+  },
+  {
+    "Lineage": "CP.3",
+    "Earliest date": "2022-08-29",
+    "Latest date": "2023-02-07",
+    "Description": "Alias of B.1.1.529.5.2.6.3, Turkey, S:N460Y"
+  },
+  {
+    "Lineage": "CP.4",
+    "Earliest date": "2022-09-19",
+    "Latest date": "2023-01-21",
+    "Description": "Alias of B.1.1.529.5.2.6.4, Turkey, S:I770V"
+  },
+  {
+    "Lineage": "CP.5",
+    "Earliest date": "2022-07-04",
+    "Latest date": "2023-01-21",
+    "Description": "Alias of B.1.1.529.5.2.6.5, South Africa, S:C1247F"
+  },
+  {
+    "Lineage": "CP.6",
+    "Earliest date": "2022-08-26",
+    "Latest date": "2022-12-07",
+    "Description": "Alias of B.1.1.529.5.2.6.6, S:V1264L"
+  },
+  {
+    "Lineage": "CP.7",
+    "Earliest date": "2022-03-15",
+    "Latest date": "2023-07-11",
+    "Description": "Alias of B.1.1.529.5.2.6.7 found mainly in Japan, from #1473"
+  },
+  {
+    "Lineage": "CP.8",
+    "Earliest date": "2022-07-27",
+    "Latest date": "2023-03-08",
+    "Description": "Alias of B.1.1.529.5.2.6.8 ORF1b:D1939G, C15240T, A15486G, C28651T, from #1627"
+  },
+  {
+    "Lineage": "CP.8.1",
+    "Earliest date": "2022-09-22",
+    "Latest date": "2023-02-09",
+    "Description": "Alias of B.1.1.529.5.2.6.8.1 found mainly in the Australia and Japan, from #1627"
+  },
+  {
+    "Lineage": "BA.5.2.7",
+    "Earliest date": "2022-01-26",
+    "Latest date": "2023-02-24",
+    "Description": "Alias of B.1.1.529.5.2.7, global lineage, from #924"
+  },
+  {
+    "Lineage": "CY.1",
+    "Earliest date": "2022-09-08",
+    "Latest date": "2023-01-28",
+    "Description": "Alias of B.1.1.529.5.2.7.1, found mainly in Belgium, Netherlands and Luxembourg, from #1247"
+  },
+  {
+    "Lineage": "CY.2",
+    "Earliest date": "2022-10-11",
+    "Latest date": "2023-04-11",
+    "Description": "Alias of B.1.1.529.5.2.7.2 found in Japan, from #1474"
+  },
+  {
+    "Lineage": "BA.5.2.8",
+    "Earliest date": "2022-04-08",
+    "Latest date": "2023-01-06",
+    "Description": "Alias of B.1.1.529.5.2.8, Israel lineage"
+  },
+  {
+    "Lineage": "BA.5.2.9",
+    "Earliest date": "2021-07-25",
+    "Latest date": "2023-07-24",
+    "Description": "Alias of B.1.1.529.5.2.9, USA lineage"
+  },
+  {
+    "Lineage": "BA.5.2.10",
+    "Earliest date": "2022-05-09",
+    "Latest date": "2022-12-07",
+    "Description": "Alias of B.1.1.529.5.2.10, Brazil lineage"
+  },
+  {
+    "Lineage": "BA.5.2.11",
+    "Earliest date": "2022-06-20",
+    "Latest date": "2023-01-14",
+    "Description": "Alias of B.1.1.529.5.2.11, Philippines lineage"
+  },
+  {
+    "Lineage": "BA.5.2.12",
+    "Earliest date": "2022-01-06",
+    "Latest date": "2024-01-06",
+    "Description": "Alias of B.1.1.529.5.2.12, Japan lineage"
+  },
+  {
+    "Lineage": "BA.5.2.13",
+    "Earliest date": "2022-06-23",
+    "Latest date": "2023-11-15",
+    "Description": "Alias of B.1.1.529.5.2.13, mainly found in England, from #959"
+  },
+  {
+    "Lineage": "BA.5.2.14",
+    "Earliest date": "2022-01-09",
+    "Latest date": "2023-02-21",
+    "Description": "Alias of B.1.1.529.5.2.14, mainly found in Denmark, Canada and Pakistan, from #1002"
+  },
+  {
+    "Lineage": "BA.5.2.16",
+    "Earliest date": "2022-01-09",
+    "Latest date": "2023-03-06",
+    "Description": "Alias of B.1.1.529.5.2.16, Indonesia lineage, defined by ORF1a:A3697V, indirectly, from #1065"
+  },
+  {
+    "Lineage": "BU.1",
+    "Earliest date": "2022-08-20",
+    "Latest date": "2023-09-06",
+    "Description": "Alias of B.1.1.529.5.2.16.1, defined by S:444M and S:460K, from #1065"
+  },
+  {
+    "Lineage": "BU.2",
+    "Earliest date": "2022-07-13",
+    "Latest date": "2023-01-02",
+    "Description": "Alias of B.1.1.529.5.2.16.2, USA lineage, S:V445A"
+  },
+  {
+    "Lineage": "BU.3",
+    "Earliest date": "2022-07-27",
+    "Latest date": "2023-02-27",
+    "Description": "Alias of B.1.1.529.5.2.16.3, Guatemala, S:K147N, S:N450D"
+  },
+  {
+    "Lineage": "BA.5.2.18",
+    "Earliest date": "2021-11-01",
+    "Latest date": "2023-04-05",
+    "Description": "Alias of B.1.1.529.5.2.18, mainly Scandinavia, defined by S:K444R on ORF1b:1050N branch, from #1025"
+  },
+  {
+    "Lineage": "CR.1",
+    "Earliest date": "2022-08-15",
+    "Latest date": "2023-06-02",
+    "Description": "Alias of B.1.1.529.5.2.18.1, global, S:R346T"
+  },
+  {
+    "Lineage": "CR.1.1",
+    "Earliest date": "2022-09-28",
+    "Latest date": "2023-03-06",
+    "Description": "Alias of B.1.1.529.5.2.18.1.1, S:V62I"
+  },
+  {
+    "Lineage": "CR.1.2",
+    "Earliest date": "2022-09-12",
+    "Latest date": "2023-01-11",
+    "Description": "Alias of B.1.1.529.5.2.18.1.2, Canada/Israel, S:V445A"
+  },
+  {
+    "Lineage": "CR.1.3",
+    "Earliest date": "2022-10-18",
+    "Latest date": "2023-02-18",
+    "Description": "Alias of B.1.1.529.5.2.18.1.3, found mainly in Denmark and Japan, from #1355"
+  },
+  {
+    "Lineage": "CR.2",
+    "Earliest date": "2022-07-18",
+    "Latest date": "2022-11-30",
+    "Description": "Alias of B.1.1.529.5.2.18.2, England, S:Y145H"
+  },
+  {
+    "Lineage": "BA.5.2.19",
+    "Earliest date": "2022-06-14",
+    "Latest date": "2023-02-27",
+    "Description": "Alias of B.1.1.529.5.2.19, mainly Scandinavia, defined by ORF3a:T14I on ORF1b:1050N branch, from #916"
+  },
+  {
+    "Lineage": "BA.5.2.20",
+    "Earliest date": "2020-07-20",
+    "Latest date": "2023-11-01",
+    "Description": "Alias of B.1.1.529.5.2.20, mainly Indonesia, defined by C23707T on ORF1b:1050N branch to reduce unspecified BA.5.2"
+  },
+  {
+    "Lineage": "BV.1",
+    "Earliest date": "2022-07-01",
+    "Latest date": "2022-12-05",
+    "Description": "Alias of B.1.1.529.5.2.20.1, mainly found in Denmark, formerly BA.5.2.17, from #1019"
+  },
+  {
+    "Lineage": "BV.2",
+    "Earliest date": "2022-06-27",
+    "Latest date": "2023-01-14",
+    "Description": "Alias of B.1.1.529.5.2.20.2, defined by S:K444N, from #1122"
+  },
+  {
+    "Lineage": "BA.5.2.21",
+    "Earliest date": "2022-02-09",
+    "Latest date": "2023-11-29",
+    "Description": "Alias of B.1.1.529.5.2.21, mainly Indonesia, defined by C5284T on ORF1b:1050N branch to reduce unspecified BA.5.2"
+  },
+  {
+    "Lineage": "CN.1",
+    "Earliest date": "2022-05-31",
+    "Latest date": "2023-02-23",
+    "Description": "Alias of B.1.1.529.5.2.21.1, S:N450D, from #1108"
+  },
+  {
+    "Lineage": "CN.2",
+    "Earliest date": "2022-08-29",
+    "Latest date": "2023-05-27",
+    "Description": "Alias of B.1.1.529.5.2.21.2, S:R346T, S:Y28H, USA/Canada, from #1404"
+  },
+  {
+    "Lineage": "BA.5.2.22",
+    "Earliest date": "2022-05-17",
+    "Latest date": "2023-06-13",
+    "Description": "Alias of B.1.1.529.5.2.22, mainly found in USA, Canada and Germany, from #945"
+  },
+  {
+    "Lineage": "BA.5.2.23",
+    "Earliest date": "2022-08-05",
+    "Latest date": "2023-06-02",
+    "Description": "Alias of B.1.1.529.5.2.23, S:S255F, S:V445A, A4576T, T4579A, mainly found in USA, from #1090"
+  },
+  {
+    "Lineage": "BA.5.2.24",
+    "Earliest date": "2022-06-13",
+    "Latest date": "2023-09-02",
+    "Description": "Alias of B.1.1.529.5.2.24, defined by S:K444N on ORF1b:1050N branch"
+  },
+  {
+    "Lineage": "CK.1",
+    "Earliest date": "2021-07-16",
+    "Latest date": "2023-04-12",
+    "Description": "Alias of B.1.1.529.5.2.24.1, Pakistan, defined by S:N460K, from #1120"
+  },
+  {
+    "Lineage": "CK.1.1",
+    "Earliest date": "2022-02-03",
+    "Latest date": "2023-08-17",
+    "Description": "Alias of B.1.1.529.5.2.24.1.1, found mainly in Japan, from #1452"
+  },
+  {
+    "Lineage": "CK.1.1.1",
+    "Earliest date": "2022-12-22",
+    "Latest date": "2023-06-12",
+    "Description": "Alias of B.1.1.529.5.2.24.1.1.1, S:E654K, G6742T, C8782T, Japan"
+  },
+  {
+    "Lineage": "CK.1.1.2",
+    "Earliest date": "2023-02-24",
+    "Latest date": "2023-11-15",
+    "Description": "Alias of B.1.1.529.5.2.24.1.1.2, S:V1264L, Japan, from #2271"
+  },
+  {
+    "Lineage": "CK.1.2",
+    "Earliest date": "2022-09-30",
+    "Latest date": "2023-03-01",
+    "Description": "Alias of B.1.1.529.5.2.24.1.2, Pakistan, S:G181V, S:R346T, from #1467"
+  },
+  {
+    "Lineage": "CK.1.3",
+    "Earliest date": "2022-10-10",
+    "Latest date": "2024-04-17",
+    "Description": "Alias of B.1.1.529.5.2.24.1.3, Mexico, S:F157L, S:G181V"
+  },
+  {
+    "Lineage": "CK.1.4",
+    "Earliest date": "2022-10-16",
+    "Latest date": "2023-04-25",
+    "Description": "Alias of B.1.1.529.5.2.24.1.4, C10228T, C25824T, C27741T, on C25614T branch"
+  },
+  {
+    "Lineage": "CK.1.5",
+    "Earliest date": "2022-09-28",
+    "Latest date": "2023-04-16",
+    "Description": "Alias of B.1.1.529.5.2.24.1.5, C9118T, C15951T, ORF1a:M3733V, on C25614T branch"
+  },
+  {
+    "Lineage": "CK.2",
+    "Earliest date": "2022-07-12",
+    "Latest date": "2023-09-07",
+    "Description": "Alias of B.1.1.529.5.2.24.2, Pakistan, defined by E:V62F, from #1190"
+  },
+  {
+    "Lineage": "CK.2.1",
+    "Earliest date": "2022-08-01",
+    "Latest date": "2023-06-08",
+    "Description": "Alias of B.1.1.529.5.2.24.2.1, Pakistan, defined by S:N460K, from #1125"
+  },
+  {
+    "Lineage": "CK.2.1.1",
+    "Earliest date": "2022-09-17",
+    "Latest date": "2023-08-22",
+    "Description": "Alias of B.1.1.529.5.2.24.2.1.1, defined by S:S255F, from #1190"
+  },
+  {
+    "Lineage": "CK.3",
+    "Earliest date": "2022-09-05",
+    "Latest date": "2023-05-06",
+    "Description": "Alias of B.1.1.529.5.2.24.3, found mainly in Singapore and USA, from #1121"
+  },
+  {
+    "Lineage": "DG.1",
+    "Earliest date": "2022-10-06",
+    "Latest date": "2023-03-04",
+    "Description": "Alias of B.1.1.529.5.2.24.2.1.1.1, defined by S:G252S, from #1288"
+  },
+  {
+    "Lineage": "BA.5.2.25",
+    "Earliest date": "2022-07-21",
+    "Latest date": "2023-04-24",
+    "Description": "Alias of B.1.1.529.5.2.25, mainly found in France, USA and Canada, from #1111"
+  },
+  {
+    "Lineage": "DB.1",
+    "Earliest date": "2022-02-12",
+    "Latest date": "2023-05-06",
+    "Description": "Alias of B.1.1.529.5.2.25.1, France/Netherlands/Spain, S:R346T, S:N460K, from #1258"
+  },
+  {
+    "Lineage": "DB.2",
+    "Earliest date": "2022-09-04",
+    "Latest date": "2023-01-12",
+    "Description": "Alias of B.1.1.529.5.2.25.2, BeNeLux, S:A262S"
+  },
+  {
+    "Lineage": "DB.3",
+    "Earliest date": "2022-11-02",
+    "Latest date": "2023-01-30",
+    "Description": "Alias of B.1.1.529.5.2.25.3 found mainly in Europe, from #1613"
+  },
+  {
+    "Lineage": "BA.5.2.26",
+    "Earliest date": "2022-01-02",
+    "Latest date": "2023-05-08",
+    "Description": "Alias of B.1.1.529.5.2.26, most common in Thailand, defined by ORF3a:L108V, from #1133"
+  },
+  {
+    "Lineage": "BA.5.2.27",
+    "Earliest date": "2022-02-09",
+    "Latest date": "2023-04-20",
+    "Description": "Alias of B.1.1.529.5.2.27, most common in Vietnam, defined by ORF1a:I2332V, from #1133"
+  },
+  {
+    "Lineage": "CF.1",
+    "Earliest date": "2022-07-13",
+    "Latest date": "2022-12-13",
+    "Description": "Alias of B.1.1.529.5.2.27.1, USA and Mexico lineage, defined by S:K97T, originally designated as BA.5.2.15, from #1054"
+  },
+  {
+    "Lineage": "CG.1",
+    "Earliest date": "2022-06-27",
+    "Latest date": "2023-03-16",
+    "Description": "Alias of B.1.1.529.5.2.26.1, mainly found in Germany, Poland and Denmark, from #1126"
+  },
+  {
+    "Lineage": "BA.5.2.28",
+    "Earliest date": "2022-03-22",
+    "Latest date": "2023-05-10",
+    "Description": "Alias of B.1.1.529.5.2.28, most common in Malaysia, defined by ORF1a:T1437I, from #1133"
+  },
+  {
+    "Lineage": "BA.5.2.29",
+    "Earliest date": "2022-07-21",
+    "Latest date": "2022-12-13",
+    "Description": "Alias of B.1.1.529.5.2.29, mainly found in Denmark, from #1050"
+  },
+  {
+    "Lineage": "BA.5.2.30",
+    "Earliest date": "2021-10-24",
+    "Latest date": "2023-01-04",
+    "Description": "Alias of B.1.1.529.5.2.30, Europe lineage, defined by S:G446D"
+  },
+  {
+    "Lineage": "BA.5.2.31",
+    "Earliest date": "2022-06-06",
+    "Latest date": "2023-02-21",
+    "Description": "Alias of B.1.1.529.5.2.31, USA lineage, defined by S:L84I"
+  },
+  {
+    "Lineage": "CD.1",
+    "Earliest date": "2022-08-03",
+    "Latest date": "2023-01-18",
+    "Description": "Alias of B.1.1.529.5.2.31.1, USA lineage, defined by S:G446D, S:A688T"
+  },
+  {
+    "Lineage": "CD.2",
+    "Earliest date": "2022-08-02",
+    "Latest date": "2023-01-20",
+    "Description": "Alias of B.1.1.529.5.2.31.2, USA lineage, defined by S:A435S"
+  },
+  {
+    "Lineage": "BA.5.2.32",
+    "Earliest date": "2022-07-11",
+    "Latest date": "2023-04-13",
+    "Description": "Alias of B.1.1.529.5.2.32, Russia lineage, defined by S:N450D after ORF8:T87I"
+  },
+  {
+    "Lineage": "BA.5.2.33",
+    "Earliest date": "2020-07-22",
+    "Latest date": "2024-01-24",
+    "Description": "Alias of B.1.1.529.5.2.33, UK lineage, defined by ORF8:P93S"
+  },
+  {
+    "Lineage": "CE.1",
+    "Earliest date": "2022-07-21",
+    "Latest date": "2023-02-08",
+    "Description": "Alias of B.1.1.529.5.2.33.1, UK lineage, defined by S:R346I"
+  },
+  {
+    "Lineage": "BA.5.2.34",
+    "Earliest date": "2021-03-01",
+    "Latest date": "2023-07-24",
+    "Description": "Alias of B.1.1.529.5.2.34, mainly found in Israel and USA, from #992"
+  },
+  {
+    "Lineage": "BA.5.2.35",
+    "Earliest date": "2022-06-18",
+    "Latest date": "2023-12-13",
+    "Description": "Alias of B.1.1.529.5.2.35, Pakistan lineage, defined by S:R346T after G28423C and C7006T"
+  },
+  {
+    "Lineage": "BA.5.2.36",
+    "Earliest date": "2022-07-03",
+    "Latest date": "2023-06-02",
+    "Description": "Alias of B.1.1.529.5.2.36, India/Pakistan lineage, defined by S:K444T, from #1203"
+  },
+  {
+    "Lineage": "CT.1",
+    "Earliest date": "2022-08-04",
+    "Latest date": "2023-01-26",
+    "Description": "Alias of B.1.1.529.5.2.36.1, India/Pakistan lineage, defined by S:K356T, from #1203"
+  },
+  {
+    "Lineage": "BA.5.2.37",
+    "Earliest date": "2022-06-30",
+    "Latest date": "2023-01-09",
+    "Description": "Alias of B.1.1.529.5.2.37, found mainly in USA and India, from #1117"
+  },
+  {
+    "Lineage": "BA.5.2.38",
+    "Earliest date": "2022-06-18",
+    "Latest date": "2023-01-03",
+    "Description": "Alias of B.1.1.529.5.2.38, S:T430I, from #1254"
+  },
+  {
+    "Lineage": "DA.1",
+    "Earliest date": "2022-01-10",
+    "Latest date": "2023-01-24",
+    "Description": "Alias of B.1.1.529.5.2.38.1, Indonesia, S:R346T, from #1254"
+  },
+  {
+    "Lineage": "BA.5.2.39",
+    "Earliest date": "2022-08-18",
+    "Latest date": "2023-01-23",
+    "Description": "Alias of B.1.1.529.5.2.39, USA, S:R346T, from #1279"
+  },
+  {
+    "Lineage": "BA.5.2.40",
+    "Earliest date": "2022-09-02",
+    "Latest date": "2022-11-14",
+    "Description": "Alias of B.1.1.529.5.2.40, Sweden, S:N450D"
+  },
+  {
+    "Lineage": "BA.5.2.41",
+    "Earliest date": "2022-07-20",
+    "Latest date": "2022-12-13",
+    "Description": "Alias of B.1.1.529.5.2.41, found mainly in Sweden, from #1328"
+  },
+  {
+    "Lineage": "BA.5.2.42",
+    "Earliest date": "2022-09-12",
+    "Latest date": "2022-12-30",
+    "Description": "Alias of B.1.1.529.5.2.42, found mainly in Australia, from #1266"
+  },
+  {
+    "Lineage": "BA.5.2.43",
+    "Earliest date": "2022-01-23",
+    "Latest date": "2023-05-07",
+    "Description": "Alias of B.1.1.529.5.2.43, found mainly in SouthKorea, from #1312"
+  },
+  {
+    "Lineage": "BA.5.2.44",
+    "Earliest date": "2022-06-04",
+    "Latest date": "2023-05-02",
+    "Description": "Alias of B.1.1.529.5.2.44, Indonesia/Malaysia/SouthKorea/global, ORF1a:L2564F"
+  },
+  {
+    "Lineage": "BA.5.2.45",
+    "Earliest date": "2022-09-17",
+    "Latest date": "2023-02-02",
+    "Description": "Alias of B.1.1.529.5.2.45, found mainly in Australia, from #1383"
+  },
+  {
+    "Lineage": "BA.5.2.46",
+    "Earliest date": "2022-09-24",
+    "Latest date": "2023-04-22",
+    "Description": "Alias of B.1.1.529.5.2.46 found mainly in Japan, from #1446"
+  },
+  {
+    "Lineage": "BA.5.2.47",
+    "Earliest date": "2022-03-10",
+    "Latest date": "2023-08-29",
+    "Description": "Alias of B.1.1.529.5.2.47 found mainly in Indonesia, Australia, and USA, from #1496"
+  },
+  {
+    "Lineage": "DQ.1",
+    "Earliest date": "2022-09-16",
+    "Latest date": "2023-04-22",
+    "Description": "Alias of B.1.1.529.5.2.47.1 found mainly in Indonesia, Germany, and USA, from #1496"
+  },
+  {
+    "Lineage": "BA.5.2.48",
+    "Earliest date": "2022-09-29",
+    "Latest date": "2024-02-29",
+    "Description": "Alias of B.1.1.529.5.2.48, China, C2710T, C8626T, T17208C, from #1471"
+  },
+  {
+    "Lineage": "DY.1",
+    "Earliest date": "2022-08-15",
+    "Latest date": "2023-06-12",
+    "Description": "Alias of B.1.1.529.5.2.48.1, China, S:A570S, from #1479"
+  },
+  {
+    "Lineage": "DY.1.1",
+    "Earliest date": "2022-11-17",
+    "Latest date": "2023-05-20",
+    "Description": "Alias of B.1.1.529.5.2.48.1.1 found mainly in China, from #1599"
+  },
+  {
+    "Lineage": "DY.2",
+    "Earliest date": "2022-10-22",
+    "Latest date": "2023-11-18",
+    "Description": "Alias of B.1.1.529.5.2.48.2, China, N:Q241K, from #1478"
+  },
+  {
+    "Lineage": "DY.3",
+    "Earliest date": "2022-01-10",
+    "Latest date": "2023-11-18",
+    "Description": "Alias of B.1.1.529.5.2.48.3, China, ORF1a:T1788M, from #1472"
+  },
+  {
+    "Lineage": "DY.4",
+    "Earliest date": "2022-10-07",
+    "Latest date": "2023-12-17",
+    "Description": "Alias of B.1.1.529.5.2.48.4, China, ORF1b:T2432I"
+  },
+  {
+    "Lineage": "BA.5.2.49",
+    "Earliest date": "2022-09-23",
+    "Latest date": "2023-11-18",
+    "Description": "Alias of B.1.1.529.5.2.49, China, S:T883I, A14673G, T16456C, from #1480"
+  },
+  {
+    "Lineage": "DZ.1",
+    "Earliest date": "2022-11-17",
+    "Latest date": "2023-11-18",
+    "Description": "Alias of B.1.1.529.5.2.49.1, China, S:D1146Y"
+  },
+  {
+    "Lineage": "DZ.2",
+    "Earliest date": "2022-11-24",
+    "Latest date": "2023-06-07",
+    "Description": "Alias of B.1.1.529.5.2.49.2, China, S:G75V"
+  },
+  {
+    "Lineage": "BA.5.2.50",
+    "Earliest date": "2022-10-03",
+    "Latest date": "2023-07-28",
+    "Description": "Alias of B.1.1.529.5.2.50 China, ORF1a:S2488F after ORF1b:P1727L, from #1542"
+  },
+  {
+    "Lineage": "BA.5.2.51",
+    "Earliest date": "2022-08-01",
+    "Latest date": "2022-12-21",
+    "Description": "Alias of B.1.1.529.5.2.51 Russia/Estonia, S:K444R after ORF1b:P1727L"
+  },
+  {
+    "Lineage": "BA.5.2.52",
+    "Earliest date": "2022-07-26",
+    "Latest date": "2023-03-06",
+    "Description": "Alias of B.1.1.529.5.2.52 S:N450D after ORF1a:D2060N"
+  },
+  {
+    "Lineage": "BA.5.2.53",
+    "Earliest date": "2022-06-21",
+    "Latest date": "2023-02-09",
+    "Description": "Alias of B.1.1.529.5.2.53 USA, S:A653V after T17928C"
+  },
+  {
+    "Lineage": "BA.5.2.54",
+    "Earliest date": "2022-08-07",
+    "Latest date": "2023-03-03",
+    "Description": "Alias of B.1.1.529.5.2.54 Guatemala, S:N450D after C11020T"
+  },
+  {
+    "Lineage": "BA.5.2.55",
+    "Earliest date": "2022-06-17",
+    "Latest date": "2023-04-12",
+    "Description": "Alias of B.1.1.529.5.2.55 Japan, C5548A"
+  },
+  {
+    "Lineage": "BA.5.2.56",
+    "Earliest date": "2022-06-27",
+    "Latest date": "2023-02-17",
+    "Description": "Alias of B.1.1.529.5.2.56 UK, S:K444M"
+  },
+  {
+    "Lineage": "BA.5.2.57",
+    "Earliest date": "2022-06-27",
+    "Latest date": "2023-10-31",
+    "Description": "Alias of B.1.1.529.5.2.57 S:R346S"
+  },
+  {
+    "Lineage": "BA.5.2.58",
+    "Earliest date": "2022-07-29",
+    "Latest date": "2023-10-30",
+    "Description": "Alias of B.1.1.529.5.2.58 S:R346S after C9565T, C11479T, C12085T"
+  },
+  {
+    "Lineage": "BA.5.2.59",
+    "Earliest date": "2022-06-08",
+    "Latest date": "2023-04-29",
+    "Description": "Alias of B.1.1.529.5.2.59 USA, S:V1264L"
+  },
+  {
+    "Lineage": "BA.5.2.60",
+    "Earliest date": "2022-08-17",
+    "Latest date": "2023-03-15",
+    "Description": "Alias of B.1.1.529.5.2.60 Europe, S:N450D, ORF1a:K3832R after ORF1b:P1727L"
+  },
+  {
+    "Lineage": "BA.5.2.61",
+    "Earliest date": "2022-07-30",
+    "Latest date": "2023-08-11",
+    "Description": "Alias of B.1.1.529.5.2.61 S:N450D, ORF1b:Q2070L"
+  },
+  {
+    "Lineage": "BA.5.2.62",
+    "Earliest date": "2022-04-07",
+    "Latest date": "2023-08-02",
+    "Description": "Alias of B.1.1.529.5.2.62 S:A653V on BA.5.2 polytomy"
+  },
+  {
+    "Lineage": "BA.5.2.63",
+    "Earliest date": "2022-09-28",
+    "Latest date": "2023-04-04",
+    "Description": "Alias of B.1.1.529.5.2.63 found mainly in Canada, from #1636"
+  },
+  {
+    "Lineage": "BA.5.3",
+    "Earliest date": "2022-01-05",
+    "Latest date": "2023-04-26",
+    "Description": "Alias of B.1.1.529.5.3, mainly found in Germany and South Africa, from #550"
+  },
+  {
+    "Lineage": "BA.5.3.1",
+    "Earliest date": "2020-07-01",
+    "Latest date": "2024-02-06",
+    "Description": "Alias of B.1.1.529.5.3.1, mainly found in South Africa, Austria, and England, from #625"
+  },
+  {
+    "Lineage": "BE.1",
+    "Earliest date": "2020-07-01",
+    "Latest date": "2024-02-28",
+    "Description": "Alias of B.1.1.529.5.3.1.1, mainly found in South Africa, Austria and England, from #625"
+  },
+  {
+    "Lineage": "BE.1.1",
+    "Earliest date": "2021-07-16",
+    "Latest date": "2024-05-12",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1, Germany lineage"
+  },
+  {
+    "Lineage": "BE.1.1.1",
+    "Earliest date": "2022-02-06",
+    "Latest date": "2023-10-03",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1, found globally, from #931"
+  },
+  {
+    "Lineage": "BQ.1",
+    "Earliest date": "2021-07-16",
+    "Latest date": "2023-12-22",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1, Nigeria lineage, from #993"
+  },
+  {
+    "Lineage": "BQ.1.1",
+    "Earliest date": "2020-10-15",
+    "Latest date": "2024-05-04",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1, found globally, defining mutations ORF1b:N1191S and S:R346T, from #993"
+  },
+  {
+    "Lineage": "BQ.1.1.1",
+    "Earliest date": "2022-01-04",
+    "Latest date": "2023-08-30",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.1, Europe, ORF1b:V1639A"
+  },
+  {
+    "Lineage": "CZ.1",
+    "Earliest date": "2022-10-05",
+    "Latest date": "2023-01-25",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.1.1, England/SouthKorea/Romania, S:F490I"
+  },
+  {
+    "Lineage": "CZ.2",
+    "Earliest date": "2022-09-25",
+    "Latest date": "2023-03-28",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.1.2, S:A688V"
+  },
+  {
+    "Lineage": "BQ.1.1.2",
+    "Earliest date": "2022-08-10",
+    "Latest date": "2023-05-30",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.2, England, S:D253G, from #1209"
+  },
+  {
+    "Lineage": "DU.1",
+    "Earliest date": "2022-11-19",
+    "Latest date": "2023-08-23",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.2.1 found mainly in UK, from #1540"
+  },
+  {
+    "Lineage": "BQ.1.1.3",
+    "Earliest date": "2022-08-01",
+    "Latest date": "2023-05-28",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.3, England, A15111G"
+  },
+  {
+    "Lineage": "DR.1",
+    "Earliest date": "2022-10-22",
+    "Latest date": "2023-03-23",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.3.1, S:M153I, found mainly in USA, from #1420"
+  },
+  {
+    "Lineage": "DR.2",
+    "Earliest date": "2022-11-01",
+    "Latest date": "2023-04-15",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.3.2, S:478R, USA"
+  },
+  {
+    "Lineage": "BQ.1.1.4",
+    "Earliest date": "2021-07-16",
+    "Latest date": "2024-01-01",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.4, T29173C"
+  },
+  {
+    "Lineage": "EE.1",
+    "Earliest date": "2022-09-09",
+    "Latest date": "2023-05-27",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.4.1, USA, N:T366I"
+  },
+  {
+    "Lineage": "EE.2",
+    "Earliest date": "2022-09-12",
+    "Latest date": "2023-05-04",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.4.2, ORF1b:V1538I"
+  },
+  {
+    "Lineage": "EE.3",
+    "Earliest date": "2022-10-02",
+    "Latest date": "2023-05-09",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.4.3, Canada/USA, C22498T"
+  },
+  {
+    "Lineage": "EE.4",
+    "Earliest date": "2022-10-03",
+    "Latest date": "2023-05-22",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.4.4, Europe, S:Q52H"
+  },
+  {
+    "Lineage": "EE.5",
+    "Earliest date": "2022-10-16",
+    "Latest date": "2023-03-09",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.4.5, USA, S:N185Y"
+  },
+  {
+    "Lineage": "BQ.1.1.5",
+    "Earliest date": "2021-07-16",
+    "Latest date": "2023-06-14",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.5, ORF1b:P2313L, ORF1a:V3855I"
+  },
+  {
+    "Lineage": "DN.1",
+    "Earliest date": "2022-10-03",
+    "Latest date": "2023-06-12",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.5.1, S:K147N"
+  },
+  {
+    "Lineage": "DN.1.1",
+    "Earliest date": "2022-10-23",
+    "Latest date": "2023-04-21",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.5.1.1 found mainly in UK and Denmark, from #1463"
+  },
+  {
+    "Lineage": "DN.1.1.1",
+    "Earliest date": "2022-12-11",
+    "Latest date": "2023-04-10",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.5.1.1.1 UK, S:Y453F, from #1548"
+  },
+  {
+    "Lineage": "DN.1.1.2",
+    "Earliest date": "2022-12-17",
+    "Latest date": "2023-03-07",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.5.1.1.2 UK, S:P479L"
+  },
+  {
+    "Lineage": "DN.1.1.3",
+    "Earliest date": "2022-11-23",
+    "Latest date": "2023-03-27",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.5.1.1.3 S:S704L, UK"
+  },
+  {
+    "Lineage": "DN.1.1.4",
+    "Earliest date": "2022-12-19",
+    "Latest date": "2023-03-24",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.5.1.1.4 S:N481S, UK"
+  },
+  {
+    "Lineage": "DN.2",
+    "Earliest date": "2022-09-24",
+    "Latest date": "2023-04-20",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.5.2, ORF1b:D2351N, USA"
+  },
+  {
+    "Lineage": "DN.3",
+    "Earliest date": "2022-10-11",
+    "Latest date": "2023-02-20",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.5.3, ORF1a:V1025L"
+  },
+  {
+    "Lineage": "DN.3.1",
+    "Earliest date": "2022-11-18",
+    "Latest date": "2023-04-13",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.5.3.1, S:K182E"
+  },
+  {
+    "Lineage": "BQ.1.1.6",
+    "Earliest date": "2022-07-26",
+    "Latest date": "2023-09-03",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.6, ORF1a:L681F"
+  },
+  {
+    "Lineage": "BQ.1.1.7",
+    "Earliest date": "2022-01-13",
+    "Latest date": "2023-07-03",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.7, ORF1a:S216Y"
+  },
+  {
+    "Lineage": "DK.1",
+    "Earliest date": "2022-10-20",
+    "Latest date": "2023-02-20",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.7.1, S:339N, ORF1a:A1809T"
+  },
+  {
+    "Lineage": "BQ.1.1.8",
+    "Earliest date": "2022-01-02",
+    "Latest date": "2023-07-17",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.8, ORF1a:H374Y, ORF1a:L969F"
+  },
+  {
+    "Lineage": "DP.1",
+    "Earliest date": "2022-11-15",
+    "Latest date": "2023-01-30",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.8.1, S:A352S, England/Belgium"
+  },
+  {
+    "Lineage": "BQ.1.1.9",
+    "Earliest date": "2022-09-26",
+    "Latest date": "2023-10-05",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.9, S:S151I"
+  },
+  {
+    "Lineage": "BQ.1.1.10",
+    "Earliest date": "2022-04-27",
+    "Latest date": "2023-12-25",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.10, S:Y144-, T16413C, Denmark/Germany"
+  },
+  {
+    "Lineage": "FA.1",
+    "Earliest date": "2022-01-17",
+    "Latest date": "2023-04-28",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.10.1, S:K478R, USA"
+  },
+  {
+    "Lineage": "FA.2",
+    "Earliest date": "2022-10-10",
+    "Latest date": "2023-02-01",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.10.2, S:T323I, Denmark"
+  },
+  {
+    "Lineage": "BQ.1.1.11",
+    "Earliest date": "2022-08-01",
+    "Latest date": "2024-05-10",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.11, S:S494P"
+  },
+  {
+    "Lineage": "BQ.1.1.12",
+    "Earliest date": "2022-09-10",
+    "Latest date": "2023-02-02",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.12, France/USA, S:S494P, on ORF1a:T4368I branch"
+  },
+  {
+    "Lineage": "BQ.1.1.13",
+    "Earliest date": "2022-09-21",
+    "Latest date": "2024-02-14",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.13, Denmark/Israel/Switzerland/France, E:V62F and S:Y144-"
+  },
+  {
+    "Lineage": "EF.1",
+    "Earliest date": "2022-09-28",
+    "Latest date": "2023-08-25",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.13.1, C6040T"
+  },
+  {
+    "Lineage": "EF.1.1",
+    "Earliest date": "2022-01-03",
+    "Latest date": "2023-07-17",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.13.1.1, C23086T,T7783C"
+  },
+  {
+    "Lineage": "EF.1.1.1",
+    "Earliest date": "2022-11-09",
+    "Latest date": "2023-05-25",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.13.1.1.1, Brazil, S:F157L"
+  },
+  {
+    "Lineage": "EY.1",
+    "Earliest date": "2022-11-17",
+    "Latest date": "2023-07-11",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.13.1.1.1.1, Brazil/USA, S:Q613H"
+  },
+  {
+    "Lineage": "EF.1.2",
+    "Earliest date": "2022-01-26",
+    "Latest date": "2024-04-04",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.13.1.2, Spain, T15492C"
+  },
+  {
+    "Lineage": "EF.1.3",
+    "Earliest date": "2022-01-13",
+    "Latest date": "2023-04-03",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.13.1.3, N:T166I"
+  },
+  {
+    "Lineage": "EF.2",
+    "Earliest date": "2022-10-13",
+    "Latest date": "2023-07-21",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.13.2, UK, ORF1b:V119I"
+  },
+  {
+    "Lineage": "EF.3",
+    "Earliest date": "2022-10-18",
+    "Latest date": "2023-09-25",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.13.2, Japan, S:S704T"
+  },
+  {
+    "Lineage": "BQ.1.1.14",
+    "Earliest date": "2022-09-20",
+    "Latest date": "2023-03-01",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.14, England, G23608T"
+  },
+  {
+    "Lineage": "CW.1",
+    "Earliest date": "2022-10-15",
+    "Latest date": "2022-10-24",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.14.1, England, S:G446S"
+  },
+  {
+    "Lineage": "BQ.1.1.15",
+    "Earliest date": "2021-07-16",
+    "Latest date": "2024-02-14",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.15, Spain, T18897C"
+  },
+  {
+    "Lineage": "DM.1",
+    "Earliest date": "2022-10-11",
+    "Latest date": "2023-05-04",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.15.1, Spain/Europe/USA, S:A348S"
+  },
+  {
+    "Lineage": "BQ.1.1.16",
+    "Earliest date": "2022-09-07",
+    "Latest date": "2023-02-13",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.16, England, S:Q607H"
+  },
+  {
+    "Lineage": "BQ.1.1.17",
+    "Earliest date": "2022-05-02",
+    "Latest date": "2023-04-08",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.17, France, ORF1a:S2273F"
+  },
+  {
+    "Lineage": "BQ.1.1.18",
+    "Earliest date": "2021-07-16",
+    "Latest date": "2024-03-25",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.18, France, C6541T"
+  },
+  {
+    "Lineage": "ED.1",
+    "Earliest date": "2022-10-31",
+    "Latest date": "2023-07-06",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.18.1, Japan, ORF3a:L108F, ORF1a:C433S"
+  },
+  {
+    "Lineage": "ED.2",
+    "Earliest date": "2022-10-01",
+    "Latest date": "2023-07-31",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.18.2, USA, ORF1a:D928Y"
+  },
+  {
+    "Lineage": "ED.3",
+    "Earliest date": "2022-10-17",
+    "Latest date": "2023-03-25",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.18.3, USA, S:D843N"
+  },
+  {
+    "Lineage": "BQ.1.1.19",
+    "Earliest date": "2022-09-27",
+    "Latest date": "2023-04-18",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.19, England, N:Q380H"
+  },
+  {
+    "Lineage": "BQ.1.1.20",
+    "Earliest date": "2022-10-13",
+    "Latest date": "2023-05-02",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.20, Denmark, S:144- and ORF3a:H204Y"
+  },
+  {
+    "Lineage": "BQ.1.1.21",
+    "Earliest date": "2022-09-26",
+    "Latest date": "2023-07-13",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.21, Switzerland/France, S:144- and A17946G"
+  },
+  {
+    "Lineage": "BQ.1.1.22",
+    "Earliest date": "2022-09-29",
+    "Latest date": "2023-06-20",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.22, Australia/England/Denmark, S:144- and C913A"
+  },
+  {
+    "Lineage": "ER.1",
+    "Earliest date": "2022-09-14",
+    "Latest date": "2023-07-24",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.22.1 found mainly in UK, from #1492"
+  },
+  {
+    "Lineage": "ER.1.1",
+    "Earliest date": "2022-12-13",
+    "Latest date": "2023-04-25",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.22.1.1 found mainly in UK, from #1715"
+  },
+  {
+    "Lineage": "BQ.1.1.23",
+    "Earliest date": "2022-07-25",
+    "Latest date": "2024-05-16",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.23, France, ORF3a:V97I, S:Y144-, on G6421T branch"
+  },
+  {
+    "Lineage": "BQ.1.1.24",
+    "Earliest date": "2022-09-18",
+    "Latest date": "2023-04-17",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.24, England, 11941T, S:Y144-"
+  },
+  {
+    "Lineage": "BQ.1.1.25",
+    "Earliest date": "2022-10-19",
+    "Latest date": "2023-02-12",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.25, USA/Canada, S:F490S and S:Y144-, from #1350"
+  },
+  {
+    "Lineage": "BQ.1.1.26",
+    "Earliest date": "2022-10-24",
+    "Latest date": "2023-03-22",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.26, S:E471Q"
+  },
+  {
+    "Lineage": "BQ.1.1.27",
+    "Earliest date": "2022-09-26",
+    "Latest date": "2023-03-01",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.27, France/USA, S:G181R, ORF1a:F2864L, on G6421T branch"
+  },
+  {
+    "Lineage": "BQ.1.1.28",
+    "Earliest date": "2022-08-15",
+    "Latest date": "2023-04-24",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.28, S:P251L, ORF1b:P976S, on C18828T branch"
+  },
+  {
+    "Lineage": "EH.1",
+    "Earliest date": "2022-01-13",
+    "Latest date": "2023-06-09",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.28.1, Europe, S:S247N, S:Y248S, from #1648"
+  },
+  {
+    "Lineage": "BQ.1.1.29",
+    "Earliest date": "2022-10-07",
+    "Latest date": "2023-07-10",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.29, S:Q613H"
+  },
+  {
+    "Lineage": "BQ.1.1.30",
+    "Earliest date": "2022-10-29",
+    "Latest date": "2023-04-18",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.30, Canada, S:V445A"
+  },
+  {
+    "Lineage": "BQ.1.1.31",
+    "Earliest date": "2022-09-21",
+    "Latest date": "2023-10-30",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.31, Indonesia/global, S:S256L"
+  },
+  {
+    "Lineage": "BQ.1.1.32",
+    "Earliest date": "2021-11-30",
+    "Latest date": "2023-05-09",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.32 found mainly in USA, S:153I, S:144-, from #1402"
+  },
+  {
+    "Lineage": "DT.1",
+    "Earliest date": "2022-11-15",
+    "Latest date": "2023-05-08",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.32.1 England, S:F494P, from #1484"
+  },
+  {
+    "Lineage": "DT.2",
+    "Earliest date": "2022-10-21",
+    "Latest date": "2023-06-19",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.32.2 found mainly in USA, from #1612"
+  },
+  {
+    "Lineage": "DT.3",
+    "Earliest date": "2022-11-26",
+    "Latest date": "2024-07-25",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.32.3 USA, S:L176F"
+  },
+  {
+    "Lineage": "BQ.1.1.34",
+    "Earliest date": "2022-11-26",
+    "Latest date": "2023-02-21",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.34, England, S:144-, S:494P, from #1483"
+  },
+  {
+    "Lineage": "BQ.1.1.35",
+    "Earliest date": "2022-10-23",
+    "Latest date": "2023-05-16",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.35, Canada, S:K147E, ORF1a:A1812T"
+  },
+  {
+    "Lineage": "ET.1",
+    "Earliest date": "2022-11-23",
+    "Latest date": "2023-05-10",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.35.1 found mainly in UK and Belgium, from #1732"
+  },
+  {
+    "Lineage": "BQ.1.1.36",
+    "Earliest date": "2022-10-18",
+    "Latest date": "2023-05-21",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.36, Brazil, S:T883I"
+  },
+  {
+    "Lineage": "BQ.1.1.37",
+    "Earliest date": "2022-11-15",
+    "Latest date": "2023-12-16",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.37 Italy, ins_S:247:SAE, S:Y248D, from #1571"
+  },
+  {
+    "Lineage": "BQ.1.1.38",
+    "Earliest date": "2022-10-25",
+    "Latest date": "2023-05-12",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.38 found mainly in South Africa and USA, from #1419"
+  },
+  {
+    "Lineage": "EW.1",
+    "Earliest date": "2022-11-29",
+    "Latest date": "2023-05-09",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.38.1 South Africa/Germany, S:478R, T4579A, from #1786"
+  },
+  {
+    "Lineage": "EW.2",
+    "Earliest date": "2022-09-25",
+    "Latest date": "2023-03-27",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.38.2 S:A701V"
+  },
+  {
+    "Lineage": "EW.3",
+    "Earliest date": "2022-12-01",
+    "Latest date": "2023-03-27",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.38.3 S:A348S, South Africa"
+  },
+  {
+    "Lineage": "BQ.1.1.39",
+    "Earliest date": "2022-09-15",
+    "Latest date": "2023-05-21",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.39 found mainly in England, Singapore and Canada, from #1385"
+  },
+  {
+    "Lineage": "FQ.1",
+    "Earliest date": "2023-01-30",
+    "Latest date": "2023-10-27",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.39.1, found mainly in Sweden, France and Australia, from #1797"
+  },
+  {
+    "Lineage": "BQ.1.1.40",
+    "Earliest date": "2022-09-21",
+    "Latest date": "2023-07-13",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.40 Canada, defined by N:T24I"
+  },
+  {
+    "Lineage": "BQ.1.1.41",
+    "Earliest date": "2022-08-15",
+    "Latest date": "2023-05-16",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.41 USA, defined by S:K182I, from #1291"
+  },
+  {
+    "Lineage": "BQ.1.1.42",
+    "Earliest date": "2022-08-01",
+    "Latest date": "2023-09-11",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.42 France, defined by S:S704L"
+  },
+  {
+    "Lineage": "BQ.1.1.43",
+    "Earliest date": "2022-11-08",
+    "Latest date": "2023-05-04",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.43 USA, S:Q613H (G23401C), C26292T"
+  },
+  {
+    "Lineage": "EZ.1",
+    "Earliest date": "2022-12-26",
+    "Latest date": "2023-06-12",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.43.1 Portugal, S:S247N, S:Y248S, from #1673"
+  },
+  {
+    "Lineage": "BQ.1.1.44",
+    "Earliest date": "2022-10-18",
+    "Latest date": "2023-05-09",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.44 S:D253G"
+  },
+  {
+    "Lineage": "BQ.1.1.45",
+    "Earliest date": "2022-02-28",
+    "Latest date": "2023-08-07",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.45 Europe, S:Y248D, from #1512"
+  },
+  {
+    "Lineage": "BQ.1.1.46",
+    "Earliest date": "2022-01-02",
+    "Latest date": "2024-02-01",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.46 France, S:F157L"
+  },
+  {
+    "Lineage": "EN.1",
+    "Earliest date": "2022-01-09",
+    "Latest date": "2023-07-19",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.46.1 France, S:V1264L, from #1696"
+  },
+  {
+    "Lineage": "EN.1.1",
+    "Earliest date": "2023-01-09",
+    "Latest date": "2023-05-30",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.46.1.1 S:M153I, France"
+  },
+  {
+    "Lineage": "BQ.1.1.47",
+    "Earliest date": "2022-01-13",
+    "Latest date": "2023-11-21",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.47 S:K147I"
+  },
+  {
+    "Lineage": "BQ.1.1.48",
+    "Earliest date": "2022-11-07",
+    "Latest date": "2023-05-11",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.48 S:H245N"
+  },
+  {
+    "Lineage": "BQ.1.1.49",
+    "Earliest date": "2022-11-14",
+    "Latest date": "2023-02-25",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.49 S:H1083D"
+  },
+  {
+    "Lineage": "BQ.1.1.50",
+    "Earliest date": "2022-02-15",
+    "Latest date": "2023-02-15",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.50 found mainly in Peru, from #1577"
+  },
+  {
+    "Lineage": "BQ.1.1.51",
+    "Earliest date": "2022-09-16",
+    "Latest date": "2023-04-26",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.51 USA, ORF3a:L101F"
+  },
+  {
+    "Lineage": "BQ.1.1.52",
+    "Earliest date": "2022-09-14",
+    "Latest date": "2023-06-04",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.52 USA/Mexico, C7006T"
+  },
+  {
+    "Lineage": "EA.1",
+    "Earliest date": "2022-10-11",
+    "Latest date": "2023-08-03",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.52.1 ORF8:C102F/ins_S:247:SKWL, from #1635"
+  },
+  {
+    "Lineage": "EA.2",
+    "Earliest date": "2022-11-03",
+    "Latest date": "2023-02-13",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.52.2 S:T470I"
+  },
+  {
+    "Lineage": "BQ.1.1.53",
+    "Earliest date": "2022-10-22",
+    "Latest date": "2023-05-20",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.53 S:N185D"
+  },
+  {
+    "Lineage": "FM.1",
+    "Earliest date": "2022-11-18",
+    "Latest date": "2023-05-20",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.53.1 S:613H, England"
+  },
+  {
+    "Lineage": "FM.2",
+    "Earliest date": "2022-12-19",
+    "Latest date": "2023-07-19",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.53.2 S:946R, Germany"
+  },
+  {
+    "Lineage": "BQ.1.1.54",
+    "Earliest date": "2022-09-29",
+    "Latest date": "2023-06-12",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.54 USA, S:F186S, N:A211T"
+  },
+  {
+    "Lineage": "BQ.1.1.55",
+    "Earliest date": "2022-11-18",
+    "Latest date": "2023-09-15",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.55 USA, S:K1149R"
+  },
+  {
+    "Lineage": "BQ.1.1.56",
+    "Earliest date": "2022-09-20",
+    "Latest date": "2023-06-13",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.56 S:H1101Y"
+  },
+  {
+    "Lineage": "BQ.1.1.57",
+    "Earliest date": "2022-09-28",
+    "Latest date": "2024-04-04",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.57 S:S256A"
+  },
+  {
+    "Lineage": "BQ.1.1.58",
+    "Earliest date": "2022-11-14",
+    "Latest date": "2023-06-15",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.58 USA/England, S:I934V"
+  },
+  {
+    "Lineage": "BQ.1.1.59",
+    "Earliest date": "2022-10-20",
+    "Latest date": "2023-05-22",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.59 France, S:T732I"
+  },
+  {
+    "Lineage": "BQ.1.1.60",
+    "Earliest date": "2022-10-17",
+    "Latest date": "2023-04-13",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.60 Brazil, S:S691F, from #1426"
+  },
+  {
+    "Lineage": "BQ.1.1.61",
+    "Earliest date": "2022-11-13",
+    "Latest date": "2023-03-23",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.61 USA, S:P621H"
+  },
+  {
+    "Lineage": "BQ.1.1.62",
+    "Earliest date": "2022-10-04",
+    "Latest date": "2023-03-11",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.62 France, S:P621S"
+  },
+  {
+    "Lineage": "BQ.1.1.63",
+    "Earliest date": "2022-10-20",
+    "Latest date": "2023-05-17",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.63 USA, S:Y248H"
+  },
+  {
+    "Lineage": "BQ.1.1.64",
+    "Earliest date": "2022-10-26",
+    "Latest date": "2023-03-11",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.64 South Africa, S:F186S"
+  },
+  {
+    "Lineage": "BQ.1.1.65",
+    "Earliest date": "2022-11-28",
+    "Latest date": "2023-09-22",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.65 Mexico, S:K147I, N:T135I"
+  },
+  {
+    "Lineage": "ES.1",
+    "Earliest date": "2022-12-19",
+    "Latest date": "2023-05-12",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.65.1 found mainly in Canada and USA, from #1722"
+  },
+  {
+    "Lineage": "BQ.1.1.66",
+    "Earliest date": "2022-10-14",
+    "Latest date": "2023-05-22",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.66 England/France, S:K147N"
+  },
+  {
+    "Lineage": "BQ.1.1.67",
+    "Earliest date": "2022-09-11",
+    "Latest date": "2023-04-21",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.67 S:L176F"
+  },
+  {
+    "Lineage": "BQ.1.1.68",
+    "Earliest date": "2022-09-26",
+    "Latest date": "2023-03-21",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.68 USA, ORF1a:V1211I"
+  },
+  {
+    "Lineage": "BQ.1.1.69",
+    "Earliest date": "2022-01-02",
+    "Latest date": "2023-06-30",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.69 ORF1b:S2027L"
+  },
+  {
+    "Lineage": "BQ.1.1.70",
+    "Earliest date": "2022-10-12",
+    "Latest date": "2023-09-13",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.70 Japan, ORF1a:A903V, M:S212G, from #1445"
+  },
+  {
+    "Lineage": "BQ.1.1.71",
+    "Earliest date": "2022-12-30",
+    "Latest date": "2023-04-12",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.71 found in England, from #1713"
+  },
+  {
+    "Lineage": "EV.1",
+    "Earliest date": "2023-02-11",
+    "Latest date": "2023-05-02",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.71.1 S:Y248H, England"
+  },
+  {
+    "Lineage": "BQ.1.1.72",
+    "Earliest date": "2022-09-13",
+    "Latest date": "2023-04-04",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.72 ORF1b:D100A"
+  },
+  {
+    "Lineage": "FC.1",
+    "Earliest date": "2022-10-31",
+    "Latest date": "2023-04-27",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.72.1 S:478R, Indonesia"
+  },
+  {
+    "Lineage": "BQ.1.1.73",
+    "Earliest date": "2022-11-22",
+    "Latest date": "2023-03-18",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.73, found mainly in Canada and Spain, from #1740"
+  },
+  {
+    "Lineage": "BQ.1.1.74",
+    "Earliest date": "2022-06-06",
+    "Latest date": "2023-05-03",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.74, S:182E, found mainly in Botswana and UK, from #1817"
+  },
+  {
+    "Lineage": "FN.1",
+    "Earliest date": "2023-01-09",
+    "Latest date": "2023-04-24",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.74.1, S:478R, Botswana/England, from #1817"
+  },
+  {
+    "Lineage": "BQ.1.1.75",
+    "Earliest date": "2022-12-21",
+    "Latest date": "2023-05-19",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.75, S:K182N, S:F456L (T22928C), Reunion"
+  },
+  {
+    "Lineage": "BQ.1.1.76",
+    "Earliest date": "2022-09-14",
+    "Latest date": "2023-08-08",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.76, C15180T, Slovenia/Austria"
+  },
+  {
+    "Lineage": "BQ.1.1.77",
+    "Earliest date": "2022-10-24",
+    "Latest date": "2023-05-28",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.77, C12853T, ORF1b:A1428V, USA/France"
+  },
+  {
+    "Lineage": "BQ.1.1.78",
+    "Earliest date": "2022-11-04",
+    "Latest date": "2023-05-24",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.78, ORF1a:M315I, ORF1b:P1953L, Japan"
+  },
+  {
+    "Lineage": "BQ.1.1.79",
+    "Earliest date": "2022-11-16",
+    "Latest date": "2023-05-17",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.1.79, S:Q613H, C1594T, C16362T, T24079C, Greece"
+  },
+  {
+    "Lineage": "BQ.1.2",
+    "Earliest date": "2022-01-04",
+    "Latest date": "2023-08-20",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.2, found globally, defined by S:I666V, from #1082"
+  },
+  {
+    "Lineage": "BQ.1.2.1",
+    "Earliest date": "2022-07-27",
+    "Latest date": "2023-05-01",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.2.1, found mainly in Japan, SouthKorea and Mongolia, from #1392"
+  },
+  {
+    "Lineage": "FB.1",
+    "Earliest date": "2022-11-14",
+    "Latest date": "2024-05-27",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.2.1.1 S:D253G, Singapore/Taiwan/Japan, from #1714"
+  },
+  {
+    "Lineage": "FB.2",
+    "Earliest date": "2022-01-24",
+    "Latest date": "2023-05-04",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.2.1.2 S:478R, USA/South Korea/Mongolia"
+  },
+  {
+    "Lineage": "BQ.1.2.2",
+    "Earliest date": "2023-01-27",
+    "Latest date": "2023-10-09",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.2.2, S:K147E, S:R346T, S:V445A, West Africa, from #1861"
+  },
+  {
+    "Lineage": "JH.1",
+    "Earliest date": "2023-06-15",
+    "Latest date": "2023-11-02",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.2.2.1, S:K182E, S:486A, S:S494P, S:E554K, from #2068"
+  },
+  {
+    "Lineage": "JH.2",
+    "Earliest date": "2023-07-24",
+    "Latest date": "2023-12-19",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.2.2.2, S:A484K, S:V486A, USA/Canada/Finland, from sars-cov-2-variants/lineage-proposals#650, from #2068, from #2068, from #2068, from #2068, from #2068, from #2068, from #2068"
+  },
+  {
+    "Lineage": "BQ.1.2.3",
+    "Earliest date": "2022-01-06",
+    "Latest date": "2023-09-25",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.2.3, E:V24L, Canada"
+  },
+  {
+    "Lineage": "BQ.1.3",
+    "Earliest date": "2022-09-02",
+    "Latest date": "2023-03-20",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.3, found globally, defined by S:E619Q, from #1082"
+  },
+  {
+    "Lineage": "BQ.1.3.1",
+    "Earliest date": "2022-08-01",
+    "Latest date": "2023-09-09",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.3.1, C2509T, Spain"
+  },
+  {
+    "Lineage": "BQ.1.3.2",
+    "Earliest date": "2022-08-01",
+    "Latest date": "2024-07-31",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.3.2, ORF1a:L1853F, USA"
+  },
+  {
+    "Lineage": "BQ.1.4",
+    "Earliest date": "2022-09-07",
+    "Latest date": "2023-03-16",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.4, England and Denmark, defined by S:R190T"
+  },
+  {
+    "Lineage": "BQ.1.5",
+    "Earliest date": "2022-07-01",
+    "Latest date": "2023-06-14",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.5, defined by ORF1b:T1076I"
+  },
+  {
+    "Lineage": "BQ.1.6",
+    "Earliest date": "2022-07-25",
+    "Latest date": "2023-03-02",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.6, USA lineage, defined by ORF1a:G94C"
+  },
+  {
+    "Lineage": "BQ.1.7",
+    "Earliest date": "2022-07-29",
+    "Latest date": "2023-02-27",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.7, defined by S:L54F"
+  },
+  {
+    "Lineage": "BQ.1.8",
+    "Earliest date": "2021-09-04",
+    "Latest date": "2023-08-16",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.8, defined by ORF1a:S505F and S:Y144-, from #1202"
+  },
+  {
+    "Lineage": "BQ.1.8.1",
+    "Earliest date": "2022-09-17",
+    "Latest date": "2023-03-27",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.8.1, England/Australia, S:256L"
+  },
+  {
+    "Lineage": "BQ.1.8.2",
+    "Earliest date": "2022-09-14",
+    "Latest date": "2023-03-09",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.8.2, England/Scotland, S:A688V"
+  },
+  {
+    "Lineage": "FF.1",
+    "Earliest date": "2022-11-10",
+    "Latest date": "2023-03-28",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.8.2.1 found mainly in the UK, from #1523"
+  },
+  {
+    "Lineage": "BQ.1.9",
+    "Earliest date": "2022-09-13",
+    "Latest date": "2023-03-21",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.9, USA lineage, defined by ORF1a:V2604I followed by S:346T (independent from BQ.1.1)"
+  },
+  {
+    "Lineage": "BQ.1.10",
+    "Earliest date": "2022-01-15",
+    "Latest date": "2024-01-09",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.10, international lineage, 27600T"
+  },
+  {
+    "Lineage": "BQ.1.10.1",
+    "Earliest date": "2021-07-16",
+    "Latest date": "2023-07-31",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.10.1, Italy/England/Denmark, S:H146L, from #1189"
+  },
+  {
+    "Lineage": "EC.1",
+    "Earliest date": "2022-11-06",
+    "Latest date": "2023-05-04",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.10.1.1, England, S:Q613H"
+  },
+  {
+    "Lineage": "EC.1.1",
+    "Earliest date": "2022-12-05",
+    "Latest date": "2023-05-16",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.10.1.1.1, England, S:V445A"
+  },
+  {
+    "Lineage": "BQ.1.10.2",
+    "Earliest date": "2022-10-26",
+    "Latest date": "2023-04-12",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.10.2, S:T523N"
+  },
+  {
+    "Lineage": "BQ.1.10.3",
+    "Earliest date": "2022-10-08",
+    "Latest date": "2023-04-26",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.10.3, S:K147E"
+  },
+  {
+    "Lineage": "BQ.1.11",
+    "Earliest date": "2022-08-01",
+    "Latest date": "2023-05-30",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.11, international lineage, 29541T"
+  },
+  {
+    "Lineage": "BQ.1.11.1",
+    "Earliest date": "2022-11-10",
+    "Latest date": "2023-02-16",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.11.1 found mainly in USA and Peru, from #1581"
+  },
+  {
+    "Lineage": "BQ.1.12",
+    "Earliest date": "2022-07-25",
+    "Latest date": "2024-03-02",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.12, international lineage, 28849T"
+  },
+  {
+    "Lineage": "BQ.1.13",
+    "Earliest date": "2022-02-18",
+    "Latest date": "2023-04-26",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.13, international lineage, ORF1a:V627I"
+  },
+  {
+    "Lineage": "BQ.1.13.1",
+    "Earliest date": "2022-07-27",
+    "Latest date": "2023-08-25",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.13.1 found mainly in USA and Europe, from #1400"
+  },
+  {
+    "Lineage": "BQ.1.14",
+    "Earliest date": "2022-01-05",
+    "Latest date": "2023-06-22",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.14, international lineage, 18570A"
+  },
+  {
+    "Lineage": "BQ.1.15",
+    "Earliest date": "2022-09-01",
+    "Latest date": "2023-03-07",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.15, international lineage, ORF1a:L3116F"
+  },
+  {
+    "Lineage": "BQ.1.15.1",
+    "Earliest date": "2022-11-14",
+    "Latest date": "2023-04-11",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.15.1, Canada, ins_S:247:SKWL, C17745T"
+  },
+  {
+    "Lineage": "BQ.1.15.2",
+    "Earliest date": "2022-12-30",
+    "Latest date": "2023-04-30",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.15.2, Canada, ins_S:247:SKWL, C6286T"
+  },
+  {
+    "Lineage": "BQ.1.16",
+    "Earliest date": "2022-08-22",
+    "Latest date": "2023-03-10",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.16, international lineage, ORF1a:A540V"
+  },
+  {
+    "Lineage": "BQ.1.17",
+    "Earliest date": "2022-09-05",
+    "Latest date": "2023-04-11",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.17, Denmark/Germany, S:K444T mutated further to S:444M"
+  },
+  {
+    "Lineage": "BQ.1.18",
+    "Earliest date": "2022-07-25",
+    "Latest date": "2023-06-29",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.18, Denmark/Austria, E:P71S, then S:R346T and S:Y144-"
+  },
+  {
+    "Lineage": "BQ.1.19",
+    "Earliest date": "2022-08-14",
+    "Latest date": "2023-01-13",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.19, S:S494P"
+  },
+  {
+    "Lineage": "BQ.1.20",
+    "Earliest date": "2022-08-29",
+    "Latest date": "2023-03-21",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.20, S:A348S"
+  },
+  {
+    "Lineage": "BQ.1.21",
+    "Earliest date": "2022-07-27",
+    "Latest date": "2023-10-30",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.21, England/France, S:R346S, S:Y144-"
+  },
+  {
+    "Lineage": "BQ.1.22",
+    "Earliest date": "2022-09-26",
+    "Latest date": "2024-06-24",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.22, Canada, S:R346T after C26681T"
+  },
+  {
+    "Lineage": "BQ.1.23",
+    "Earliest date": "2021-12-07",
+    "Latest date": "2023-08-22",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.23, Singapore/Indonesia/Australia, A2653G and S:Y144-"
+  },
+  {
+    "Lineage": "BQ.1.24",
+    "Earliest date": "2022-09-05",
+    "Latest date": "2023-10-03",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.24, South Africa, S:T240I, S:R346T, from #1240"
+  },
+  {
+    "Lineage": "BQ.1.25",
+    "Earliest date": "2022-01-12",
+    "Latest date": "2023-08-31",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.25, S:R346T, T8038C, T25569C, G26031A"
+  },
+  {
+    "Lineage": "BQ.1.25.1",
+    "Earliest date": "2022-10-21",
+    "Latest date": "2023-06-29",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.25.1, found mainly in USA, from #1451"
+  },
+  {
+    "Lineage": "BQ.1.26",
+    "Earliest date": "2022-08-01",
+    "Latest date": "2023-04-17",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.26, found mainly in Denmark, from #1315"
+  },
+  {
+    "Lineage": "BQ.1.26.1",
+    "Earliest date": "2022-10-06",
+    "Latest date": "2023-03-23",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.26.1, found mainly in Denmark, from #1369"
+  },
+  {
+    "Lineage": "BQ.1.26.2",
+    "Earliest date": "2022-10-13",
+    "Latest date": "2023-03-30",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.26.2, Europe, S:F157L"
+  },
+  {
+    "Lineage": "BQ.1.27",
+    "Earliest date": "2022-10-04",
+    "Latest date": "2024-03-15",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.27, USA/England, S:V445A"
+  },
+  {
+    "Lineage": "BQ.1.28",
+    "Earliest date": "2022-11-02",
+    "Latest date": "2023-09-05",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.28, found mainly in USA, ins:S:247SWRM, from #1415"
+  },
+  {
+    "Lineage": "BQ.1.29",
+    "Earliest date": "2022-11-04",
+    "Latest date": "2023-02-11",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.29, found mainly in USA, S:E554Q"
+  },
+  {
+    "Lineage": "BQ.1.30",
+    "Earliest date": "2022-10-24",
+    "Latest date": "2023-03-17",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.30, Canada, S:V445A after T8038C, T25569C, G26031A"
+  },
+  {
+    "Lineage": "BQ.1.31",
+    "Earliest date": "2022-09-23",
+    "Latest date": "2023-05-11",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.31, France, S:K147E"
+  },
+  {
+    "Lineage": "BQ.1.32",
+    "Earliest date": "2022-12-09",
+    "Latest date": "2023-04-15",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.32 found mainly in USA and Mexico, from #1731"
+  },
+  {
+    "Lineage": "BQ.1.33",
+    "Earliest date": "2022-10-07",
+    "Latest date": "2023-04-13",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.1.33 S:F157L, S:K147I"
+  },
+  {
+    "Lineage": "BQ.2",
+    "Earliest date": "2022-08-06",
+    "Latest date": "2023-02-22",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.1.2, international, S:A522P"
+  },
+  {
+    "Lineage": "BE.1.2",
+    "Earliest date": "2022-06-09",
+    "Latest date": "2023-04-03",
+    "Description": "Alias of B.1.1.529.5.3.1.1.2, mainly found in Costa Rica and USA, from #923"
+  },
+  {
+    "Lineage": "BE.1.1.2",
+    "Earliest date": "2022-04-07",
+    "Latest date": "2023-04-23",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.2, Germany lineage, defined by ORF9b:S50L"
+  },
+  {
+    "Lineage": "CC.1",
+    "Earliest date": "2022-06-27",
+    "Latest date": "2023-01-21",
+    "Description": "Alias of B.1.1.529.5.3.1.1.1.2.1, Germany lineage, defined by S:N450D"
+  },
+  {
+    "Lineage": "BE.1.2.1",
+    "Earliest date": "2022-07-04",
+    "Latest date": "2023-03-19",
+    "Description": "Alias of B.1.1.529.5.3.1.1.2.1, Panama, Canada, USA, defined by S:V445A, from #1095"
+  },
+  {
+    "Lineage": "DW.1",
+    "Earliest date": "2022-10-13",
+    "Latest date": "2023-02-10",
+    "Description": "Alias of B.1.1.529.5.3.1.1.2.1.1 found mainly in Costa Rica, from #1564"
+  },
+  {
+    "Lineage": "BE.1.3",
+    "Earliest date": "2022-05-18",
+    "Latest date": "2023-01-19",
+    "Description": "Alias of B.1.1.529.5.3.1.1.3, Finland and Estonia lineage"
+  },
+  {
+    "Lineage": "BE.1.4",
+    "Earliest date": "2022-02-17",
+    "Latest date": "2023-02-17",
+    "Description": "Alias of B.1.1.529.5.3.1.1.4, America lineage, ORF1b:V1787I"
+  },
+  {
+    "Lineage": "BE.1.4.1",
+    "Earliest date": "2021-11-06",
+    "Latest date": "2022-12-28",
+    "Description": "Alias of B.1.1.529.5.3.1.1.4.1, S:A701V"
+  },
+  {
+    "Lineage": "BE.1.4.2",
+    "Earliest date": "2022-08-05",
+    "Latest date": "2023-05-04",
+    "Description": "Alias of B.1.1.529.5.3.1.1.4.2, S:R346T"
+  },
+  {
+    "Lineage": "BE.1.4.3",
+    "Earliest date": "2022-07-21",
+    "Latest date": "2022-11-01",
+    "Description": "Alias of B.1.1.529.5.3.1.1.4.3, Mexico, S:V445A"
+  },
+  {
+    "Lineage": "BE.1.4.4",
+    "Earliest date": "2022-06-08",
+    "Latest date": "2022-12-23",
+    "Description": "Alias of B.1.1.529.5.3.1.1.4.4, S:L176F"
+  },
+  {
+    "Lineage": "BE.2",
+    "Earliest date": "2022-04-06",
+    "Latest date": "2023-03-20",
+    "Description": "Alias of B.1.1.529.5.3.1.2, Belgium lineage"
+  },
+  {
+    "Lineage": "BE.3",
+    "Earliest date": "2022-01-19",
+    "Latest date": "2023-01-06",
+    "Description": "Alias of B.1.1.529.5.3.1.3, USA lineage, from #723"
+  },
+  {
+    "Lineage": "BE.4",
+    "Earliest date": "2022-03-20",
+    "Latest date": "2023-02-28",
+    "Description": "Alias of B.1.1.529.5.3.1.4, Bangladesh, defined by ORF1a:T3308N, from #1115"
+  },
+  {
+    "Lineage": "BE.4.1",
+    "Earliest date": "2022-07-05",
+    "Latest date": "2023-06-13",
+    "Description": "Alias of B.1.1.529.5.3.1.4.1, Bangladesh, defined by S:P209L, S:R346T, from #1115"
+  },
+  {
+    "Lineage": "BE.4.1.1",
+    "Earliest date": "2022-08-07",
+    "Latest date": "2023-03-15",
+    "Description": "Alias of B.1.1.529.5.3.1.4.1.1, Bangladesh, defined by S:K444R, from #1115"
+  },
+  {
+    "Lineage": "CQ.1",
+    "Earliest date": "2022-08-30",
+    "Latest date": "2023-03-13",
+    "Description": "Alias of B.1.1.529.5.3.1.4.1.1.1, Bangladesh, defined by S:Y144- and 11866T"
+  },
+  {
+    "Lineage": "CQ.1.1",
+    "Earliest date": "2022-09-15",
+    "Latest date": "2023-02-01",
+    "Description": "Alias of B.1.1.529.5.3.1.4.1.1.1.1, Canada/England, S:A262S"
+  },
+  {
+    "Lineage": "CQ.2",
+    "Earliest date": "2022-09-24",
+    "Latest date": "2023-05-06",
+    "Description": "Alias of B.1.1.529.5.3.1.4.1.1.2, Japan/USA, defined by S:V445A, from #1232"
+  },
+  {
+    "Lineage": "BE.4.2",
+    "Earliest date": "2022-09-01",
+    "Latest date": "2023-05-05",
+    "Description": "Alias of B.1.1.529.5.3.1.4.2, Bangladesh, defined by S:K444N & S:N460K, from #1114"
+  },
+  {
+    "Lineage": "BE.5",
+    "Earliest date": "2022-04-19",
+    "Latest date": "2022-12-16",
+    "Description": "Alias of B.1.1.529.5.3.1.5, South Africa, S:R346T, from #1281"
+  },
+  {
+    "Lineage": "BE.6",
+    "Earliest date": "2022-08-16",
+    "Latest date": "2023-03-08",
+    "Description": "Alias of B.1.1.529.5.3.1.6, France, S:R346S, on 28693C, 22624C"
+  },
+  {
+    "Lineage": "BE.7",
+    "Earliest date": "2022-07-14",
+    "Latest date": "2023-05-06",
+    "Description": "Alias of B.1.1.529.5.3.1.7, South Africa, S:R346T on 28693C, 22624C, from #1280"
+  },
+  {
+    "Lineage": "BE.8",
+    "Earliest date": "2022-08-18",
+    "Latest date": "2023-07-26",
+    "Description": "Alias of B.1.1.529.5.3.1.8, South Africa, S:R346T on 28693C, from #1278"
+  },
+  {
+    "Lineage": "BE.9",
+    "Earliest date": "2022-01-11",
+    "Latest date": "2023-05-15",
+    "Description": "Alias of B.1.1.529.5.3.1.9, S:144-, S:444T, S:460K, on 28693C, Brazil, from #1302"
+  },
+  {
+    "Lineage": "BE.10",
+    "Earliest date": "2022-01-12",
+    "Latest date": "2023-04-05",
+    "Description": "Alias of B.1.1.529.5.3.1.10, S:K444T, S:N460K, mainly Brazil, from #1411"
+  },
+  {
+    "Lineage": "BE.11",
+    "Earliest date": "2022-05-22",
+    "Latest date": "2023-01-25",
+    "Description": "Alias of B.1.1.529.5.3.1.11, T3049C, on 28693C"
+  },
+  {
+    "Lineage": "BE.12",
+    "Earliest date": "2022-04-20",
+    "Latest date": "2023-01-17",
+    "Description": "Alias of B.1.1.529.5.3.1.12, C10834T, T18975C, A29359G, on 28693C"
+  },
+  {
+    "Lineage": "BE.13",
+    "Earliest date": "2022-10-28",
+    "Latest date": "2023-05-02",
+    "Description": "Alias of B.1.1.529.5.3.1.13, S:346T, S:478R, on 28693C, South Africa"
+  },
+  {
+    "Lineage": "BA.5.3.2",
+    "Earliest date": "2021-12-20",
+    "Latest date": "2023-05-16",
+    "Description": "Alias of B.1.1.529.5.3.2, mainly found in Germany, from #697"
+  },
+  {
+    "Lineage": "BA.5.3.3",
+    "Earliest date": "2021-07-05",
+    "Latest date": "2023-03-13",
+    "Description": "Alias of B.1.1.529.5.3.3, UK lineage"
+  },
+  {
+    "Lineage": "BA.5.3.4",
+    "Earliest date": "2021-11-15",
+    "Latest date": "2023-01-14",
+    "Description": "Alias of B.1.1.529.5.3.4, Germany lineage"
+  },
+  {
+    "Lineage": "BA.5.3.5",
+    "Earliest date": "2022-06-15",
+    "Latest date": "2023-05-22",
+    "Description": "Alias of B.1.1.529.5.3.5, mainly found in South Africa, from #1042"
+  },
+  {
+    "Lineage": "BA.5.5",
+    "Earliest date": "2021-11-05",
+    "Latest date": "2023-07-06",
+    "Description": "Alias of B.1.1.529.5.5, mainly found in USA, from #656"
+  },
+  {
+    "Lineage": "BA.5.5.1",
+    "Earliest date": "2022-06-04",
+    "Latest date": "2023-07-11",
+    "Description": "Alias of B.1.1.529.5.5.1, mainly found in USA, from #873"
+  },
+  {
+    "Lineage": "BA.5.5.2",
+    "Earliest date": "2022-05-22",
+    "Latest date": "2023-01-20",
+    "Description": "Alias of B.1.1.529.5.5.2, mainly found in USA, Canada, England and Ireland, from #938"
+  },
+  {
+    "Lineage": "BA.5.5.3",
+    "Earliest date": "2022-06-05",
+    "Latest date": "2022-12-22",
+    "Description": "Alias of B.1.1.529.5.5.3, USA lineage, from #1015"
+  },
+  {
+    "Lineage": "BA.5.6",
+    "Earliest date": "2021-10-11",
+    "Latest date": "2023-07-06",
+    "Description": "Alias of B.1.1.529.5.6, USA lineage, from #738"
+  },
+  {
+    "Lineage": "BA.5.6.1",
+    "Earliest date": "2022-06-09",
+    "Latest date": "2023-07-11",
+    "Description": "Alias of B.1.1.529.5.6.1, Peru lineage"
+  },
+  {
+    "Lineage": "BA.5.6.2",
+    "Earliest date": "2021-12-14",
+    "Latest date": "2023-03-15",
+    "Description": "Alias of B.1.1.529.5.6.2, mainly found in USA, Belgium and Mexico, from #903"
+  },
+  {
+    "Lineage": "BW.1",
+    "Earliest date": "2022-01-03",
+    "Latest date": "2023-12-30",
+    "Description": "Alias of B.1.1.529.5.6.2.1, Mexico lineage, defined by S:460K, from #1059"
+  },
+  {
+    "Lineage": "BW.1.1",
+    "Earliest date": "2022-08-10",
+    "Latest date": "2023-05-08",
+    "Description": "Alias of B.1.1.529.5.6.2.1.1, Mexico lineage, defined by S:V486A, from #1341"
+  },
+  {
+    "Lineage": "BW.1.1.1",
+    "Earliest date": "2022-01-06",
+    "Latest date": "2023-04-13",
+    "Description": "Alias of B.1.1.529.5.6.2.1.1.1, Mexico, ORF1a:L864F"
+  },
+  {
+    "Lineage": "BW.1.1.2",
+    "Earliest date": "2022-11-13",
+    "Latest date": "2023-08-10",
+    "Description": "Alias of B.1.1.529.5.6.2.1.1.2, Mexico, ORF1b:P1101S"
+  },
+  {
+    "Lineage": "BW.1.2",
+    "Earliest date": "2022-10-13",
+    "Latest date": "2023-01-24",
+    "Description": "Alias of B.1.1.529.5.6.2.1.2, Mexico lineage, defined by S:R346S"
+  },
+  {
+    "Lineage": "BA.5.6.3",
+    "Earliest date": "2022-07-27",
+    "Latest date": "2023-09-20",
+    "Description": "Alias of B.1.1.529.5.6.3, mainly found in England, from #1118"
+  },
+  {
+    "Lineage": "BA.5.6.4",
+    "Earliest date": "2022-07-03",
+    "Latest date": "2023-01-24",
+    "Description": "Alias of B.1.1.529.5.6.4, found in USA and Europe, from #1191"
+  },
+  {
+    "Lineage": "BA.5.7",
+    "Earliest date": "2022-05-15",
+    "Latest date": "2023-03-04",
+    "Description": "Alias of B.1.1.529.5.7, Australia lineage"
+  },
+  {
+    "Lineage": "BA.5.8",
+    "Earliest date": "2022-02-20",
+    "Latest date": "2022-12-28",
+    "Description": "Alias of B.1.1.529.5.8, mainly found in England, USA, Denmark and Scotland, from #743"
+  },
+  {
+    "Lineage": "BA.5.9",
+    "Earliest date": "2022-01-24",
+    "Latest date": "2023-03-22",
+    "Description": "Alias of B.1.1.529.5.9, mainly found in Germany, Switzerland and Denmark, from #753"
+  },
+  {
+    "Lineage": "BA.5.10",
+    "Earliest date": "2022-02-09",
+    "Latest date": "2022-12-28",
+    "Description": "Alias of B.1.1.529.5.10, mainly found in Philippines, Canada, and USA, from #936"
+  },
+  {
+    "Lineage": "BA.5.10.1",
+    "Earliest date": "2022-08-02",
+    "Latest date": "2023-01-30",
+    "Description": "Alias of B.1.1.529.5.10.1, mainly from Philippines, defined by S:346T, from #1031"
+  },
+  {
+    "Lineage": "DF.1",
+    "Earliest date": "2022-07-27",
+    "Latest date": "2023-03-09",
+    "Description": "Alias of B.1.1.529.5.10.1.1, found mainly in UK, from #1270"
+  },
+  {
+    "Lineage": "DF.1.1",
+    "Earliest date": "2022-10-19",
+    "Latest date": "2023-05-14",
+    "Description": "Alias of B.1.1.529.5.10.1.1.1 found mainly in USA, from #1494"
+  },
+  {
+    "Lineage": "BA.5.11",
+    "Earliest date": "2022-07-14",
+    "Latest date": "2023-07-11",
+    "Description": "Alias of B.1.1.529.5.11, South Africa, C1627T, S:R346T, from #1277"
+  },
+  {
+    "Lineage": "BA.5.12",
+    "Earliest date": "2022-09-17",
+    "Latest date": "2023-05-04",
+    "Description": "Alias of B.1.1.529.5.12 found mainly in Switzerland, France and Germany, from #1640"
+  },
+  {
+    "Lineage": "B.1.2",
+    "Earliest date": "2020-01-04",
+    "Latest date": "2023-07-17",
+    "Description": "USA"
+  },
+  {
+    "Lineage": "B.1.3",
+    "Earliest date": "2020-03-30",
+    "Latest date": "2021-05-11",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.1.6",
+    "Earliest date": "2020-03-05",
+    "Latest date": "2021-08-06",
+    "Description": "Belgian lineage"
+  },
+  {
+    "Lineage": "B.1.8",
+    "Earliest date": "2020-03-04",
+    "Latest date": "2020-11-12",
+    "Description": "Netherlands, South Africa, Denmark, USA"
+  },
+  {
+    "Lineage": "B.1.12",
+    "Earliest date": "2020-03-04",
+    "Latest date": "2020-07-18",
+    "Description": "Luxembourg lineage (also England, Belgium etc.)"
+  },
+  {
+    "Lineage": "B.1.13",
+    "Earliest date": "2020-03-09",
+    "Latest date": "2020-06-22",
+    "Description": "UK lineage"
+  },
+  {
+    "Lineage": "B.1.14",
+    "Earliest date": "2020-02-03",
+    "Latest date": "2020-05-07",
+    "Description": "USA lineage (CA)"
+  },
+  {
+    "Lineage": "B.1.22",
+    "Earliest date": "2020-03-05",
+    "Latest date": "2021-10-27",
+    "Description": "Netherlands lineage"
+  },
+  {
+    "Lineage": "B.1.22.1",
+    "Earliest date": "2020-09-07",
+    "Latest date": "2021-01-26",
+    "Description": "Curacao"
+  },
+  {
+    "Lineage": "B.1.23",
+    "Earliest date": "2020-03-18",
+    "Latest date": "2021-03-28",
+    "Description": "New Zealand / Australia"
+  },
+  {
+    "Lineage": "B.1.35",
+    "Earliest date": "2020-03-20",
+    "Latest date": "2020-06-11",
+    "Description": "Wales lineage"
+  },
+  {
+    "Lineage": "B.1.36",
+    "Earliest date": "2020-02-16",
+    "Latest date": "2022-05-05",
+    "Description": "Global many sublineages (see below)"
+  },
+  {
+    "Lineage": "B.1.36.1",
+    "Earliest date": "2020-01-10",
+    "Latest date": "2021-05-18",
+    "Description": "European/Denmark"
+  },
+  {
+    "Lineage": "B.1.36.2",
+    "Earliest date": "2020-09-27",
+    "Latest date": "2021-01-18",
+    "Description": "UK"
+  },
+  {
+    "Lineage": "B.1.36.7",
+    "Earliest date": "2020-07-07",
+    "Latest date": "2021-05-07",
+    "Description": "UK (reassigned from Oman lineage)"
+  },
+  {
+    "Lineage": "B.1.36.8",
+    "Earliest date": "2020-04-11",
+    "Latest date": "2021-10-08",
+    "Description": "Predominantly Indian lineage with global records (inc. Canada)"
+  },
+  {
+    "Lineage": "B.1.36.9",
+    "Earliest date": "2020-04-21",
+    "Latest date": "2021-02-10",
+    "Description": "UK"
+  },
+  {
+    "Lineage": "B.1.36.10",
+    "Earliest date": "2020-04-24",
+    "Latest date": "2021-03-22",
+    "Description": "Jordan/Saudi Arabia (single recent record from USA)"
+  },
+  {
+    "Lineage": "B.1.36.12",
+    "Earliest date": "2020-06-12",
+    "Latest date": "2020-11-09",
+    "Description": "England"
+  },
+  {
+    "Lineage": "B.1.36.16",
+    "Earliest date": "2020-04-26",
+    "Latest date": "2021-12-02",
+    "Description": "SE Asia"
+  },
+  {
+    "Lineage": "B.1.36.17",
+    "Earliest date": "2020-07-16",
+    "Latest date": "2021-11-06",
+    "Description": "UK lineage"
+  },
+  {
+    "Lineage": "B.1.36.18",
+    "Earliest date": "2020-08-25",
+    "Latest date": "2021-05-23",
+    "Description": "Canadian lineage"
+  },
+  {
+    "Lineage": "B.1.36.19",
+    "Earliest date": "2020-06-17",
+    "Latest date": "2022-06-05",
+    "Description": "Oceana"
+  },
+  {
+    "Lineage": "B.1.36.20",
+    "Earliest date": "2020-08-20",
+    "Latest date": "2021-04-25",
+    "Description": "Mainly Scotland"
+  },
+  {
+    "Lineage": "B.1.36.21",
+    "Earliest date": "2020-10-07",
+    "Latest date": "2021-03-09",
+    "Description": "Norway lineage"
+  },
+  {
+    "Lineage": "B.1.36.22",
+    "Earliest date": "2020-05-01",
+    "Latest date": "2022-07-09",
+    "Description": "Lineage with sequences majoritively from Finland"
+  },
+  {
+    "Lineage": "B.1.36.23",
+    "Earliest date": "2020-05-08",
+    "Latest date": "2020-11-04",
+    "Description": "UK"
+  },
+  {
+    "Lineage": "B.1.36.24",
+    "Earliest date": "2020-06-04",
+    "Latest date": "2021-05-27",
+    "Description": "England with Global records"
+  },
+  {
+    "Lineage": "B.1.36.25",
+    "Earliest date": "2020-10-12",
+    "Latest date": "2021-02-15",
+    "Description": "Denmark"
+  },
+  {
+    "Lineage": "B.1.36.26",
+    "Earliest date": "2020-08-26",
+    "Latest date": "2021-02-11",
+    "Description": "Canada/USA"
+  },
+  {
+    "Lineage": "B.1.36.28",
+    "Earliest date": "2020-09-09",
+    "Latest date": "2021-01-05",
+    "Description": "UK"
+  },
+  {
+    "Lineage": "B.1.36.27",
+    "Earliest date": "2020-09-18",
+    "Latest date": "2021-11-11",
+    "Description": "Hong Kong lineage, initially associated with travellers from Nepal. Epidemiologically and phylogenetically supported."
+  },
+  {
+    "Lineage": "B.1.36.29",
+    "Earliest date": "2020-06-27",
+    "Latest date": "2021-11-01",
+    "Description": "India"
+  },
+  {
+    "Lineage": "B.1.36.31",
+    "Earliest date": "2020-03-08",
+    "Latest date": "2021-05-13",
+    "Description": "UK/Global"
+  },
+  {
+    "Lineage": "B.1.36.33",
+    "Earliest date": "2020-05-23",
+    "Latest date": "2021-02-01",
+    "Description": "Denmark"
+  },
+  {
+    "Lineage": "B.1.36.34",
+    "Earliest date": "2020-06-10",
+    "Latest date": "2021-03-02",
+    "Description": "UK"
+  },
+  {
+    "Lineage": "B.1.36.35",
+    "Earliest date": "2020-06-24",
+    "Latest date": "2021-05-03",
+    "Description": "European/Switzerland"
+  },
+  {
+    "Lineage": "B.1.36.36",
+    "Earliest date": "2020-09-05",
+    "Latest date": "2021-04-15",
+    "Description": "Canada"
+  },
+  {
+    "Lineage": "B.1.36.37",
+    "Earliest date": "2020-08-20",
+    "Latest date": "2021-04-14",
+    "Description": "Canada"
+  },
+  {
+    "Lineage": "B.1.36.38",
+    "Earliest date": "2020-06-30",
+    "Latest date": "2021-04-05",
+    "Description": "Canada/UK"
+  },
+  {
+    "Lineage": "B.1.36.39",
+    "Earliest date": "2020-09-21",
+    "Latest date": "2021-01-25",
+    "Description": "UK"
+  },
+  {
+    "Lineage": "B.1.37",
+    "Earliest date": "2020-03-10",
+    "Latest date": "2020-08-19",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.1.38",
+    "Earliest date": "2020-03-17",
+    "Latest date": "2020-06-15",
+    "Description": "USA"
+  },
+  {
+    "Lineage": "B.1.39",
+    "Earliest date": "2020-03-09",
+    "Latest date": "2020-06-29",
+    "Description": "Denmark"
+  },
+  {
+    "Lineage": "B.1.40",
+    "Earliest date": "2020-03-18",
+    "Latest date": "2020-05-23",
+    "Description": "Scotland lineage"
+  },
+  {
+    "Lineage": "B.1.44",
+    "Earliest date": "2020-03-20",
+    "Latest date": "2020-06-19",
+    "Description": "Wales lineage"
+  },
+  {
+    "Lineage": "B.1.67",
+    "Earliest date": "2020-03-23",
+    "Latest date": "2020-06-30",
+    "Description": "Wales lineage"
+  },
+  {
+    "Lineage": "B.1.69",
+    "Earliest date": "2020-03-06",
+    "Latest date": "2020-04-23",
+    "Description": "Scotland"
+  },
+  {
+    "Lineage": "B.1.70",
+    "Earliest date": "2020-03-13",
+    "Latest date": "2020-04-24",
+    "Description": "Scotland"
+  },
+  {
+    "Lineage": "B.1.76",
+    "Earliest date": "2020-02-24",
+    "Latest date": "2020-08-12",
+    "Description": "English Lineage"
+  },
+  {
+    "Lineage": "B.1.77",
+    "Earliest date": "2020-05-18",
+    "Latest date": "2020-07-18",
+    "Description": "English lineage"
+  },
+  {
+    "Lineage": "B.1.78",
+    "Earliest date": "2020-03-12",
+    "Latest date": "2021-04-05",
+    "Description": "Netherlands lineage"
+  },
+  {
+    "Lineage": "B.1.81",
+    "Earliest date": "2020-03-18",
+    "Latest date": "2021-03-03",
+    "Description": "UK lineage"
+  },
+  {
+    "Lineage": "B.1.83",
+    "Earliest date": "2020-03-20",
+    "Latest date": "2020-05-09",
+    "Description": "Belgian lineage"
+  },
+  {
+    "Lineage": "B.1.84",
+    "Earliest date": "2020-03-31",
+    "Latest date": "2020-08-06",
+    "Description": "DRC lineage"
+  },
+  {
+    "Lineage": "B.1.91",
+    "Earliest date": "2020-02-21",
+    "Latest date": "2020-12-10",
+    "Description": "Portuguese lineage"
+  },
+  {
+    "Lineage": "B.1.93",
+    "Earliest date": "2020-03-06",
+    "Latest date": "2021-09-29",
+    "Description": "UK lineage"
+  },
+  {
+    "Lineage": "B.1.94",
+    "Earliest date": "2020-03-15",
+    "Latest date": "2021-04-23",
+    "Description": "Luxembourg"
+  },
+  {
+    "Lineage": "B.1.96",
+    "Earliest date": "2020-04-01",
+    "Latest date": "2020-05-11",
+    "Description": "Netherlands lineage"
+  },
+  {
+    "Lineage": "B.1.97",
+    "Earliest date": "2020-03-24",
+    "Latest date": "2020-05-05",
+    "Description": "England"
+  },
+  {
+    "Lineage": "B.1.103",
+    "Earliest date": "2020-04-09",
+    "Latest date": "2020-05-22",
+    "Description": "USA"
+  },
+  {
+    "Lineage": "B.1.104",
+    "Earliest date": "2020-03-02",
+    "Latest date": "2021-09-08",
+    "Description": "England"
+  },
+  {
+    "Lineage": "B.1.105",
+    "Earliest date": "2020-03-06",
+    "Latest date": "2020-06-08",
+    "Description": "England"
+  },
+  {
+    "Lineage": "B.1.106",
+    "Earliest date": "2020-04-23",
+    "Latest date": "2020-08-13",
+    "Description": "USA"
+  },
+  {
+    "Lineage": "B.1.108",
+    "Earliest date": "2020-02-25",
+    "Latest date": "2021-03-09",
+    "Description": "USA"
+  },
+  {
+    "Lineage": "B.1.110",
+    "Earliest date": "2020-03-02",
+    "Latest date": "2021-02-17",
+    "Description": "Chilean/ USA and Australia lineage"
+  },
+  {
+    "Lineage": "B.1.110.1",
+    "Earliest date": "2020-03-18",
+    "Latest date": "2020-10-16",
+    "Description": "Chilean/ USA lineage"
+  },
+  {
+    "Lineage": "B.1.110.2",
+    "Earliest date": "2020-04-03",
+    "Latest date": "2020-04-12",
+    "Description": "UK lineage"
+  },
+  {
+    "Lineage": "B.1.110.3",
+    "Earliest date": "2020-03-15",
+    "Latest date": "2022-03-30",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.1.111",
+    "Earliest date": "2020-03-07",
+    "Latest date": "2022-03-30",
+    "Description": "South/ Central American lineage (mostly Trinidad and Colombia, an a small cluster from Norwich)"
+  },
+  {
+    "Lineage": "B.1.112",
+    "Earliest date": "2020-04-06",
+    "Latest date": "2020-09-02",
+    "Description": "USA/UT"
+  },
+  {
+    "Lineage": "B.1.113",
+    "Earliest date": "2020-06-03",
+    "Latest date": "2020-06-20",
+    "Description": "Indian lineage"
+  },
+  {
+    "Lineage": "B.1.115",
+    "Earliest date": "2020-03-17",
+    "Latest date": "2020-10-10",
+    "Description": "Israel and UK"
+  },
+  {
+    "Lineage": "B.1.116",
+    "Earliest date": "2020-03-29",
+    "Latest date": "2020-11-18",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.1.117",
+    "Earliest date": "2020-03-30",
+    "Latest date": "2020-05-18",
+    "Description": "UK lineage"
+  },
+  {
+    "Lineage": "B.1.118",
+    "Earliest date": "2020-03-09",
+    "Latest date": "2021-05-11",
+    "Description": "Danish"
+  },
+  {
+    "Lineage": "B.1.119",
+    "Earliest date": "2020-03-12",
+    "Latest date": "2020-09-18",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.1.120",
+    "Earliest date": "2020-03-27",
+    "Latest date": "2020-06-15",
+    "Description": "Wales lineage"
+  },
+  {
+    "Lineage": "B.1.124",
+    "Earliest date": "2020-03-19",
+    "Latest date": "2020-10-03",
+    "Description": "USA/WA"
+  },
+  {
+    "Lineage": "B.1.126",
+    "Earliest date": "2020-03-14",
+    "Latest date": "2021-08-21",
+    "Description": "USA (MN) lineage"
+  },
+  {
+    "Lineage": "B.1.127",
+    "Earliest date": "2020-10-26",
+    "Latest date": "2021-03-22",
+    "Description": "Denmark"
+  },
+  {
+    "Lineage": "B.1.128",
+    "Earliest date": "2020-03-09",
+    "Latest date": "2021-01-15",
+    "Description": "Canada, Switzerland and DRC"
+  },
+  {
+    "Lineage": "B.1.131",
+    "Earliest date": "2020-05-27",
+    "Latest date": "2021-03-08",
+    "Description": "European lineage"
+  },
+  {
+    "Lineage": "B.1.134",
+    "Earliest date": "2020-04-03",
+    "Latest date": "2021-07-20",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.1.137",
+    "Earliest date": "2020-04-06",
+    "Latest date": "2021-03-31",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.1.139",
+    "Earliest date": "2020-03-18",
+    "Latest date": "2021-09-14",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.1.140",
+    "Earliest date": "2020-06-15",
+    "Latest date": "2020-09-25",
+    "Description": "South African lineage"
+  },
+  {
+    "Lineage": "B.1.142",
+    "Earliest date": "2020-03-12",
+    "Latest date": "2020-07-13",
+    "Description": "Wales lineage"
+  },
+  {
+    "Lineage": "B.1.143",
+    "Earliest date": "2020-03-28",
+    "Latest date": "2021-01-27",
+    "Description": "Indian lineage"
+  },
+  {
+    "Lineage": "B.1.145",
+    "Earliest date": "2020-04-21",
+    "Latest date": "2021-02-03",
+    "Description": "Indian lineage"
+  },
+  {
+    "Lineage": "B.1.146",
+    "Earliest date": "2020-06-23",
+    "Latest date": "2021-06-28",
+    "Description": "Swiss lineage"
+  },
+  {
+    "Lineage": "B.1.147",
+    "Earliest date": "2020-03-04",
+    "Latest date": "2021-03-03",
+    "Description": "Canadian lineage"
+  },
+  {
+    "Lineage": "B.1.149",
+    "Earliest date": "2020-03-31",
+    "Latest date": "2021-01-13",
+    "Description": "DRC lineage"
+  },
+  {
+    "Lineage": "B.1.151",
+    "Earliest date": "2020-03-10",
+    "Latest date": "2020-05-26",
+    "Description": "UK lineage"
+  },
+  {
+    "Lineage": "B.1.153",
+    "Earliest date": "2020-03-11",
+    "Latest date": "2021-09-29",
+    "Description": "English lineage with some Australian, New Zealand and European sequences"
+  },
+  {
+    "Lineage": "B.1.157",
+    "Earliest date": "2020-03-03",
+    "Latest date": "2020-06-24",
+    "Description": "UK/ Spanish lineage"
+  },
+  {
+    "Lineage": "B.1.158",
+    "Earliest date": "2020-03-13",
+    "Latest date": "2020-05-22",
+    "Description": "Finland lineage"
+  },
+  {
+    "Lineage": "B.1.159",
+    "Earliest date": "2020-03-17",
+    "Latest date": "2020-08-28",
+    "Description": "French lineage"
+  },
+  {
+    "Lineage": "B.1.160",
+    "Earliest date": "2020-02-02",
+    "Latest date": "2022-05-21",
+    "Description": "Large European lineage, sequences from BeNeLuX, Denmark, Switzerland, Hungary and UK."
+  },
+  {
+    "Lineage": "B.1.160.7",
+    "Earliest date": "2020-10-03",
+    "Latest date": "2021-02-18",
+    "Description": "English Lineage"
+  },
+  {
+    "Lineage": "B.1.160.8",
+    "Earliest date": "2020-10-05",
+    "Latest date": "2021-03-31",
+    "Description": "Denmark"
+  },
+  {
+    "Lineage": "B.1.160.9",
+    "Earliest date": "2020-11-11",
+    "Latest date": "2021-02-18",
+    "Description": "Switzerland"
+  },
+  {
+    "Lineage": "B.1.160.10",
+    "Earliest date": "2020-10-10",
+    "Latest date": "2021-02-20",
+    "Description": "Switzerland"
+  },
+  {
+    "Lineage": "B.1.160.11",
+    "Earliest date": "2020-09-29",
+    "Latest date": "2021-03-08",
+    "Description": "Switzerland"
+  },
+  {
+    "Lineage": "B.1.160.12",
+    "Earliest date": "2020-10-15",
+    "Latest date": "2021-02-14",
+    "Description": "Switzerland"
+  },
+  {
+    "Lineage": "B.1.160.13",
+    "Earliest date": "2020-09-18",
+    "Latest date": "2021-03-08",
+    "Description": "Netherlands lineage"
+  },
+  {
+    "Lineage": "B.1.160.14",
+    "Earliest date": "2020-09-01",
+    "Latest date": "2021-03-16",
+    "Description": "Switzerland"
+  },
+  {
+    "Lineage": "B.1.160.15",
+    "Earliest date": "2020-09-30",
+    "Latest date": "2021-03-12",
+    "Description": "Mostly Switzerland"
+  },
+  {
+    "Lineage": "B.1.160.16",
+    "Earliest date": "2020-09-30",
+    "Latest date": "2021-08-09",
+    "Description": "Mostly Switzerland"
+  },
+  {
+    "Lineage": "AB.1",
+    "Earliest date": "2020-12-01",
+    "Latest date": "2021-02-15",
+    "Description": "Alias of B.1.160.16.1, Denmark, grown out of big swiss cluster"
+  },
+  {
+    "Lineage": "B.1.160.17",
+    "Earliest date": "2020-11-09",
+    "Latest date": "2021-01-31",
+    "Description": "Denmark"
+  },
+  {
+    "Lineage": "B.1.160.18",
+    "Earliest date": "2020-11-10",
+    "Latest date": "2021-03-10",
+    "Description": "Mayotte"
+  },
+  {
+    "Lineage": "B.1.160.19",
+    "Earliest date": "2020-11-24",
+    "Latest date": "2021-01-25",
+    "Description": "Switzerland"
+  },
+  {
+    "Lineage": "B.1.160.20",
+    "Earliest date": "2020-10-12",
+    "Latest date": "2021-03-02",
+    "Description": "Switzerland"
+  },
+  {
+    "Lineage": "B.1.160.21",
+    "Earliest date": "2020-11-24",
+    "Latest date": "2021-01-26",
+    "Description": "Luxembourg"
+  },
+  {
+    "Lineage": "B.1.160.22",
+    "Earliest date": "2020-10-07",
+    "Latest date": "2021-10-23",
+    "Description": "Switzerland, Germany, Austria"
+  },
+  {
+    "Lineage": "B.1.160.23",
+    "Earliest date": "2020-09-07",
+    "Latest date": "2021-01-19",
+    "Description": "England"
+  },
+  {
+    "Lineage": "B.1.160.24",
+    "Earliest date": "2020-11-23",
+    "Latest date": "2021-02-20",
+    "Description": "Denmark"
+  },
+  {
+    "Lineage": "B.1.160.25",
+    "Earliest date": "2020-12-16",
+    "Latest date": "2021-11-04",
+    "Description": "French Guiana"
+  },
+  {
+    "Lineage": "B.1.160.26",
+    "Earliest date": "2020-09-25",
+    "Latest date": "2021-04-08",
+    "Description": "Mostly Switzerland, a little Europe"
+  },
+  {
+    "Lineage": "B.1.160.27",
+    "Earliest date": "2020-11-12",
+    "Latest date": "2021-03-09",
+    "Description": "Mayotte"
+  },
+  {
+    "Lineage": "B.1.160.28",
+    "Earliest date": "2020-09-05",
+    "Latest date": "2021-06-08",
+    "Description": "Belgium and Luxembourg"
+  },
+  {
+    "Lineage": "B.1.160.29",
+    "Earliest date": "2020-10-26",
+    "Latest date": "2021-03-30",
+    "Description": "Switzerland"
+  },
+  {
+    "Lineage": "B.1.160.30",
+    "Earliest date": "2020-08-20",
+    "Latest date": "2021-04-30",
+    "Description": "Switzerland"
+  },
+  {
+    "Lineage": "B.1.160.31",
+    "Earliest date": "2020-10-08",
+    "Latest date": "2021-03-19",
+    "Description": "Switzerland"
+  },
+  {
+    "Lineage": "B.1.160.32",
+    "Earliest date": "2020-10-02",
+    "Latest date": "2021-01-26",
+    "Description": "Switzerland"
+  },
+  {
+    "Lineage": "B.1.160.33",
+    "Earliest date": "2020-10-30",
+    "Latest date": "2021-01-24",
+    "Description": "Was part of B.1.160.7 but this is now split on tree. English lineage last seen 2020-11-18 in uk, but long branch to a recent French sample sticking out"
+  },
+  {
+    "Lineage": "B.1.161",
+    "Earliest date": "2020-03-27",
+    "Latest date": "2020-12-05",
+    "Description": "USA"
+  },
+  {
+    "Lineage": "B.1.162",
+    "Earliest date": "2020-03-15",
+    "Latest date": "2020-09-28",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.1.163",
+    "Earliest date": "2020-03-16",
+    "Latest date": "2020-08-12",
+    "Description": "USA"
+  },
+  {
+    "Lineage": "B.1.164",
+    "Earliest date": "2020-04-24",
+    "Latest date": "2021-03-11",
+    "Description": "Eastern Europe"
+  },
+  {
+    "Lineage": "B.1.165",
+    "Earliest date": "2020-05-01",
+    "Latest date": "2020-06-15",
+    "Description": "England"
+  },
+  {
+    "Lineage": "B.1.166",
+    "Earliest date": "2020-03-04",
+    "Latest date": "2020-07-17",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.1.167",
+    "Earliest date": "2020-03-27",
+    "Latest date": "2020-12-24",
+    "Description": "Canada, England"
+  },
+  {
+    "Lineage": "B.1.168",
+    "Earliest date": "2020-04-23",
+    "Latest date": "2020-05-19",
+    "Description": "Scottish lineage"
+  },
+  {
+    "Lineage": "B.1.169",
+    "Earliest date": "2020-03-31",
+    "Latest date": "2020-08-14",
+    "Description": "USA, some previously B.1.333.1"
+  },
+  {
+    "Lineage": "B.1.170",
+    "Earliest date": "2020-03-19",
+    "Latest date": "2021-05-21",
+    "Description": "Egypt UAE"
+  },
+  {
+    "Lineage": "B.1.173",
+    "Earliest date": "2020-05-16",
+    "Latest date": "2020-11-04",
+    "Description": "England"
+  },
+  {
+    "Lineage": "B.1.177",
+    "Earliest date": "2020-02-02",
+    "Latest date": "2022-05-25",
+    "Description": "Major mostly European lineage, result of opening borders summer 2020"
+  },
+  {
+    "Lineage": "B.1.177.2",
+    "Earliest date": "2020-09-03",
+    "Latest date": "2021-01-26",
+    "Description": "English lineage"
+  },
+  {
+    "Lineage": "B.1.177.3",
+    "Earliest date": "2020-08-24",
+    "Latest date": "2020-11-23",
+    "Description": "Welsh and English lineage"
+  },
+  {
+    "Lineage": "B.1.177.4",
+    "Earliest date": "2020-06-03",
+    "Latest date": "2021-04-03",
+    "Description": "UK lineage"
+  },
+  {
+    "Lineage": "B.1.177.5",
+    "Earliest date": "2020-08-29",
+    "Latest date": "2021-09-29",
+    "Description": "UK, mostly Scotland"
+  },
+  {
+    "Lineage": "B.1.177.6",
+    "Earliest date": "2020-07-07",
+    "Latest date": "2021-03-07",
+    "Description": "Wales lineage"
+  },
+  {
+    "Lineage": "B.1.177.7",
+    "Earliest date": "2020-03-21",
+    "Latest date": "2021-09-29",
+    "Description": "Wales lineage"
+  },
+  {
+    "Lineage": "B.1.177.8",
+    "Earliest date": "2020-09-03",
+    "Latest date": "2021-09-29",
+    "Description": "Wales lineage"
+  },
+  {
+    "Lineage": "B.1.177.9",
+    "Earliest date": "2020-09-02",
+    "Latest date": "2021-02-21",
+    "Description": "UK lineage"
+  },
+  {
+    "Lineage": "B.1.177.10",
+    "Earliest date": "2020-09-02",
+    "Latest date": "2021-05-25",
+    "Description": "England"
+  },
+  {
+    "Lineage": "B.1.177.11",
+    "Earliest date": "2020-04-04",
+    "Latest date": "2021-10-02",
+    "Description": "Scotland mostly, some England"
+  },
+  {
+    "Lineage": "B.1.177.12",
+    "Earliest date": "2020-03-30",
+    "Latest date": "2021-04-12",
+    "Description": "Danish"
+  },
+  {
+    "Lineage": "B.1.177.14",
+    "Earliest date": "2020-07-27",
+    "Latest date": "2021-07-27",
+    "Description": "Danish/ Norway lineage"
+  },
+  {
+    "Lineage": "B.1.177.15",
+    "Earliest date": "2020-09-01",
+    "Latest date": "2021-11-22",
+    "Description": "English Welsh lineage"
+  },
+  {
+    "Lineage": "AA.1",
+    "Earliest date": "2020-08-11",
+    "Latest date": "2021-05-31",
+    "Description": "Alias of B.1.177.15.1, European Lineage"
+  },
+  {
+    "Lineage": "AA.2",
+    "Earliest date": "2020-11-14",
+    "Latest date": "2021-02-19",
+    "Description": "Alias of B.1.177.15.2, Welsh Lineage"
+  },
+  {
+    "Lineage": "AA.3",
+    "Earliest date": "2020-10-21",
+    "Latest date": "2021-01-30",
+    "Description": "Alias of B.1.177.15.3, Welsh Lineage"
+  },
+  {
+    "Lineage": "AA.4",
+    "Earliest date": "2020-10-22",
+    "Latest date": "2021-03-01",
+    "Description": "Alias of B.1.177.15.4, Welsh Lineage"
+  },
+  {
+    "Lineage": "AA.5",
+    "Earliest date": "2020-12-05",
+    "Latest date": "2021-03-02",
+    "Description": "Alias of B.1.177.15.5, Welsh Lineage"
+  },
+  {
+    "Lineage": "AA.6",
+    "Earliest date": "2020-10-13",
+    "Latest date": "2021-02-16",
+    "Description": "Alias of B.1.177.15.6, Welsh Lineage"
+  },
+  {
+    "Lineage": "AA.7",
+    "Earliest date": "2020-11-04",
+    "Latest date": "2021-02-26",
+    "Description": "Alias of B.1.177.15.7, Welsh Lineage"
+  },
+  {
+    "Lineage": "AA.8",
+    "Earliest date": "2020-11-25",
+    "Latest date": "2021-02-19",
+    "Description": "Alias of B.1.177.15.8, Welsh Lineage"
+  },
+  {
+    "Lineage": "B.1.177.16",
+    "Earliest date": "2020-09-10",
+    "Latest date": "2021-05-13",
+    "Description": "UK lineage"
+  },
+  {
+    "Lineage": "B.1.177.17",
+    "Earliest date": "2020-08-02",
+    "Latest date": "2021-02-16",
+    "Description": "UK, merged with B.1.177.13"
+  },
+  {
+    "Lineage": "B.1.177.18",
+    "Earliest date": "2020-09-14",
+    "Latest date": "2021-10-12",
+    "Description": "England, some Wales, parent is mainland Europe"
+  },
+  {
+    "Lineage": "B.1.177.19",
+    "Earliest date": "2020-09-03",
+    "Latest date": "2021-03-12",
+    "Description": "England, some Wales"
+  },
+  {
+    "Lineage": "B.1.177.20",
+    "Earliest date": "2020-03-21",
+    "Latest date": "2021-05-03",
+    "Description": "England"
+  },
+  {
+    "Lineage": "B.1.177.21",
+    "Earliest date": "2020-08-24",
+    "Latest date": "2021-05-31",
+    "Description": "Denmark"
+  },
+  {
+    "Lineage": "B.1.177.23",
+    "Earliest date": "2020-08-17",
+    "Latest date": "2022-06-09",
+    "Description": "Swiss lineage"
+  },
+  {
+    "Lineage": "B.1.177.24",
+    "Earliest date": "2020-08-17",
+    "Latest date": "2021-03-16",
+    "Description": "Danish lineage, contains some previous B.1.177.1"
+  },
+  {
+    "Lineage": "B.1.177.25",
+    "Earliest date": "2020-10-27",
+    "Latest date": "2020-10-29",
+    "Description": "Gibraltar lineage"
+  },
+  {
+    "Lineage": "B.1.177.26",
+    "Earliest date": "2020-10-03",
+    "Latest date": "2020-12-28",
+    "Description": "UK lineage"
+  },
+  {
+    "Lineage": "B.1.177.27",
+    "Earliest date": "2020-10-12",
+    "Latest date": "2020-11-09",
+    "Description": "Danish"
+  },
+  {
+    "Lineage": "B.1.177.28",
+    "Earliest date": "2020-10-18",
+    "Latest date": "2021-04-13",
+    "Description": "Swiss lineage"
+  },
+  {
+    "Lineage": "B.1.177.29",
+    "Earliest date": "2020-09-07",
+    "Latest date": "2021-06-09",
+    "Description": "Spain"
+  },
+  {
+    "Lineage": "B.1.177.30",
+    "Earliest date": "2020-10-23",
+    "Latest date": "2021-02-08",
+    "Description": "England"
+  },
+  {
+    "Lineage": "B.1.177.31",
+    "Earliest date": "2020-08-24",
+    "Latest date": "2021-02-03",
+    "Description": "Swiss lineage"
+  },
+  {
+    "Lineage": "B.1.177.32",
+    "Earliest date": "2020-09-29",
+    "Latest date": "2021-05-06",
+    "Description": "Swiss and Portuguese mostly"
+  },
+  {
+    "Lineage": "B.1.177.33",
+    "Earliest date": "2020-09-01",
+    "Latest date": "2022-06-29",
+    "Description": "Mostly italian, some swiss, some english"
+  },
+  {
+    "Lineage": "B.1.177.34",
+    "Earliest date": "2020-12-06",
+    "Latest date": "2021-02-22",
+    "Description": "Dutch"
+  },
+  {
+    "Lineage": "B.1.177.35",
+    "Earliest date": "2020-10-17",
+    "Latest date": "2021-04-23",
+    "Description": "Danish, some Israel more recently"
+  },
+  {
+    "Lineage": "B.1.177.36",
+    "Earliest date": "2020-09-14",
+    "Latest date": "2021-03-05",
+    "Description": "Dutch"
+  },
+  {
+    "Lineage": "B.1.177.37",
+    "Earliest date": "2020-11-16",
+    "Latest date": "2021-02-25",
+    "Description": "Belgian"
+  },
+  {
+    "Lineage": "B.1.177.38",
+    "Earliest date": "2020-09-11",
+    "Latest date": "2021-03-17",
+    "Description": "Dutch"
+  },
+  {
+    "Lineage": "B.1.177.39",
+    "Earliest date": "2020-10-05",
+    "Latest date": "2021-03-02",
+    "Description": "Ireland andNorthern Ireland"
+  },
+  {
+    "Lineage": "B.1.177.40",
+    "Earliest date": "2020-10-14",
+    "Latest date": "2021-04-02",
+    "Description": "Dutch"
+  },
+  {
+    "Lineage": "B.1.177.41",
+    "Earliest date": "2020-09-20",
+    "Latest date": "2021-04-24",
+    "Description": "Danish and swedish"
+  },
+  {
+    "Lineage": "B.1.177.42",
+    "Earliest date": "2020-10-19",
+    "Latest date": "2021-03-29",
+    "Description": "Danish"
+  },
+  {
+    "Lineage": "B.1.177.43",
+    "Earliest date": "2020-08-17",
+    "Latest date": "2021-12-29",
+    "Description": "Swiss, then into Germany and Austria"
+  },
+  {
+    "Lineage": "B.1.177.44",
+    "Earliest date": "2020-08-07",
+    "Latest date": "2021-06-07",
+    "Description": "Swiss mostly"
+  },
+  {
+    "Lineage": "B.1.177.45",
+    "Earliest date": "2020-09-12",
+    "Latest date": "2021-01-27",
+    "Description": "Iceland"
+  },
+  {
+    "Lineage": "B.1.177.46",
+    "Earliest date": "2020-10-29",
+    "Latest date": "2021-05-27",
+    "Description": "Sweden and Denmark"
+  },
+  {
+    "Lineage": "B.1.177.47",
+    "Earliest date": "2020-12-01",
+    "Latest date": "2021-02-09",
+    "Description": "England"
+  },
+  {
+    "Lineage": "B.1.177.48",
+    "Earliest date": "2020-09-24",
+    "Latest date": "2021-01-27",
+    "Description": "UK lineage"
+  },
+  {
+    "Lineage": "B.1.177.49",
+    "Earliest date": "2020-09-11",
+    "Latest date": "2021-02-22",
+    "Description": "Spanish lineage"
+  },
+  {
+    "Lineage": "B.1.177.50",
+    "Earliest date": "2020-08-17",
+    "Latest date": "2021-08-09",
+    "Description": "Netherlands / Germany"
+  },
+  {
+    "Lineage": "Z.1",
+    "Earliest date": "2020-06-02",
+    "Latest date": "2021-04-23",
+    "Description": "Alias of B.1.177.50.1, UK lineage"
+  },
+  {
+    "Lineage": "B.1.177.51",
+    "Earliest date": "2020-10-01",
+    "Latest date": "2021-04-20",
+    "Description": "European lineage"
+  },
+  {
+    "Lineage": "B.1.177.52",
+    "Earliest date": "2020-08-18",
+    "Latest date": "2021-05-02",
+    "Description": "European lineage"
+  },
+  {
+    "Lineage": "Y.1",
+    "Earliest date": "2020-11-03",
+    "Latest date": "2021-03-26",
+    "Description": "Alias of B.1.177.52.1, Portuguese lineage"
+  },
+  {
+    "Lineage": "B.1.177.53",
+    "Earliest date": "2020-08-03",
+    "Latest date": "2021-07-20",
+    "Description": "UK lineage"
+  },
+  {
+    "Lineage": "W.1",
+    "Earliest date": "2020-10-02",
+    "Latest date": "2021-05-14",
+    "Description": "Alias of B.1.177.53.1, French and USA lineage"
+  },
+  {
+    "Lineage": "W.2",
+    "Earliest date": "2020-09-23",
+    "Latest date": "2021-03-04",
+    "Description": "Alias of B.1.177.53.2, Dutch lineage"
+  },
+  {
+    "Lineage": "W.3",
+    "Earliest date": "2020-08-18",
+    "Latest date": "2021-01-30",
+    "Description": "Alias of B.1.177.53.3, UK lineage"
+  },
+  {
+    "Lineage": "W.4",
+    "Earliest date": "2020-06-03",
+    "Latest date": "2021-09-29",
+    "Description": "Alias of B.1.177.53.4, UK lineage"
+  },
+  {
+    "Lineage": "B.1.177.54",
+    "Earliest date": "2020-08-17",
+    "Latest date": "2021-11-08",
+    "Description": "UK lineage"
+  },
+  {
+    "Lineage": "V.1",
+    "Earliest date": "2020-10-05",
+    "Latest date": "2021-02-22",
+    "Description": "Alias of B.1.177.54.1, Northern Irish and Irish lineage"
+  },
+  {
+    "Lineage": "V.2",
+    "Earliest date": "2020-10-20",
+    "Latest date": "2021-02-07",
+    "Description": "Alias of B.1.177.54.2, Northern Irish lineage"
+  },
+  {
+    "Lineage": "B.1.177.55",
+    "Earliest date": "2020-08-28",
+    "Latest date": "2021-02-24",
+    "Description": "England and Ireland"
+  },
+  {
+    "Lineage": "B.1.177.56",
+    "Earliest date": "2020-08-12",
+    "Latest date": "2021-03-08",
+    "Description": "UK lineage"
+  },
+  {
+    "Lineage": "B.1.177.57",
+    "Earliest date": "2020-06-02",
+    "Latest date": "2021-04-13",
+    "Description": "UK lineage"
+  },
+  {
+    "Lineage": "B.1.177.58",
+    "Earliest date": "2020-09-25",
+    "Latest date": "2021-06-22",
+    "Description": "UK"
+  },
+  {
+    "Lineage": "B.1.177.59",
+    "Earliest date": "2020-09-05",
+    "Latest date": "2021-04-24",
+    "Description": "Ireland"
+  },
+  {
+    "Lineage": "B.1.177.60",
+    "Earliest date": "2020-08-17",
+    "Latest date": "2021-11-11",
+    "Description": "Northern Europe, mostly Lithuania"
+  },
+  {
+    "Lineage": "U.1",
+    "Earliest date": "2020-12-15",
+    "Latest date": "2021-02-08",
+    "Description": "Alias of B.1.177.60.1, England"
+  },
+  {
+    "Lineage": "U.2",
+    "Earliest date": "2020-11-11",
+    "Latest date": "2021-03-18",
+    "Description": "Alias of B.1.177.60.2, Denmark"
+  },
+  {
+    "Lineage": "U.3",
+    "Earliest date": "2021-01-11",
+    "Latest date": "2021-05-26",
+    "Description": "Alias of B.1.177.60.3, Norway and Latvia"
+  },
+  {
+    "Lineage": "B.1.177.61",
+    "Earliest date": "2020-12-02",
+    "Latest date": "2021-02-18",
+    "Description": "Spain"
+  },
+  {
+    "Lineage": "B.1.177.62",
+    "Earliest date": "2020-10-02",
+    "Latest date": "2021-05-13",
+    "Description": "Germany, Switzerland, Netherlands"
+  },
+  {
+    "Lineage": "B.1.177.63",
+    "Earliest date": "2020-10-13",
+    "Latest date": "2021-03-21",
+    "Description": "Wales"
+  },
+  {
+    "Lineage": "B.1.177.64",
+    "Earliest date": "2021-01-04",
+    "Latest date": "2021-01-25",
+    "Description": "Ireland"
+  },
+  {
+    "Lineage": "B.1.177.65",
+    "Earliest date": "2020-08-24",
+    "Latest date": "2021-03-07",
+    "Description": "Wales"
+  },
+  {
+    "Lineage": "B.1.177.66",
+    "Earliest date": "2020-10-23",
+    "Latest date": "2020-12-28",
+    "Description": "Irish lineage"
+  },
+  {
+    "Lineage": "B.1.177.67",
+    "Earliest date": "2020-11-05",
+    "Latest date": "2021-04-22",
+    "Description": "Irish lineage"
+  },
+  {
+    "Lineage": "B.1.177.68",
+    "Earliest date": "2020-12-27",
+    "Latest date": "2021-03-10",
+    "Description": "Irish lineage"
+  },
+  {
+    "Lineage": "B.1.177.69",
+    "Earliest date": "2020-09-16",
+    "Latest date": "2021-04-15",
+    "Description": "UK lineage"
+  },
+  {
+    "Lineage": "B.1.177.70",
+    "Earliest date": "2020-11-09",
+    "Latest date": "2021-01-11",
+    "Description": "Danish lineage"
+  },
+  {
+    "Lineage": "B.1.177.71",
+    "Earliest date": "2020-09-21",
+    "Latest date": "2021-02-19",
+    "Description": "Swiss lineage"
+  },
+  {
+    "Lineage": "B.1.177.72",
+    "Earliest date": "2020-10-22",
+    "Latest date": "2021-04-12",
+    "Description": "Portuguese lineage"
+  },
+  {
+    "Lineage": "B.1.177.73",
+    "Earliest date": "2020-04-12",
+    "Latest date": "2021-06-07",
+    "Description": "Netherlands lineage"
+  },
+  {
+    "Lineage": "B.1.177.74",
+    "Earliest date": "2020-10-25",
+    "Latest date": "2021-03-11",
+    "Description": "Netherlands, Spain, UK"
+  },
+  {
+    "Lineage": "B.1.177.75",
+    "Earliest date": "2020-09-02",
+    "Latest date": "2021-10-08",
+    "Description": "Italian lineage"
+  },
+  {
+    "Lineage": "B.1.177.76",
+    "Earliest date": "2020-10-01",
+    "Latest date": "2021-04-12",
+    "Description": "Danish"
+  },
+  {
+    "Lineage": "B.1.177.77",
+    "Earliest date": "2020-03-31",
+    "Latest date": "2021-12-16",
+    "Description": "Benelux + Denmark"
+  },
+  {
+    "Lineage": "B.1.177.78",
+    "Earliest date": "2020-10-23",
+    "Latest date": "2021-03-03",
+    "Description": "French lineage"
+  },
+  {
+    "Lineage": "B.1.177.80",
+    "Earliest date": "2020-10-21",
+    "Latest date": "2021-04-22",
+    "Description": "Scandinavian lineage"
+  },
+  {
+    "Lineage": "B.1.177.81",
+    "Earliest date": "2020-08-10",
+    "Latest date": "2021-11-05",
+    "Description": "Large European lineage"
+  },
+  {
+    "Lineage": "B.1.177.82",
+    "Earliest date": "2020-08-26",
+    "Latest date": "2021-06-09",
+    "Description": "Scandinavian lineage"
+  },
+  {
+    "Lineage": "B.1.177.83",
+    "Earliest date": "2020-08-25",
+    "Latest date": "2021-06-08",
+    "Description": "Italian lineage"
+  },
+  {
+    "Lineage": "B.1.177.84",
+    "Earliest date": "2020-09-16",
+    "Latest date": "2021-01-31",
+    "Description": "UK lineage"
+  },
+  {
+    "Lineage": "B.1.177.85",
+    "Earliest date": "2020-10-23",
+    "Latest date": "2021-05-08",
+    "Description": "Portuguese lineage"
+  },
+  {
+    "Lineage": "B.1.177.86",
+    "Earliest date": "2020-09-21",
+    "Latest date": "2022-08-30",
+    "Description": "German and Danish lineage"
+  },
+  {
+    "Lineage": "B.1.177.87",
+    "Earliest date": "2020-08-25",
+    "Latest date": "2021-05-03",
+    "Description": "UK lineage"
+  },
+  {
+    "Lineage": "B.1.177.88",
+    "Earliest date": "2020-12-26",
+    "Latest date": "2021-04-20",
+    "Description": "Italian lineage, from #19"
+  },
+  {
+    "Lineage": "B.1.177.89",
+    "Earliest date": "2020-11-21",
+    "Latest date": "2021-02-16",
+    "Description": "Switzerland lineage"
+  },
+  {
+    "Lineage": "B.1.178",
+    "Earliest date": "2020-03-17",
+    "Latest date": "2021-07-15",
+    "Description": "DRC lineage"
+  },
+  {
+    "Lineage": "B.1.179",
+    "Earliest date": "2020-03-09",
+    "Latest date": "2021-07-31",
+    "Description": "Denmark"
+  },
+  {
+    "Lineage": "B.1.180",
+    "Earliest date": "2020-04-09",
+    "Latest date": "2020-09-03",
+    "Description": "Romanian lineage"
+  },
+  {
+    "Lineage": "B.1.181",
+    "Earliest date": "2020-04-20",
+    "Latest date": "2020-07-17",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.1.182",
+    "Earliest date": "2020-03-13",
+    "Latest date": "2020-11-15",
+    "Description": "Spanish lineage"
+  },
+  {
+    "Lineage": "B.1.184",
+    "Earliest date": "2020-06-18",
+    "Latest date": "2020-07-18",
+    "Description": "India"
+  },
+  {
+    "Lineage": "B.1.187",
+    "Earliest date": "2020-03-28",
+    "Latest date": "2020-05-05",
+    "Description": "Polish lineage"
+  },
+  {
+    "Lineage": "B.1.188",
+    "Earliest date": "2020-07-17",
+    "Latest date": "2021-06-10",
+    "Description": "USA (OR) lineage"
+  },
+  {
+    "Lineage": "B.1.189",
+    "Earliest date": "2020-04-14",
+    "Latest date": "2021-04-20",
+    "Description": "USA/Mexico"
+  },
+  {
+    "Lineage": "B.1.190",
+    "Earliest date": "2020-03-13",
+    "Latest date": "2020-05-06",
+    "Description": "Netherlands lineage"
+  },
+  {
+    "Lineage": "B.1.192",
+    "Earliest date": "2020-04-21",
+    "Latest date": "2020-12-08",
+    "Description": "Equatorial Guinea"
+  },
+  {
+    "Lineage": "B.1.194",
+    "Earliest date": "2020-05-23",
+    "Latest date": "2020-08-28",
+    "Description": "USA"
+  },
+  {
+    "Lineage": "B.1.195",
+    "Earliest date": "2020-03-17",
+    "Latest date": "2021-07-21",
+    "Description": "UAE"
+  },
+  {
+    "Lineage": "B.1.198",
+    "Earliest date": "2020-04-03",
+    "Latest date": "2020-05-06",
+    "Description": "UK lineage"
+  },
+  {
+    "Lineage": "B.1.199",
+    "Earliest date": "2020-03-16",
+    "Latest date": "2020-12-18",
+    "Description": "USA"
+  },
+  {
+    "Lineage": "B.1.201",
+    "Earliest date": "2020-03-06",
+    "Latest date": "2020-07-05",
+    "Description": "UK lineage"
+  },
+  {
+    "Lineage": "B.1.203",
+    "Earliest date": "2020-06-11",
+    "Latest date": "2021-03-12",
+    "Description": "Panama/Costa Rica"
+  },
+  {
+    "Lineage": "B.1.206",
+    "Earliest date": "2020-04-09",
+    "Latest date": "2020-12-14",
+    "Description": "USA"
+  },
+  {
+    "Lineage": "B.1.205",
+    "Earliest date": "2020-03-05",
+    "Latest date": "2020-11-30",
+    "Description": "Peruvian"
+  },
+  {
+    "Lineage": "B.1.208",
+    "Earliest date": "2020-03-15",
+    "Latest date": "2021-01-16",
+    "Description": "French lineage"
+  },
+  {
+    "Lineage": "B.1.210",
+    "Earliest date": "2020-03-10",
+    "Latest date": "2021-07-13",
+    "Description": "Indian lineage"
+  },
+  {
+    "Lineage": "B.1.211",
+    "Earliest date": "2020-03-04",
+    "Latest date": "2020-05-18",
+    "Description": "Belgium/ Luxembourg lineage"
+  },
+  {
+    "Lineage": "B.1.212",
+    "Earliest date": "2020-03-03",
+    "Latest date": "2021-02-05",
+    "Description": "South American lineage"
+  },
+  {
+    "Lineage": "B.1.213",
+    "Earliest date": "2020-05-10",
+    "Latest date": "2021-07-30",
+    "Description": "Polish lineage"
+  },
+  {
+    "Lineage": "B.1.214",
+    "Earliest date": "2020-04-18",
+    "Latest date": "2021-11-05",
+    "Description": "DRC/ Congo lineage"
+  },
+  {
+    "Lineage": "B.1.214.1",
+    "Earliest date": "2020-12-05",
+    "Latest date": "2021-02-26",
+    "Description": "Congo/ France lineage, from #21"
+  },
+  {
+    "Lineage": "B.1.214.2",
+    "Earliest date": "2020-12-05",
+    "Latest date": "2021-04-27",
+    "Description": "Lineage from Belgium with a number of key spike mutations and a 9bp spike insertion, from #20"
+  },
+  {
+    "Lineage": "B.1.214.3",
+    "Earliest date": "2020-12-14",
+    "Latest date": "2021-07-08",
+    "Description": "France, Belgium and Mayotte lineage, from #20"
+  },
+  {
+    "Lineage": "B.1.214.4",
+    "Earliest date": "2021-01-25",
+    "Latest date": "2021-03-15",
+    "Description": "Danish lineage, from #20"
+  },
+  {
+    "Lineage": "B.1.215",
+    "Earliest date": "2020-03-14",
+    "Latest date": "2020-06-19",
+    "Description": "Scottish lineage"
+  },
+  {
+    "Lineage": "B.1.218",
+    "Earliest date": "2020-07-20",
+    "Latest date": "2021-05-10",
+    "Description": "Swiss lineage"
+  },
+  {
+    "Lineage": "B.1.219",
+    "Earliest date": "2020-03-22",
+    "Latest date": "2021-10-11",
+    "Description": "Suriname lineage"
+  },
+  {
+    "Lineage": "B.1.220",
+    "Earliest date": "2020-03-14",
+    "Latest date": "2020-07-01",
+    "Description": "European lineage"
+  },
+  {
+    "Lineage": "B.1.221",
+    "Earliest date": "2020-02-02",
+    "Latest date": "2023-10-03",
+    "Description": "European lineage"
+  },
+  {
+    "Lineage": "B.1.221.1",
+    "Earliest date": "2020-08-18",
+    "Latest date": "2021-03-03",
+    "Description": "UK lineage"
+  },
+  {
+    "Lineage": "B.1.221.2",
+    "Earliest date": "2020-03-21",
+    "Latest date": "2021-03-31",
+    "Description": "German lineage"
+  },
+  {
+    "Lineage": "B.1.221.3",
+    "Earliest date": "2020-09-14",
+    "Latest date": "2021-12-22",
+    "Description": "Danish lineage"
+  },
+  {
+    "Lineage": "B.1.221.4",
+    "Earliest date": "2020-09-30",
+    "Latest date": "2021-05-12",
+    "Description": "Belgium/ Luxembourg lineage"
+  },
+  {
+    "Lineage": "B.1.222",
+    "Earliest date": "2020-02-24",
+    "Latest date": "2021-09-29",
+    "Description": "Scottish lineage"
+  },
+  {
+    "Lineage": "B.1.223",
+    "Earliest date": "2020-02-28",
+    "Latest date": "2021-09-29",
+    "Description": "UK lineage"
+  },
+  {
+    "Lineage": "B.1.224",
+    "Earliest date": "2020-03-16",
+    "Latest date": "2020-06-17",
+    "Description": "Austrian lineage"
+  },
+  {
+    "Lineage": "B.1.225",
+    "Earliest date": "2020-03-19",
+    "Latest date": "2020-06-12",
+    "Description": "UK lineage"
+  },
+  {
+    "Lineage": "B.1.227",
+    "Earliest date": "2020-03-16",
+    "Latest date": "2020-08-11",
+    "Description": "Sweden"
+  },
+  {
+    "Lineage": "B.1.229",
+    "Earliest date": "2020-03-19",
+    "Latest date": "2021-01-29",
+    "Description": "UK lineage"
+  },
+  {
+    "Lineage": "B.1.231",
+    "Earliest date": "2020-04-07",
+    "Latest date": "2020-07-23",
+    "Description": "UK lineage"
+  },
+  {
+    "Lineage": "B.1.232",
+    "Earliest date": "2020-04-06",
+    "Latest date": "2021-05-07",
+    "Description": "USA/ Scottish lineage"
+  },
+  {
+    "Lineage": "B.1.233",
+    "Earliest date": "2020-06-16",
+    "Latest date": "2020-11-19",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.1.234",
+    "Earliest date": "2020-06-03",
+    "Latest date": "2022-09-23",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.1.235",
+    "Earliest date": "2020-06-08",
+    "Latest date": "2020-12-20",
+    "Description": "UK"
+  },
+  {
+    "Lineage": "B.1.236",
+    "Earliest date": "2020-04-15",
+    "Latest date": "2021-04-07",
+    "Description": "Swiss lineage"
+  },
+  {
+    "Lineage": "B.1.237",
+    "Earliest date": "2020-04-24",
+    "Latest date": "2021-08-04",
+    "Description": "South african lineage"
+  },
+  {
+    "Lineage": "B.1.238",
+    "Earliest date": "2020-05-14",
+    "Latest date": "2021-03-12",
+    "Description": "UK lineage"
+  },
+  {
+    "Lineage": "B.1.239",
+    "Earliest date": "2020-04-09",
+    "Latest date": "2021-09-14",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.1.240",
+    "Earliest date": "2020-03-22",
+    "Latest date": "2022-03-10",
+    "Description": "USA"
+  },
+  {
+    "Lineage": "B.1.240.1",
+    "Earliest date": "2020-08-04",
+    "Latest date": "2021-02-12",
+    "Description": "Curacao and Aruba"
+  },
+  {
+    "Lineage": "B.1.240.2",
+    "Earliest date": "2020-08-24",
+    "Latest date": "2021-02-23",
+    "Description": "England"
+  },
+  {
+    "Lineage": "B.1.241",
+    "Earliest date": "2020-04-15",
+    "Latest date": "2021-12-10",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.1.243",
+    "Earliest date": "2020-03-23",
+    "Latest date": "2024-06-24",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.1.243.1",
+    "Earliest date": "2020-12-15",
+    "Latest date": "2021-05-04",
+    "Description": "Emergent lineage in Arizona with a number of defining amino acid mutations, including S:E484K and S:V213G. Described in Skidmore et al 2021. https://www.medrxiv.org/content/10.1101/2021.03.26.21254367v1.full.pdf, from #35"
+  },
+  {
+    "Lineage": "B.1.243.2",
+    "Earliest date": "2021-05-10",
+    "Latest date": "2021-10-27",
+    "Description": "Mexico lineage, from #169"
+  },
+  {
+    "Lineage": "B.1.242",
+    "Earliest date": "2020-06-12",
+    "Latest date": "2020-08-13",
+    "Description": "Norway lineage"
+  },
+  {
+    "Lineage": "B.1.245",
+    "Earliest date": "2020-03-24",
+    "Latest date": "2020-08-21",
+    "Description": "USA/CA"
+  },
+  {
+    "Lineage": "B.1.247",
+    "Earliest date": "2020-05-04",
+    "Latest date": "2020-07-09",
+    "Description": "India"
+  },
+  {
+    "Lineage": "B.1.249",
+    "Earliest date": "2020-04-11",
+    "Latest date": "2020-06-27",
+    "Description": "England"
+  },
+  {
+    "Lineage": "B.1.248",
+    "Earliest date": "2020-03-28",
+    "Latest date": "2021-09-29",
+    "Description": "Scotland"
+  },
+  {
+    "Lineage": "B.1.250",
+    "Earliest date": "2020-03-12",
+    "Latest date": "2020-05-13",
+    "Description": "England"
+  },
+  {
+    "Lineage": "B.1.251",
+    "Earliest date": "2020-06-01",
+    "Latest date": "2020-07-15",
+    "Description": "England"
+  },
+  {
+    "Lineage": "B.1.252",
+    "Earliest date": "2020-03-27",
+    "Latest date": "2020-07-13",
+    "Description": "Wales"
+  },
+  {
+    "Lineage": "B.1.254",
+    "Earliest date": "2020-04-06",
+    "Latest date": "2020-05-13",
+    "Description": "Scotland"
+  },
+  {
+    "Lineage": "B.1.256",
+    "Earliest date": "2020-03-22",
+    "Latest date": "2020-06-01",
+    "Description": "Scottish lineage"
+  },
+  {
+    "Lineage": "B.1.258",
+    "Earliest date": "2020-03-25",
+    "Latest date": "2022-11-26",
+    "Description": "UK lineage"
+  },
+  {
+    "Lineage": "B.1.258.2",
+    "Earliest date": "2020-07-03",
+    "Latest date": "2020-11-23",
+    "Description": "Irish lineage (has sub-lineage G.1)"
+  },
+  {
+    "Lineage": "G.1",
+    "Earliest date": "2020-09-10",
+    "Latest date": "2020-11-20",
+    "Description": "Alias of B.1.258.2.1, UK lineage"
+  },
+  {
+    "Lineage": "B.1.258.3",
+    "Earliest date": "2020-07-06",
+    "Latest date": "2022-03-15",
+    "Description": "UK lineage"
+  },
+  {
+    "Lineage": "B.1.258.4",
+    "Earliest date": "2020-09-03",
+    "Latest date": "2021-04-10",
+    "Description": "UK lineage"
+  },
+  {
+    "Lineage": "B.1.258.5",
+    "Earliest date": "2020-09-09",
+    "Latest date": "2020-12-08",
+    "Description": "UK lineage"
+  },
+  {
+    "Lineage": "B.1.258.6",
+    "Earliest date": "2020-09-10",
+    "Latest date": "2020-11-22",
+    "Description": "UK lineage"
+  },
+  {
+    "Lineage": "B.1.258.7",
+    "Earliest date": "2020-08-29",
+    "Latest date": "2021-02-09",
+    "Description": "UK lineage"
+  },
+  {
+    "Lineage": "B.1.258.9",
+    "Earliest date": "2020-08-31",
+    "Latest date": "2021-01-25",
+    "Description": "Danish lineage"
+  },
+  {
+    "Lineage": "B.1.258.10",
+    "Earliest date": "2020-09-17",
+    "Latest date": "2020-12-05",
+    "Description": "Scottish lineage"
+  },
+  {
+    "Lineage": "B.1.258.11",
+    "Earliest date": "2020-09-14",
+    "Latest date": "2021-04-05",
+    "Description": "Danish lineage"
+  },
+  {
+    "Lineage": "B.1.258.12",
+    "Earliest date": "2020-09-20",
+    "Latest date": "2021-01-16",
+    "Description": "UK lineage"
+  },
+  {
+    "Lineage": "B.1.258.14",
+    "Earliest date": "2020-10-06",
+    "Latest date": "2021-05-05",
+    "Description": "Italian lineage"
+  },
+  {
+    "Lineage": "B.1.258.15",
+    "Earliest date": "2020-11-10",
+    "Latest date": "2021-01-11",
+    "Description": "Danish lineage"
+  },
+  {
+    "Lineage": "B.1.258.16",
+    "Earliest date": "2020-11-23",
+    "Latest date": "2021-02-05",
+    "Description": "Swiss/ Danish lineage"
+  },
+  {
+    "Lineage": "B.1.258.17",
+    "Earliest date": "2020-09-11",
+    "Latest date": "2023-04-17",
+    "Description": "European lineage"
+  },
+  {
+    "Lineage": "B.1.258.18",
+    "Earliest date": "2020-10-05",
+    "Latest date": "2020-12-20",
+    "Description": "Netherlands lineage"
+  },
+  {
+    "Lineage": "B.1.258.19",
+    "Earliest date": "2020-11-23",
+    "Latest date": "2021-01-18",
+    "Description": "Danish lineage"
+  },
+  {
+    "Lineage": "B.1.258.20",
+    "Earliest date": "2020-09-23",
+    "Latest date": "2021-04-05",
+    "Description": "Luxembourg lineage"
+  },
+  {
+    "Lineage": "B.1.258.21",
+    "Earliest date": "2020-10-08",
+    "Latest date": "2021-02-02",
+    "Description": "Netherlands lineage"
+  },
+  {
+    "Lineage": "B.1.258.22",
+    "Earliest date": "2020-12-07",
+    "Latest date": "2021-04-23",
+    "Description": "Swedish lineage"
+  },
+  {
+    "Lineage": "B.1.258.23",
+    "Earliest date": "2020-11-18",
+    "Latest date": "2021-01-27",
+    "Description": "USA (UT) lineage"
+  },
+  {
+    "Lineage": "B.1.258.24",
+    "Earliest date": "2020-12-21",
+    "Latest date": "2021-02-04",
+    "Description": "Italian lineage"
+  },
+  {
+    "Lineage": "B.1.260",
+    "Earliest date": "2020-03-24",
+    "Latest date": "2020-12-27",
+    "Description": "Saudi Arabian lineage"
+  },
+  {
+    "Lineage": "B.1.263",
+    "Earliest date": "2020-03-19",
+    "Latest date": "2021-01-05",
+    "Description": "Danish"
+  },
+  {
+    "Lineage": "B.1.264",
+    "Earliest date": "2020-03-13",
+    "Latest date": "2021-02-11",
+    "Description": "USA (UT)"
+  },
+  {
+    "Lineage": "B.1.264.1",
+    "Earliest date": "2020-08-26",
+    "Latest date": "2021-04-01",
+    "Description": "Russia, Germany, Switzerland, Austria. Was B.1.412"
+  },
+  {
+    "Lineage": "B.1.265",
+    "Earliest date": "2020-03-15",
+    "Latest date": "2021-08-21",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.1.267",
+    "Earliest date": "2020-03-24",
+    "Latest date": "2020-09-01",
+    "Description": "USA (CA)"
+  },
+  {
+    "Lineage": "B.1.268",
+    "Earliest date": "2020-03-18",
+    "Latest date": "2020-06-16",
+    "Description": "USA"
+  },
+  {
+    "Lineage": "B.1.270",
+    "Earliest date": "2020-03-18",
+    "Latest date": "2020-07-17",
+    "Description": "Canadian lineage"
+  },
+  {
+    "Lineage": "B.1.273",
+    "Earliest date": "2020-03-13",
+    "Latest date": "2020-06-06",
+    "Description": "French lineage"
+  },
+  {
+    "Lineage": "B.1.274",
+    "Earliest date": "2020-04-21",
+    "Latest date": "2021-01-14",
+    "Description": "Utah lineage"
+  },
+  {
+    "Lineage": "B.1.276",
+    "Earliest date": "2020-03-22",
+    "Latest date": "2020-07-24",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.1.277",
+    "Earliest date": "2020-03-04",
+    "Latest date": "2020-07-04",
+    "Description": "European lineage"
+  },
+  {
+    "Lineage": "B.1.279",
+    "Earliest date": "2020-03-15",
+    "Latest date": "2021-02-13",
+    "Description": "Canadian lineage"
+  },
+  {
+    "Lineage": "B.1.280",
+    "Earliest date": "2020-03-12",
+    "Latest date": "2021-08-16",
+    "Description": "USA"
+  },
+  {
+    "Lineage": "B.1.281",
+    "Earliest date": "2020-04-08",
+    "Latest date": "2020-11-16",
+    "Description": "Bahrain lineage"
+  },
+  {
+    "Lineage": "B.1.282",
+    "Earliest date": "2020-06-01",
+    "Latest date": "2020-09-08",
+    "Description": "UK lineage"
+  },
+  {
+    "Lineage": "B.1.284",
+    "Earliest date": "2020-03-16",
+    "Latest date": "2020-10-17",
+    "Description": "USA - Texas"
+  },
+  {
+    "Lineage": "B.1.285",
+    "Earliest date": "2020-06-10",
+    "Latest date": "2020-07-02",
+    "Description": "USA - Texas"
+  },
+  {
+    "Lineage": "B.1.287",
+    "Earliest date": "2020-06-02",
+    "Latest date": "2020-07-20",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.1.289",
+    "Earliest date": "2020-03-29",
+    "Latest date": "2021-04-26",
+    "Description": "USA - Arizona"
+  },
+  {
+    "Lineage": "B.1.291",
+    "Earliest date": "2020-04-27",
+    "Latest date": "2021-01-22",
+    "Description": "Costa Rica"
+  },
+  {
+    "Lineage": "B.1.292",
+    "Earliest date": "2020-04-01",
+    "Latest date": "2020-09-09",
+    "Description": "Gambia"
+  },
+  {
+    "Lineage": "B.1.293",
+    "Earliest date": "2020-03-16",
+    "Latest date": "2021-02-23",
+    "Description": "USA"
+  },
+  {
+    "Lineage": "B.1.294",
+    "Earliest date": "2020-06-16",
+    "Latest date": "2020-10-17",
+    "Description": "USA - WI and MN"
+  },
+  {
+    "Lineage": "B.1.298",
+    "Earliest date": "2020-03-20",
+    "Latest date": "2022-01-20",
+    "Description": "USA (north east)"
+  },
+  {
+    "Lineage": "B.1.301",
+    "Earliest date": "2020-04-01",
+    "Latest date": "2021-03-27",
+    "Description": "USA , some B.1.2 merged in"
+  },
+  {
+    "Lineage": "B.1.302",
+    "Earliest date": "2020-03-12",
+    "Latest date": "2020-10-19",
+    "Description": "USA, New England"
+  },
+  {
+    "Lineage": "B.1.304",
+    "Earliest date": "2020-05-20",
+    "Latest date": "2020-09-21",
+    "Description": "USA"
+  },
+  {
+    "Lineage": "B.1.305",
+    "Earliest date": "2020-06-04",
+    "Latest date": "2021-08-21",
+    "Description": "USA, mostly TX"
+  },
+  {
+    "Lineage": "B.1.306",
+    "Earliest date": "2020-06-03",
+    "Latest date": "2021-03-25",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.1.308",
+    "Earliest date": "2020-03-18",
+    "Latest date": "2020-08-14",
+    "Description": "Northern USA and Canada"
+  },
+  {
+    "Lineage": "B.1.309",
+    "Earliest date": "2020-04-26",
+    "Latest date": "2020-10-26",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.1.310",
+    "Earliest date": "2020-04-01",
+    "Latest date": "2020-04-30",
+    "Description": "Netherlands"
+  },
+  {
+    "Lineage": "B.1.311",
+    "Earliest date": "2020-03-31",
+    "Latest date": "2021-10-31",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.1.313",
+    "Earliest date": "2020-04-01",
+    "Latest date": "2021-08-05",
+    "Description": "USA (removed the polytomy at the base of the lineage)"
+  },
+  {
+    "Lineage": "B.1.314",
+    "Earliest date": "2020-03-07",
+    "Latest date": "2020-11-17",
+    "Description": "North American lineage"
+  },
+  {
+    "Lineage": "B.1.315",
+    "Earliest date": "2020-03-25",
+    "Latest date": "2021-10-22",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.1.316",
+    "Earliest date": "2020-04-29",
+    "Latest date": "2020-06-16",
+    "Description": "Canada lineage"
+  },
+  {
+    "Lineage": "B.1.318",
+    "Earliest date": "2020-06-22",
+    "Latest date": "2021-01-27",
+    "Description": "USA (FL)"
+  },
+  {
+    "Lineage": "B.1.319",
+    "Earliest date": "2020-03-05",
+    "Latest date": "2021-04-26",
+    "Description": "USA and Australia"
+  },
+  {
+    "Lineage": "B.1.320",
+    "Earliest date": "2020-03-07",
+    "Latest date": "2021-08-31",
+    "Description": "USA"
+  },
+  {
+    "Lineage": "B.1.321",
+    "Earliest date": "2020-03-09",
+    "Latest date": "2020-05-01",
+    "Description": "Belgium, England"
+  },
+  {
+    "Lineage": "B.1.323",
+    "Earliest date": "2020-03-13",
+    "Latest date": "2020-09-26",
+    "Description": "USA (NY)"
+  },
+  {
+    "Lineage": "B.1.324",
+    "Earliest date": "2020-03-15",
+    "Latest date": "2021-09-14",
+    "Description": "USA"
+  },
+  {
+    "Lineage": "B.1.325",
+    "Earliest date": "2020-05-27",
+    "Latest date": "2020-09-14",
+    "Description": "USA (TX)"
+  },
+  {
+    "Lineage": "B.1.326",
+    "Earliest date": "2020-04-25",
+    "Latest date": "2020-08-12",
+    "Description": "USA (TX)"
+  },
+  {
+    "Lineage": "B.1.328",
+    "Earliest date": "2020-05-23",
+    "Latest date": "2020-08-24",
+    "Description": "USA"
+  },
+  {
+    "Lineage": "B.1.329",
+    "Earliest date": "2020-03-18",
+    "Latest date": "2020-09-25",
+    "Description": "German"
+  },
+  {
+    "Lineage": "B.1.330",
+    "Earliest date": "2020-03-24",
+    "Latest date": "2020-07-17",
+    "Description": "USA (MN)"
+  },
+  {
+    "Lineage": "B.1.332",
+    "Earliest date": "2020-03-07",
+    "Latest date": "2021-06-01",
+    "Description": "USA"
+  },
+  {
+    "Lineage": "B.1.333",
+    "Earliest date": "2020-03-17",
+    "Latest date": "2020-08-13",
+    "Description": "USA lineage WA"
+  },
+  {
+    "Lineage": "B.1.334",
+    "Earliest date": "2020-03-20",
+    "Latest date": "2020-09-14",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.1.335",
+    "Earliest date": "2020-04-28",
+    "Latest date": "2020-11-04",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.1.336",
+    "Earliest date": "2020-03-13",
+    "Latest date": "2021-02-06",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.1.337",
+    "Earliest date": "2020-07-03",
+    "Latest date": "2021-02-25",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.1.338",
+    "Earliest date": "2020-03-16",
+    "Latest date": "2020-06-10",
+    "Description": "Australia"
+  },
+  {
+    "Lineage": "B.1.340",
+    "Earliest date": "2020-05-03",
+    "Latest date": "2021-03-02",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.1.341",
+    "Earliest date": "2020-04-25",
+    "Latest date": "2020-07-16",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.1.342",
+    "Earliest date": "2020-05-23",
+    "Latest date": "2020-08-07",
+    "Description": "Sweden"
+  },
+  {
+    "Lineage": "B.1.344",
+    "Earliest date": "2020-03-12",
+    "Latest date": "2020-08-13",
+    "Description": "USA (CO)"
+  },
+  {
+    "Lineage": "B.1.346",
+    "Earliest date": "2020-06-27",
+    "Latest date": "2021-10-04",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.1.348",
+    "Earliest date": "2020-10-07",
+    "Latest date": "2021-01-15",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.1.349",
+    "Earliest date": "2020-06-05",
+    "Latest date": "2021-08-21",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.1.350",
+    "Earliest date": "2020-03-13",
+    "Latest date": "2021-01-15",
+    "Description": "Canada"
+  },
+  {
+    "Lineage": "B.1.350.1",
+    "Earliest date": "2020-05-25",
+    "Latest date": "2020-06-12",
+    "Description": "England"
+  },
+  {
+    "Lineage": "B.1.351",
+    "Earliest date": "2020-02-18",
+    "Latest date": "2023-04-18",
+    "Description": "Lineage of concern detected in South Africa"
+  },
+  {
+    "Lineage": "B.1.351.1",
+    "Earliest date": "2021-01-19",
+    "Latest date": "2021-01-22",
+    "Description": "Sublineage of B.1.351 circulating in Botswana"
+  },
+  {
+    "Lineage": "B.1.351.2",
+    "Earliest date": "2020-11-03",
+    "Latest date": "2021-10-12",
+    "Description": "Sublineage of B.1.351 circulating in Mayotte"
+  },
+  {
+    "Lineage": "B.1.351.3",
+    "Earliest date": "2020-11-04",
+    "Latest date": "2021-08-05",
+    "Description": "Sublineage of B.1.351 predominantly in Bangladesh and Singapore with exports elsewhere, from #65"
+  },
+  {
+    "Lineage": "B.1.351.5",
+    "Earliest date": "2021-04-30",
+    "Latest date": "2022-01-16",
+    "Description": "Sublineage of B.1.351 in Spain, from #211"
+  },
+  {
+    "Lineage": "B.1.343",
+    "Earliest date": "2020-03-09",
+    "Latest date": "2021-10-05",
+    "Description": "Denmark"
+  },
+  {
+    "Lineage": "B.1.354",
+    "Earliest date": "2020-03-12",
+    "Latest date": "2020-12-13",
+    "Description": "Denmark"
+  },
+  {
+    "Lineage": "B.1.355",
+    "Earliest date": "2020-05-09",
+    "Latest date": "2020-07-27",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.1.356",
+    "Earliest date": "2020-02-28",
+    "Latest date": "2020-11-23",
+    "Description": "European, mostly dutch and spanish, some north american"
+  },
+  {
+    "Lineage": "B.1.357",
+    "Earliest date": "2020-05-21",
+    "Latest date": "2021-07-20",
+    "Description": "USA (OR,WA,HI)"
+  },
+  {
+    "Lineage": "B.1.358",
+    "Earliest date": "2020-04-01",
+    "Latest date": "2020-05-11",
+    "Description": "Danish lineage"
+  },
+  {
+    "Lineage": "B.1.359",
+    "Earliest date": "2020-03-09",
+    "Latest date": "2020-11-10",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.1.360",
+    "Earliest date": "2020-03-17",
+    "Latest date": "2021-03-23",
+    "Description": "USA"
+  },
+  {
+    "Lineage": "B.1.361",
+    "Earliest date": "2020-04-15",
+    "Latest date": "2021-09-17",
+    "Description": "USA lineage (split from whatever Chris reassigns B.1.361 to)"
+  },
+  {
+    "Lineage": "B.1.362",
+    "Earliest date": "2020-04-03",
+    "Latest date": "2021-05-05",
+    "Description": "Israel lineage"
+  },
+  {
+    "Lineage": "B.1.362.1",
+    "Earliest date": "2020-09-19",
+    "Latest date": "2020-11-12",
+    "Description": "UK lineage"
+  },
+  {
+    "Lineage": "B.1.362.2",
+    "Earliest date": "2020-09-01",
+    "Latest date": "2021-02-02",
+    "Description": "UK lineage"
+  },
+  {
+    "Lineage": "B.1.363",
+    "Earliest date": "2020-06-19",
+    "Latest date": "2021-03-27",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.1.366",
+    "Earliest date": "2020-04-27",
+    "Latest date": "2021-03-07",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.1.367",
+    "Earliest date": "2020-07-13",
+    "Latest date": "2021-12-07",
+    "Description": "European lineage (mostly France and England)"
+  },
+  {
+    "Lineage": "B.1.369",
+    "Earliest date": "2020-03-11",
+    "Latest date": "2021-09-21",
+    "Description": "USA/ New Zealand lineage"
+  },
+  {
+    "Lineage": "B.1.369.1",
+    "Earliest date": "2020-12-29",
+    "Latest date": "2021-01-21",
+    "Description": "Canada lineage"
+  },
+  {
+    "Lineage": "B.1.370",
+    "Earliest date": "2020-03-19",
+    "Latest date": "2021-03-31",
+    "Description": "USA lineage, cleaned up a lot in release 2021-01-20"
+  },
+  {
+    "Lineage": "B.1.371",
+    "Earliest date": "2020-03-08",
+    "Latest date": "2021-04-11",
+    "Description": "Danish/ USA lineage, previously part of B.1.21"
+  },
+  {
+    "Lineage": "B.1.372",
+    "Earliest date": "2020-03-30",
+    "Latest date": "2020-09-14",
+    "Description": "Danish lineage"
+  },
+  {
+    "Lineage": "B.1.375",
+    "Earliest date": "2020-09-14",
+    "Latest date": "2021-05-06",
+    "Description": "USA lineage (circulating in Connecticut with the 69-70del, which leads to SGTF. However, they express 484E and 501N in their spike proteins.)"
+  },
+  {
+    "Lineage": "B.1.377",
+    "Earliest date": "2020-04-19",
+    "Latest date": "2021-05-18",
+    "Description": "USA and England"
+  },
+  {
+    "Lineage": "B.1.378",
+    "Earliest date": "2020-03-14",
+    "Latest date": "2021-01-17",
+    "Description": "USA"
+  },
+  {
+    "Lineage": "B.1.379",
+    "Earliest date": "2020-03-16",
+    "Latest date": "2020-04-24",
+    "Description": "UK"
+  },
+  {
+    "Lineage": "B.1.380",
+    "Earliest date": "2020-03-04",
+    "Latest date": "2021-02-16",
+    "Description": "Rwanda / Uganda"
+  },
+  {
+    "Lineage": "B.1.381",
+    "Earliest date": "2020-04-14",
+    "Latest date": "2021-01-28",
+    "Description": "South Africa"
+  },
+  {
+    "Lineage": "B.1.382",
+    "Earliest date": "2020-03-16",
+    "Latest date": "2021-01-19",
+    "Description": "USA"
+  },
+  {
+    "Lineage": "B.1.383",
+    "Earliest date": "2020-03-01",
+    "Latest date": "2020-07-14",
+    "Description": "Wales"
+  },
+  {
+    "Lineage": "B.1.384",
+    "Earliest date": "2020-03-15",
+    "Latest date": "2021-03-31",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.1.385",
+    "Earliest date": "2020-06-22",
+    "Latest date": "2021-01-18",
+    "Description": "USA"
+  },
+  {
+    "Lineage": "B.1.387",
+    "Earliest date": "2020-03-06",
+    "Latest date": "2020-05-11",
+    "Description": "French lineage"
+  },
+  {
+    "Lineage": "B.1.388",
+    "Earliest date": "2020-06-10",
+    "Latest date": "2020-09-09",
+    "Description": "Cote d'Ivoire lineage"
+  },
+  {
+    "Lineage": "B.1.389",
+    "Earliest date": "2020-08-02",
+    "Latest date": "2021-05-03",
+    "Description": "England + Europe"
+  },
+  {
+    "Lineage": "B.1.390",
+    "Earliest date": "2020-03-25",
+    "Latest date": "2021-05-25",
+    "Description": "USA"
+  },
+  {
+    "Lineage": "B.1.391",
+    "Earliest date": "2020-03-09",
+    "Latest date": "2021-09-29",
+    "Description": "UK"
+  },
+  {
+    "Lineage": "B.1.393",
+    "Earliest date": "2020-05-29",
+    "Latest date": "2021-05-22",
+    "Description": "Uganda"
+  },
+  {
+    "Lineage": "B.1.395",
+    "Earliest date": "2020-03-06",
+    "Latest date": "2021-07-28",
+    "Description": "Wales"
+  },
+  {
+    "Lineage": "B.1.396",
+    "Earliest date": "2020-05-12",
+    "Latest date": "2021-11-17",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.1.397",
+    "Earliest date": "2020-04-07",
+    "Latest date": "2021-09-14",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.1.398",
+    "Earliest date": "2020-01-10",
+    "Latest date": "2021-03-02",
+    "Description": "European lineage"
+  },
+  {
+    "Lineage": "B.1.399",
+    "Earliest date": "2020-04-26",
+    "Latest date": "2021-08-21",
+    "Description": "USA"
+  },
+  {
+    "Lineage": "B.1.400",
+    "Earliest date": "2020-04-15",
+    "Latest date": "2021-08-21",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.1.400.1",
+    "Earliest date": "2020-11-09",
+    "Latest date": "2021-04-29",
+    "Description": "USA lineage, from #94"
+  },
+  {
+    "Lineage": "B.1.401",
+    "Earliest date": "2020-06-04",
+    "Latest date": "2021-02-20",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.1.402",
+    "Earliest date": "2020-06-19",
+    "Latest date": "2021-02-05",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.1.403",
+    "Earliest date": "2020-04-07",
+    "Latest date": "2021-05-07",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.1.404",
+    "Earliest date": "2020-07-06",
+    "Latest date": "2021-05-30",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.1.405",
+    "Earliest date": "2020-04-30",
+    "Latest date": "2021-08-21",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.1.406",
+    "Earliest date": "2020-07-06",
+    "Latest date": "2021-01-25",
+    "Description": "Germany/ UK lineage"
+  },
+  {
+    "Lineage": "B.1.407",
+    "Earliest date": "2020-06-09",
+    "Latest date": "2020-08-03",
+    "Description": "UK lineage"
+  },
+  {
+    "Lineage": "B.1.408",
+    "Earliest date": "2020-05-12",
+    "Latest date": "2021-04-07",
+    "Description": "UK/ Romanian lineage"
+  },
+  {
+    "Lineage": "B.1.409",
+    "Earliest date": "2020-09-23",
+    "Latest date": "2021-05-26",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.1.411",
+    "Earliest date": "2020-10-03",
+    "Latest date": "2021-11-26",
+    "Description": "Sri Lankan lineage"
+  },
+  {
+    "Lineage": "B.1.413",
+    "Earliest date": "2020-03-12",
+    "Latest date": "2021-01-16",
+    "Description": "USA"
+  },
+  {
+    "Lineage": "B.1.415",
+    "Earliest date": "2020-03-16",
+    "Latest date": "2020-09-02",
+    "Description": "USA"
+  },
+  {
+    "Lineage": "B.1.415.1",
+    "Earliest date": "2021-05-07",
+    "Latest date": "2021-08-02",
+    "Description": "Predominantly Mexico lineage, from #157"
+  },
+  {
+    "Lineage": "B.1.416",
+    "Earliest date": "2020-04-06",
+    "Latest date": "2022-05-23",
+    "Description": "Senegal/ Gambian lineage, reassigned from B.1.5.12"
+  },
+  {
+    "Lineage": "B.1.416.1",
+    "Earliest date": "2020-07-24",
+    "Latest date": "2021-03-30",
+    "Description": "European lineage within diversity of B.1.416. Previously assigned E.1"
+  },
+  {
+    "Lineage": "B.1.417",
+    "Earliest date": "2020-04-02",
+    "Latest date": "2021-07-01",
+    "Description": "South African lineage"
+  },
+  {
+    "Lineage": "B.1.418",
+    "Earliest date": "2020-04-24",
+    "Latest date": "2020-06-25",
+    "Description": "Scottish lineage"
+  },
+  {
+    "Lineage": "B.1.420",
+    "Earliest date": "2020-03-16",
+    "Latest date": "2021-05-10",
+    "Description": "Colombian lineage"
+  },
+  {
+    "Lineage": "B.1.421",
+    "Earliest date": "2020-07-28",
+    "Latest date": "2021-02-02",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.1.422",
+    "Earliest date": "2020-03-13",
+    "Latest date": "2020-11-24",
+    "Description": "Canada mostly"
+  },
+  {
+    "Lineage": "B.1.423",
+    "Earliest date": "2020-07-01",
+    "Latest date": "2021-03-31",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.1.424",
+    "Earliest date": "2020-03-16",
+    "Latest date": "2020-10-09",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.1.425",
+    "Earliest date": "2020-05-07",
+    "Latest date": "2022-04-20",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.1.426",
+    "Earliest date": "2020-03-08",
+    "Latest date": "2021-04-03",
+    "Description": "USA (UT) lineage"
+  },
+  {
+    "Lineage": "B.1.427",
+    "Earliest date": "2020-04-11",
+    "Latest date": "2024-01-30",
+    "Description": "USA lineage (CA)"
+  },
+  {
+    "Lineage": "B.1.428",
+    "Earliest date": "2020-03-03",
+    "Latest date": "2021-06-12",
+    "Description": "Danish lineage (amalgam of Danish sequences from B.1.358, B.1.288, B.1.262)"
+  },
+  {
+    "Lineage": "B.1.428.1",
+    "Earliest date": "2020-06-06",
+    "Latest date": "2020-10-01",
+    "Description": "Iraq"
+  },
+  {
+    "Lineage": "B.1.428.2",
+    "Earliest date": "2020-04-07",
+    "Latest date": "2021-12-30",
+    "Description": "Tunisia, England, France"
+  },
+  {
+    "Lineage": "B.1.428.3",
+    "Earliest date": "2020-06-03",
+    "Latest date": "2021-02-22",
+    "Description": "UAE, Jordan"
+  },
+  {
+    "Lineage": "B.1.429",
+    "Earliest date": "2020-01-26",
+    "Latest date": "2022-06-03",
+    "Description": "A lineage predominantly circulating in California but with exports to other countries. Characterised by the spike L452R mutation but also has spike:W152C orf1ab:D5584Y, and N:T205I, from #3"
+  },
+  {
+    "Lineage": "B.1.429.1",
+    "Earliest date": "2020-11-28",
+    "Latest date": "2021-03-12",
+    "Description": "Colorado lineage, from #37"
+  },
+  {
+    "Lineage": "B.1.431",
+    "Earliest date": "2020-03-30",
+    "Latest date": "2020-05-15",
+    "Description": "Scotland"
+  },
+  {
+    "Lineage": "B.1.432",
+    "Earliest date": "2020-05-01",
+    "Latest date": "2020-08-29",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.1.433",
+    "Earliest date": "2020-09-10",
+    "Latest date": "2021-08-12",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.1.434",
+    "Earliest date": "2020-03-22",
+    "Latest date": "2020-05-01",
+    "Description": "Australian lineage (previously a couple part of B.1.25, B.1.295)"
+  },
+  {
+    "Lineage": "B.1.435",
+    "Earliest date": "2020-04-10",
+    "Latest date": "2020-07-28",
+    "Description": "USA - UT"
+  },
+  {
+    "Lineage": "B.1.436",
+    "Earliest date": "2020-07-08",
+    "Latest date": "2021-05-28",
+    "Description": "USA lineage reassigned from previous tree"
+  },
+  {
+    "Lineage": "B.1.437",
+    "Earliest date": "2020-06-03",
+    "Latest date": "2020-09-15",
+    "Description": "USA - FL"
+  },
+  {
+    "Lineage": "B.1.438",
+    "Earliest date": "2020-01-10",
+    "Latest date": "2021-08-07",
+    "Description": "Lineage circulating in multiple countries, from #48"
+  },
+  {
+    "Lineage": "B.1.438.1",
+    "Earliest date": "2020-09-24",
+    "Latest date": "2021-12-07",
+    "Description": "Canada lineage"
+  },
+  {
+    "Lineage": "B.1.438.2",
+    "Earliest date": "2021-01-06",
+    "Latest date": "2021-02-12",
+    "Description": "Mayotte and Reunion lineage"
+  },
+  {
+    "Lineage": "B.1.438.3",
+    "Earliest date": "2020-12-09",
+    "Latest date": "2021-03-22",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.1.438.4",
+    "Earliest date": "2020-10-19",
+    "Latest date": "2021-03-23",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.1.439",
+    "Earliest date": "2020-03-13",
+    "Latest date": "2020-09-23",
+    "Description": "USA"
+  },
+  {
+    "Lineage": "B.1.441",
+    "Earliest date": "2020-03-13",
+    "Latest date": "2021-06-14",
+    "Description": "Global lineage (inc. merge of B.1.274)"
+  },
+  {
+    "Lineage": "B.1.442",
+    "Earliest date": "2020-03-12",
+    "Latest date": "2020-07-13",
+    "Description": "USA"
+  },
+  {
+    "Lineage": "B.1.443",
+    "Earliest date": "2020-01-17",
+    "Latest date": "2021-04-16",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.1.444",
+    "Earliest date": "2020-05-21",
+    "Latest date": "2020-10-21",
+    "Description": "USA Utah lineage"
+  },
+  {
+    "Lineage": "B.1.445",
+    "Earliest date": "2020-04-05",
+    "Latest date": "2021-01-14",
+    "Description": "USA (AZ)"
+  },
+  {
+    "Lineage": "B.1.446",
+    "Earliest date": "2020-03-13",
+    "Latest date": "2020-07-02",
+    "Description": "USA, some B.1.333"
+  },
+  {
+    "Lineage": "B.1.448",
+    "Earliest date": "2020-04-15",
+    "Latest date": "2021-04-03",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.1.450",
+    "Earliest date": "2020-03-14",
+    "Latest date": "2020-09-29",
+    "Description": "USA (TX)"
+  },
+  {
+    "Lineage": "B.1.451",
+    "Earliest date": "2020-04-09",
+    "Latest date": "2020-11-11",
+    "Description": "USA lineage (VA), previously B.1.328 and B.1.317"
+  },
+  {
+    "Lineage": "B.1.452",
+    "Earliest date": "2020-05-12",
+    "Latest date": "2021-01-06",
+    "Description": "USA (CA)"
+  },
+  {
+    "Lineage": "B.1.453",
+    "Earliest date": "2020-03-17",
+    "Latest date": "2021-02-12",
+    "Description": "USA (CA and TX)"
+  },
+  {
+    "Lineage": "B.1.456",
+    "Earliest date": "2020-02-20",
+    "Latest date": "2022-04-04",
+    "Description": "SE Asian (reassigned)"
+  },
+  {
+    "Lineage": "B.1.458",
+    "Earliest date": "2020-05-25",
+    "Latest date": "2020-05-25",
+    "Description": "India"
+  },
+  {
+    "Lineage": "B.1.459",
+    "Earliest date": "2020-03-18",
+    "Latest date": "2021-07-23",
+    "Description": "Indonesia"
+  },
+  {
+    "Lineage": "B.1.460",
+    "Earliest date": "2020-09-10",
+    "Latest date": "2021-01-26",
+    "Description": "UK lineage"
+  },
+  {
+    "Lineage": "B.1.462",
+    "Earliest date": "2020-04-20",
+    "Latest date": "2021-04-03",
+    "Description": "UK/Nigeria"
+  },
+  {
+    "Lineage": "B.1.463",
+    "Earliest date": "2020-09-10",
+    "Latest date": "2020-10-31",
+    "Description": "Finland"
+  },
+  {
+    "Lineage": "B.1.465",
+    "Earliest date": "2020-03-10",
+    "Latest date": "2021-01-10",
+    "Description": "UK, contains B.1.466 which is reassigned (see below)"
+  },
+  {
+    "Lineage": "B.1.466",
+    "Earliest date": "2020-04-30",
+    "Latest date": "2022-04-16",
+    "Description": "Global lineage containing two new sublineages (see below)"
+  },
+  {
+    "Lineage": "B.1.466.1",
+    "Earliest date": "2020-06-09",
+    "Latest date": "2021-04-03",
+    "Description": "USA/UAE"
+  },
+  {
+    "Lineage": "B.1.466.2",
+    "Earliest date": "2020-08-06",
+    "Latest date": "2023-05-24",
+    "Description": "Indonesia, from #30"
+  },
+  {
+    "Lineage": "AU.1",
+    "Earliest date": "2021-01-01",
+    "Latest date": "2021-06-22",
+    "Description": "Alias of B.1.466.2.1, predominantly Papua New Guinea with some Australia sequences"
+  },
+  {
+    "Lineage": "AU.2",
+    "Earliest date": "2021-01-03",
+    "Latest date": "2021-09-06",
+    "Description": "Alias of B.1.466.2.2, Malaysia lineage"
+  },
+  {
+    "Lineage": "AU.3",
+    "Earliest date": "2021-02-09",
+    "Latest date": "2021-07-19",
+    "Description": "Alias of B.1.466.2.3, predominantly Australia with some Papua New Guinea and Singapore sequences"
+  },
+  {
+    "Lineage": "B.1.467",
+    "Earliest date": "2020-05-17",
+    "Latest date": "2020-12-30",
+    "Description": "Nigeria/Switzerland"
+  },
+  {
+    "Lineage": "B.1.468",
+    "Earliest date": "2020-02-13",
+    "Latest date": "2021-04-27",
+    "Description": "Indonesia/Singapore. Seq names misassigned in original file"
+  },
+  {
+    "Lineage": "B.1.469",
+    "Earliest date": "2020-08-21",
+    "Latest date": "2021-10-08",
+    "Description": "European (Turkey, Denmark, UK)"
+  },
+  {
+    "Lineage": "B.1.470",
+    "Earliest date": "2020-04-09",
+    "Latest date": "2021-07-24",
+    "Description": "Indonesia/Singapore"
+  },
+  {
+    "Lineage": "B.1.471",
+    "Earliest date": "2020-03-25",
+    "Latest date": "2021-04-02",
+    "Description": "UK with global representation"
+  },
+  {
+    "Lineage": "B.1.473",
+    "Earliest date": "2020-04-01",
+    "Latest date": "2020-10-01",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.1.474",
+    "Earliest date": "2020-09-21",
+    "Latest date": "2021-05-19",
+    "Description": "Denmark/ Luxembourg lineage"
+  },
+  {
+    "Lineage": "B.1.475",
+    "Earliest date": "2020-04-05",
+    "Latest date": "2020-07-01",
+    "Description": "German lineage"
+  },
+  {
+    "Lineage": "B.1.476",
+    "Earliest date": "2020-03-29",
+    "Latest date": "2020-09-22",
+    "Description": "West African lineage"
+  },
+  {
+    "Lineage": "B.1.478",
+    "Earliest date": "2020-05-15",
+    "Latest date": "2021-03-05",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.1.479",
+    "Earliest date": "2020-03-25",
+    "Latest date": "2020-10-24",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.1.480",
+    "Earliest date": "2020-07-03",
+    "Latest date": "2021-07-21",
+    "Description": "England, Australia, Sweden, Norway"
+  },
+  {
+    "Lineage": "B.1.482",
+    "Earliest date": "2020-03-17",
+    "Latest date": "2020-07-21",
+    "Description": "France/ West African lineage"
+  },
+  {
+    "Lineage": "B.1.483",
+    "Earliest date": "2020-03-15",
+    "Latest date": "2020-05-21",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.1.485",
+    "Earliest date": "2020-03-25",
+    "Latest date": "2020-05-22",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.1.486",
+    "Earliest date": "2020-04-28",
+    "Latest date": "2020-09-09",
+    "Description": "USA (MA)"
+  },
+  {
+    "Lineage": "B.1.487",
+    "Earliest date": "2020-05-24",
+    "Latest date": "2020-08-01",
+    "Description": "USA - TX"
+  },
+  {
+    "Lineage": "B.1.488",
+    "Earliest date": "2020-07-13",
+    "Latest date": "2020-08-06",
+    "Description": "Denmark and Sweden"
+  },
+  {
+    "Lineage": "B.1.489",
+    "Earliest date": "2020-03-26",
+    "Latest date": "2021-03-30",
+    "Description": "Wales and Norway"
+  },
+  {
+    "Lineage": "B.1.490",
+    "Earliest date": "2020-04-20",
+    "Latest date": "2020-05-03",
+    "Description": "Finland."
+  },
+  {
+    "Lineage": "B.1.491",
+    "Earliest date": "2020-03-14",
+    "Latest date": "2020-05-21",
+    "Description": "England"
+  },
+  {
+    "Lineage": "B.1.492",
+    "Earliest date": "2020-02-02",
+    "Latest date": "2020-10-19",
+    "Description": "USA - Colorado"
+  },
+  {
+    "Lineage": "B.1.493",
+    "Earliest date": "2020-04-07",
+    "Latest date": "2021-04-05",
+    "Description": "USA (FL)"
+  },
+  {
+    "Lineage": "B.1.494",
+    "Earliest date": "2020-03-12",
+    "Latest date": "2020-09-22",
+    "Description": "USA (Split from B.1.3)"
+  },
+  {
+    "Lineage": "B.1.495",
+    "Earliest date": "2020-04-19",
+    "Latest date": "2021-07-20",
+    "Description": "USA (Split from B.1.3)"
+  },
+  {
+    "Lineage": "B.1.496",
+    "Earliest date": "2020-03-15",
+    "Latest date": "2020-07-06",
+    "Description": "USA (could be dissolved - sequences jumped out, previously split from B.1.3)"
+  },
+  {
+    "Lineage": "B.1.497",
+    "Earliest date": "2020-05-05",
+    "Latest date": "2021-06-04",
+    "Description": "South Korea (was B.1.3.1)"
+  },
+  {
+    "Lineage": "B.1.498",
+    "Earliest date": "2020-04-27",
+    "Latest date": "2020-11-18",
+    "Description": "USA (Split from B.1.3)"
+  },
+  {
+    "Lineage": "B.1.499",
+    "Earliest date": "2020-01-01",
+    "Latest date": "2021-12-14",
+    "Description": "Mostly Argentina, some Spain, NL, Hong Kong (was B.1.3.2)"
+  },
+  {
+    "Lineage": "B.1.499.1",
+    "Earliest date": "2020-11-30",
+    "Latest date": "2021-03-26",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.1.500",
+    "Earliest date": "2020-08-10",
+    "Latest date": "2020-09-20",
+    "Description": "USA (split from B.1.3)"
+  },
+  {
+    "Lineage": "B.1.501",
+    "Earliest date": "2020-04-27",
+    "Latest date": "2020-10-02",
+    "Description": "USA (Split from B.1.3)"
+  },
+  {
+    "Lineage": "B.1.502",
+    "Earliest date": "2020-06-07",
+    "Latest date": "2020-09-01",
+    "Description": "USA (Split from B.1.3)"
+  },
+  {
+    "Lineage": "B.1.503",
+    "Earliest date": "2020-04-01",
+    "Latest date": "2022-11-14",
+    "Description": "USA (Split from B.1.3)"
+  },
+  {
+    "Lineage": "B.1.504",
+    "Earliest date": "2020-04-19",
+    "Latest date": "2021-01-11",
+    "Description": "Israel and England (was B.1.3.3)"
+  },
+  {
+    "Lineage": "B.1.505",
+    "Earliest date": "2020-03-15",
+    "Latest date": "2021-02-09",
+    "Description": "Israel and england (was B.1.3.4)"
+  },
+  {
+    "Lineage": "B.1.506",
+    "Earliest date": "2020-04-20",
+    "Latest date": "2020-08-13",
+    "Description": "USA (NY, split from B.1.3)"
+  },
+  {
+    "Lineage": "B.1.507",
+    "Earliest date": "2020-03-15",
+    "Latest date": "2020-11-11",
+    "Description": "USA (MI, NY, split from B.1.3)"
+  },
+  {
+    "Lineage": "B.1.508",
+    "Earliest date": "2020-04-28",
+    "Latest date": "2020-08-12",
+    "Description": "USA (NY, AZ, split from B.1.3)"
+  },
+  {
+    "Lineage": "B.1.509",
+    "Earliest date": "2020-04-18",
+    "Latest date": "2021-11-05",
+    "Description": "USA (split from B.1.3, mostly FL)"
+  },
+  {
+    "Lineage": "B.1.510",
+    "Earliest date": "2020-03-06",
+    "Latest date": "2020-03-18",
+    "Description": "Iceland, Sweden, North America (could be dissolved)"
+  },
+  {
+    "Lineage": "B.1.511",
+    "Earliest date": "2020-05-02",
+    "Latest date": "2020-09-23",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.1.513",
+    "Earliest date": "2020-03-09",
+    "Latest date": "2020-06-02",
+    "Description": "Northern Europe"
+  },
+  {
+    "Lineage": "B.1.515",
+    "Earliest date": "2020-04-17",
+    "Latest date": "2020-05-29",
+    "Description": "USA (Utah)"
+  },
+  {
+    "Lineage": "B.1.516",
+    "Earliest date": "2020-03-11",
+    "Latest date": "2021-04-16",
+    "Description": "USA (AZ and NM)"
+  },
+  {
+    "Lineage": "B.1.517",
+    "Earliest date": "2020-04-26",
+    "Latest date": "2022-03-07",
+    "Description": "USA (mostly AZ)"
+  },
+  {
+    "Lineage": "B.1.517.1",
+    "Earliest date": "2020-12-02",
+    "Latest date": "2021-01-10",
+    "Description": "Australia"
+  },
+  {
+    "Lineage": "B.1.518",
+    "Earliest date": "2020-03-21",
+    "Latest date": "2022-04-19",
+    "Description": "USA"
+  },
+  {
+    "Lineage": "B.1.520",
+    "Earliest date": "2020-03-25",
+    "Latest date": "2021-08-02",
+    "Description": "USA, Canada, England, Germany etc. (could be dissolved / reassigned to B.1)"
+  },
+  {
+    "Lineage": "B.1.521",
+    "Earliest date": "2020-03-21",
+    "Latest date": "2021-01-20",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.1.523",
+    "Earliest date": "2020-03-29",
+    "Latest date": "2021-03-10",
+    "Description": "UK/Australia"
+  },
+  {
+    "Lineage": "B.1.524",
+    "Earliest date": "2020-07-31",
+    "Latest date": "2021-07-31",
+    "Description": "Malaysian lineage"
+  },
+  {
+    "Lineage": "B.1.525",
+    "Earliest date": "2020-03-25",
+    "Latest date": "2022-12-17",
+    "Description": "International lineage with E484K, del69-70 among other defining mutations, from #4"
+  },
+  {
+    "Lineage": "B.1.526",
+    "Earliest date": "2020-01-28",
+    "Latest date": "2022-05-19",
+    "Description": "A lineage predominantly circulating in New York but with a few exports to other countries. Characterised by spike mutations T95I and D253G, plus others. The most frequent spike mutation pattern is L5F T95I D253G E484K D614G A701V, with a smaller fraction having S477N instead of E484K. Spike mutation E484K is present in about half of this lineage (as of 2021-02-10) - Very possible not all new additions carry T95I and D253G (someone should check this, e.g. for USA/NY-Wadsworth-21008455-01/2021 and Aruba/AW-RIVM-11403/2021), from #6"
+  },
+  {
+    "Lineage": "B.1.527",
+    "Earliest date": "2020-03-24",
+    "Latest date": "2021-01-29",
+    "Description": "Czech Republic/ Ukraine lineage"
+  },
+  {
+    "Lineage": "B.1.528",
+    "Earliest date": "2020-04-23",
+    "Latest date": "2020-11-19",
+    "Description": "Moroccan lineage"
+  },
+  {
+    "Lineage": "B.1.529",
+    "Earliest date": "2020-04-02",
+    "Latest date": "2020-06-05",
+    "Description": "French lineage"
+  },
+  {
+    "Lineage": "B.1.530",
+    "Earliest date": "2020-07-17",
+    "Latest date": "2021-05-02",
+    "Description": "Kenya"
+  },
+  {
+    "Lineage": "B.1.531",
+    "Earliest date": "2020-11-18",
+    "Latest date": "2021-01-24",
+    "Description": "England"
+  },
+  {
+    "Lineage": "B.1.532",
+    "Earliest date": "2020-07-04",
+    "Latest date": "2020-12-16",
+    "Description": "England"
+  },
+  {
+    "Lineage": "B.1.533",
+    "Earliest date": "2020-03-24",
+    "Latest date": "2021-09-04",
+    "Description": "Saudi Arabia"
+  },
+  {
+    "Lineage": "B.1.534",
+    "Earliest date": "2020-11-02",
+    "Latest date": "2021-01-25",
+    "Description": "Denmark"
+  },
+  {
+    "Lineage": "B.1.535",
+    "Earliest date": "2020-03-25",
+    "Latest date": "2020-04-28",
+    "Description": "Australia"
+  },
+  {
+    "Lineage": "B.1.536",
+    "Earliest date": "2020-10-26",
+    "Latest date": "2021-02-22",
+    "Description": "Denmark"
+  },
+  {
+    "Lineage": "B.1.537",
+    "Earliest date": "2020-05-24",
+    "Latest date": "2020-12-19",
+    "Description": "India"
+  },
+  {
+    "Lineage": "B.1.538",
+    "Earliest date": "2020-05-16",
+    "Latest date": "2021-01-29",
+    "Description": "India"
+  },
+  {
+    "Lineage": "B.1.539",
+    "Earliest date": "2020-10-23",
+    "Latest date": "2021-03-12",
+    "Description": "USA"
+  },
+  {
+    "Lineage": "B.1.540",
+    "Earliest date": "2020-03-27",
+    "Latest date": "2021-03-15",
+    "Description": "India"
+  },
+  {
+    "Lineage": "B.1.541",
+    "Earliest date": "2020-07-01",
+    "Latest date": "2021-03-14",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.1.542",
+    "Earliest date": "2020-03-24",
+    "Latest date": "2020-05-05",
+    "Description": "Spain"
+  },
+  {
+    "Lineage": "B.1.543",
+    "Earliest date": "2020-08-30",
+    "Latest date": "2021-03-10",
+    "Description": "USA"
+  },
+  {
+    "Lineage": "B.1.544",
+    "Earliest date": "2020-06-25",
+    "Latest date": "2021-03-20",
+    "Description": "Congo/ Cameroon/ USA lineage"
+  },
+  {
+    "Lineage": "B.1.545",
+    "Earliest date": "2020-03-25",
+    "Latest date": "2021-04-28",
+    "Description": "New Zealand"
+  },
+  {
+    "Lineage": "B.1.546",
+    "Earliest date": "2020-05-23",
+    "Latest date": "2021-03-10",
+    "Description": "USA"
+  },
+  {
+    "Lineage": "B.1.547",
+    "Earliest date": "2020-03-13",
+    "Latest date": "2021-01-12",
+    "Description": "Canada"
+  },
+  {
+    "Lineage": "B.1.548",
+    "Earliest date": "2020-05-12",
+    "Latest date": "2021-04-05",
+    "Description": "India"
+  },
+  {
+    "Lineage": "B.1.549",
+    "Earliest date": "2020-07-17",
+    "Latest date": "2021-01-29",
+    "Description": "Kenya + England"
+  },
+  {
+    "Lineage": "B.1.550",
+    "Earliest date": "2020-10-03",
+    "Latest date": "2021-03-19",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.1.551",
+    "Earliest date": "2020-08-20",
+    "Latest date": "2021-09-14",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.1.552",
+    "Earliest date": "2020-03-30",
+    "Latest date": "2020-04-23",
+    "Description": "North American"
+  },
+  {
+    "Lineage": "B.1.554",
+    "Earliest date": "2020-05-02",
+    "Latest date": "2020-09-09",
+    "Description": "USA (UT) lineage"
+  },
+  {
+    "Lineage": "B.1.555",
+    "Earliest date": "2020-03-11",
+    "Latest date": "2020-05-25",
+    "Description": "Sweden"
+  },
+  {
+    "Lineage": "B.1.556",
+    "Earliest date": "2020-06-10",
+    "Latest date": "2021-05-19",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.1.557",
+    "Earliest date": "2020-04-06",
+    "Latest date": "2020-05-18",
+    "Description": "Northern Ireland"
+  },
+  {
+    "Lineage": "B.1.558",
+    "Earliest date": "2020-04-06",
+    "Latest date": "2022-05-31",
+    "Description": "USA/ Mexico lineage"
+  },
+  {
+    "Lineage": "B.1.559",
+    "Earliest date": "2020-03-29",
+    "Latest date": "2020-04-22",
+    "Description": "Scotland"
+  },
+  {
+    "Lineage": "B.1.560",
+    "Earliest date": "2020-04-08",
+    "Latest date": "2021-09-13",
+    "Description": "India"
+  },
+  {
+    "Lineage": "B.1.561",
+    "Earliest date": "2020-06-18",
+    "Latest date": "2021-08-21",
+    "Description": "USA - contains previous B.1.404"
+  },
+  {
+    "Lineage": "B.1.562",
+    "Earliest date": "2020-12-01",
+    "Latest date": "2021-03-02",
+    "Description": "England base, to Ireland"
+  },
+  {
+    "Lineage": "B.1.563",
+    "Earliest date": "2020-12-06",
+    "Latest date": "2021-03-25",
+    "Description": "UK lineage"
+  },
+  {
+    "Lineage": "B.1.564",
+    "Earliest date": "2020-03-24",
+    "Latest date": "2021-02-18",
+    "Description": "USA lineage, split out from B.1.369"
+  },
+  {
+    "Lineage": "B.1.564.1",
+    "Earliest date": "2020-08-23",
+    "Latest date": "2021-04-30",
+    "Description": "Canada lineage"
+  },
+  {
+    "Lineage": "B.1.565",
+    "Earliest date": "2020-06-09",
+    "Latest date": "2021-05-11",
+    "Description": "USA - contains previous B.1.139"
+  },
+  {
+    "Lineage": "B.1.566",
+    "Earliest date": "2020-03-16",
+    "Latest date": "2020-11-16",
+    "Description": "USA - Arizona and Texas"
+  },
+  {
+    "Lineage": "B.1.567",
+    "Earliest date": "2020-03-23",
+    "Latest date": "2022-02-12",
+    "Description": "USA lineage, formally part of B.1.2"
+  },
+  {
+    "Lineage": "B.1.568",
+    "Earliest date": "2020-09-10",
+    "Latest date": "2021-06-09",
+    "Description": "USA lineage, split out from B.1.361"
+  },
+  {
+    "Lineage": "B.1.569",
+    "Earliest date": "2020-09-10",
+    "Latest date": "2021-01-15",
+    "Description": "USA (CA and TX)"
+  },
+  {
+    "Lineage": "B.1.570",
+    "Earliest date": "2020-05-26",
+    "Latest date": "2021-01-12",
+    "Description": "USA (CO)"
+  },
+  {
+    "Lineage": "B.1.571",
+    "Earliest date": "2020-06-01",
+    "Latest date": "2021-01-24",
+    "Description": "USA lineage, split out from B.1.369"
+  },
+  {
+    "Lineage": "B.1.572",
+    "Earliest date": "2020-03-21",
+    "Latest date": "2021-02-19",
+    "Description": "USA, split from B.1.325"
+  },
+  {
+    "Lineage": "B.1.573",
+    "Earliest date": "2020-06-24",
+    "Latest date": "2020-10-03",
+    "Description": "Canada (BC)"
+  },
+  {
+    "Lineage": "B.1.574",
+    "Earliest date": "2020-06-09",
+    "Latest date": "2021-01-02",
+    "Description": "USA lineage, split out from B.1.363"
+  },
+  {
+    "Lineage": "B.1.575",
+    "Earliest date": "2020-10-23",
+    "Latest date": "2021-10-11",
+    "Description": "USA and Aruba lineage with spike mutations \"S:P681H\",\"S:S494P\" and \"S:T716I\""
+  },
+  {
+    "Lineage": "B.1.575.1",
+    "Earliest date": "2020-11-30",
+    "Latest date": "2022-03-24",
+    "Description": "Spanish sub lineage of B.1.575 with spike mutations \"S:P681H\",\"S:S494P\" and \"S:T716I\", from #64"
+  },
+  {
+    "Lineage": "B.1.575.2",
+    "Earliest date": "2021-05-19",
+    "Latest date": "2021-07-02",
+    "Description": "Spain lineage, from #116"
+  },
+  {
+    "Lineage": "B.1.576",
+    "Earliest date": "2020-03-29",
+    "Latest date": "2021-02-10",
+    "Description": "USA lineage, formally part of B.1.363"
+  },
+  {
+    "Lineage": "B.1.577",
+    "Earliest date": "2020-03-20",
+    "Latest date": "2022-03-24",
+    "Description": "USA lineage, formally part of B.1.2"
+  },
+  {
+    "Lineage": "B.1.578",
+    "Earliest date": "2020-03-17",
+    "Latest date": "2021-03-04",
+    "Description": "USA, formally part of B.1.313"
+  },
+  {
+    "Lineage": "B.1.579",
+    "Earliest date": "2020-04-13",
+    "Latest date": "2020-07-05",
+    "Description": "USA (AZ) formally part of B.1.516"
+  },
+  {
+    "Lineage": "B.1.580",
+    "Earliest date": "2020-07-20",
+    "Latest date": "2021-05-06",
+    "Description": "USA Southern (some B.1.361)"
+  },
+  {
+    "Lineage": "B.1.581",
+    "Earliest date": "2020-06-18",
+    "Latest date": "2021-03-01",
+    "Description": "USA (TX)"
+  },
+  {
+    "Lineage": "B.1.582",
+    "Earliest date": "2020-05-27",
+    "Latest date": "2021-08-21",
+    "Description": "USA (TX some B.1.361)"
+  },
+  {
+    "Lineage": "B.1.585",
+    "Earliest date": "2020-10-13",
+    "Latest date": "2021-03-17",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.1.586",
+    "Earliest date": "2020-03-12",
+    "Latest date": "2020-10-26",
+    "Description": "USA lineage (previously part of B.1.320 that jumped to a new part of the tree)"
+  },
+  {
+    "Lineage": "B.1.587",
+    "Earliest date": "2020-04-23",
+    "Latest date": "2021-07-20",
+    "Description": "USA (OR) lineage"
+  },
+  {
+    "Lineage": "B.1.588",
+    "Earliest date": "2020-08-02",
+    "Latest date": "2023-03-22",
+    "Description": "USA (NY/PR) lineage"
+  },
+  {
+    "Lineage": "B.1.588.1",
+    "Earliest date": "2020-11-28",
+    "Latest date": "2020-11-28",
+    "Description": "Romanian lineage"
+  },
+  {
+    "Lineage": "B.1.589",
+    "Earliest date": "2020-03-15",
+    "Latest date": "2021-02-27",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.1.590",
+    "Earliest date": "2020-03-15",
+    "Latest date": "2020-11-20",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.1.591",
+    "Earliest date": "2020-07-26",
+    "Latest date": "2021-02-23",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.1.592",
+    "Earliest date": "2020-03-30",
+    "Latest date": "2020-05-07",
+    "Description": "Canadian lineage"
+  },
+  {
+    "Lineage": "B.1.593",
+    "Earliest date": "2020-09-11",
+    "Latest date": "2020-10-29",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.1.594",
+    "Earliest date": "2020-03-27",
+    "Latest date": "2020-06-23",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.1.595",
+    "Earliest date": "2020-03-09",
+    "Latest date": "2023-01-11",
+    "Description": "USA (was B.1.2)"
+  },
+  {
+    "Lineage": "B.1.595.1",
+    "Earliest date": "2020-05-16",
+    "Latest date": "2021-01-18",
+    "Description": "USA (FL into Louisiana)"
+  },
+  {
+    "Lineage": "B.1.595.2",
+    "Earliest date": "2020-06-14",
+    "Latest date": "2020-11-05",
+    "Description": "USA (AZ)"
+  },
+  {
+    "Lineage": "B.1.595.3",
+    "Earliest date": "2020-06-27",
+    "Latest date": "2021-01-07",
+    "Description": "USA (up the east coast)"
+  },
+  {
+    "Lineage": "B.1.595.4",
+    "Earliest date": "2020-04-18",
+    "Latest date": "2020-11-06",
+    "Description": "USA (MN)"
+  },
+  {
+    "Lineage": "B.1.596",
+    "Earliest date": "2020-04-11",
+    "Latest date": "2021-09-22",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.1.596.1",
+    "Earliest date": "2020-10-02",
+    "Latest date": "2021-02-22",
+    "Description": "Kenyan lineage"
+  },
+  {
+    "Lineage": "B.1.597",
+    "Earliest date": "2020-03-19",
+    "Latest date": "2021-10-06",
+    "Description": "France, Algeria (previously part of B.1.367 that jumped to a new part of the tree)"
+  },
+  {
+    "Lineage": "B.1.598",
+    "Earliest date": "2020-03-30",
+    "Latest date": "2020-06-05",
+    "Description": "Canada (from NY)"
+  },
+  {
+    "Lineage": "B.1.599",
+    "Earliest date": "2020-05-20",
+    "Latest date": "2021-06-30",
+    "Description": "USA, Canada (previously part of B.1.311 that jumped to a new part of the tree)"
+  },
+  {
+    "Lineage": "B.1.600",
+    "Earliest date": "2020-04-07",
+    "Latest date": "2021-04-21",
+    "Description": "Bolivia/ Spain lineage"
+  },
+  {
+    "Lineage": "B.1.601",
+    "Earliest date": "2020-11-04",
+    "Latest date": "2021-02-16",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.1.602",
+    "Earliest date": "2020-07-07",
+    "Latest date": "2021-02-12",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.1.603",
+    "Earliest date": "2020-11-10",
+    "Latest date": "2021-04-17",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.1.604",
+    "Earliest date": "2020-07-28",
+    "Latest date": "2021-04-22",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.1.605",
+    "Earliest date": "2020-05-12",
+    "Latest date": "2021-05-08",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.1.606",
+    "Earliest date": "2020-05-21",
+    "Latest date": "2020-11-13",
+    "Description": "USA lineage (previously part of B.1.325 that jumped to a new part of the tree)"
+  },
+  {
+    "Lineage": "B.1.607",
+    "Earliest date": "2020-03-29",
+    "Latest date": "2020-12-07",
+    "Description": "England (previously part of B.1.369 that jumped to a new part of the tree - could also be withdrawn)."
+  },
+  {
+    "Lineage": "B.1.609",
+    "Earliest date": "2020-03-10",
+    "Latest date": "2021-11-21",
+    "Description": "USA/ Mexico lineage"
+  },
+  {
+    "Lineage": "B.1.610",
+    "Earliest date": "2020-06-11",
+    "Latest date": "2021-01-19",
+    "Description": "UK lineage, previously part of B.1.235"
+  },
+  {
+    "Lineage": "B.1.611",
+    "Earliest date": "2020-06-09",
+    "Latest date": "2020-09-08",
+    "Description": "Canada lineage"
+  },
+  {
+    "Lineage": "B.1.612",
+    "Earliest date": "2020-03-11",
+    "Latest date": "2021-03-01",
+    "Description": "USA lineage, split out from B.1.361"
+  },
+  {
+    "Lineage": "B.1.613",
+    "Earliest date": "2020-04-06",
+    "Latest date": "2020-06-01",
+    "Description": "Danish lineage (amalgam of Danish sequences from B.1.358, B.1.288, B.1.262), split out from B.1.428"
+  },
+  {
+    "Lineage": "B.1.614",
+    "Earliest date": "2020-06-15",
+    "Latest date": "2020-07-12",
+    "Description": "Sweden"
+  },
+  {
+    "Lineage": "B.1.615",
+    "Earliest date": "2020-07-26",
+    "Latest date": "2020-08-21",
+    "Description": "Canada"
+  },
+  {
+    "Lineage": "B.1.616",
+    "Earliest date": "2021-01-29",
+    "Latest date": "2021-04-23",
+    "Description": "France lineage, from #31"
+  },
+  {
+    "Lineage": "B.1.617",
+    "Earliest date": "2020-03-06",
+    "Latest date": "2022-03-30",
+    "Description": "Predominantly India lineage with several spike mutations, from #38"
+  },
+  {
+    "Lineage": "B.1.617.1",
+    "Earliest date": "2020-03-03",
+    "Latest date": "2022-05-06",
+    "Description": "Predominantly India lineage with 484Q, from #49"
+  },
+  {
+    "Lineage": "B.1.617.2",
+    "Earliest date": "2020-03-27",
+    "Latest date": "2023-10-09",
+    "Description": "Predominantly India lineage with several spike mutations, from #49"
+  },
+  {
+    "Lineage": "AY.1",
+    "Earliest date": "2021-03-31",
+    "Latest date": "2023-04-22",
+    "Description": "Alias of B.1.617.2.1, in several European countries, from #95"
+  },
+  {
+    "Lineage": "AY.2",
+    "Earliest date": "2021-03-31",
+    "Latest date": "2021-12-18",
+    "Description": "Alias of B.1.617.2.2, in USA with K417N, from #107"
+  },
+  {
+    "Lineage": "AY.3",
+    "Earliest date": "2020-06-27",
+    "Latest date": "2022-09-27",
+    "Description": "Alias of B.1.617.2.3, USA lineage, from #121"
+  },
+  {
+    "Lineage": "AY.3.1",
+    "Earliest date": "2020-11-20",
+    "Latest date": "2022-01-30",
+    "Description": "Alias of B.1.617.2.3.1, USA lineage, from #147"
+  },
+  {
+    "Lineage": "AY.3.2",
+    "Earliest date": "2021-08-04",
+    "Latest date": "2022-01-06",
+    "Description": "Alias of B.1.617.2.3.2, Peru lineage, from #312"
+  },
+  {
+    "Lineage": "AY.3.3",
+    "Earliest date": "2021-09-01",
+    "Latest date": "2022-02-07",
+    "Description": "Alias of B.1.617.2.3.3, USA lineage, from #365"
+  },
+  {
+    "Lineage": "AY.3.4",
+    "Earliest date": "2021-11-06",
+    "Latest date": "2021-12-31",
+    "Description": "Alias of B.1.617.2.3.4, Bahrain lineage"
+  },
+  {
+    "Lineage": "AY.4",
+    "Earliest date": "2020-05-11",
+    "Latest date": "2023-02-22",
+    "Description": "Alias of B.1.617.2.4, UK lineage, from #180"
+  },
+  {
+    "Lineage": "AY.4.1",
+    "Earliest date": "2021-06-21",
+    "Latest date": "2021-12-06",
+    "Description": "Alias of B.1.617.2.4.1, UK lineage, from #214"
+  },
+  {
+    "Lineage": "AY.4.2",
+    "Earliest date": "2021-01-01",
+    "Latest date": "2022-08-15",
+    "Description": "Alias of B.1.617.2.4.2, predominantly UK lineage, from #223"
+  },
+  {
+    "Lineage": "AY.4.2.1",
+    "Earliest date": "2020-12-21",
+    "Latest date": "2022-03-09",
+    "Description": "Alias of B.1.617.2.4.2.1, predominantly UK lineage, from #248"
+  },
+  {
+    "Lineage": "AY.4.2.2",
+    "Earliest date": "2021-04-12",
+    "Latest date": "2022-03-13",
+    "Description": "Alias of B.1.617.2.4.2.2, UK lineage, from #249"
+  },
+  {
+    "Lineage": "AY.4.2.3",
+    "Earliest date": "2021-04-30",
+    "Latest date": "2022-04-12",
+    "Description": "Alias of B.1.617.2.4.2.3, European lineage, from #356"
+  },
+  {
+    "Lineage": "AY.4.2.4",
+    "Earliest date": "2021-10-10",
+    "Latest date": "2022-01-25",
+    "Description": "Alias of B.1.617.2.4.2.4, European lineage"
+  },
+  {
+    "Lineage": "AY.4.2.5",
+    "Earliest date": "2021-10-22",
+    "Latest date": "2022-01-27",
+    "Description": "Alias of B.1.617.2.4.2.5, UK lineage, from #543"
+  },
+  {
+    "Lineage": "AY.4.3",
+    "Earliest date": "2021-04-30",
+    "Latest date": "2022-01-29",
+    "Description": "Alias of B.1.617.2.4.3, lineage in several countries, from #222"
+  },
+  {
+    "Lineage": "AY.4.4",
+    "Earliest date": "2021-01-19",
+    "Latest date": "2022-02-22",
+    "Description": "Alias of B.1.617.2.4.4, lineage in several European countries, from #237"
+  },
+  {
+    "Lineage": "AY.4.5",
+    "Earliest date": "2021-01-11",
+    "Latest date": "2022-04-07",
+    "Description": "Alias of B.1.617.2.4.5, predominantly Lithuania lineage, from #241"
+  },
+  {
+    "Lineage": "AY.4.6",
+    "Earliest date": "2020-06-11",
+    "Latest date": "2022-03-09",
+    "Description": "Alias of B.1.617.2.4.6, European lineage, from #264"
+  },
+  {
+    "Lineage": "AY.4.7",
+    "Earliest date": "2021-03-16",
+    "Latest date": "2022-01-27",
+    "Description": "Alias of B.1.617.2.4.7, lineage in Aruba and other countries, from #291"
+  },
+  {
+    "Lineage": "AY.4.8",
+    "Earliest date": "2021-07-13",
+    "Latest date": "2022-01-29",
+    "Description": "Alias of B.1.617.2.4.8, UK lineage, from #304"
+  },
+  {
+    "Lineage": "AY.4.9",
+    "Earliest date": "2020-08-11",
+    "Latest date": "2022-12-17",
+    "Description": "Alias of B.1.617.2.4.9, European lineage, from #332"
+  },
+  {
+    "Lineage": "AY.4.10",
+    "Earliest date": "2021-09-10",
+    "Latest date": "2022-01-28",
+    "Description": "Alias of B.1.617.2.4.10, European lineage, from #332"
+  },
+  {
+    "Lineage": "AY.4.11",
+    "Earliest date": "2021-05-03",
+    "Latest date": "2022-12-17",
+    "Description": "Alias of B.1.617.2.4.11, European lineage"
+  },
+  {
+    "Lineage": "AY.4.12",
+    "Earliest date": "2021-07-26",
+    "Latest date": "2022-01-26",
+    "Description": "Alias of B.1.617.2.4.12, Canada lineage"
+  },
+  {
+    "Lineage": "AY.4.13",
+    "Earliest date": "2021-05-03",
+    "Latest date": "2022-03-04",
+    "Description": "Alias of B.1.617.2.4.13, European lineage"
+  },
+  {
+    "Lineage": "AY.4.14",
+    "Earliest date": "2021-07-14",
+    "Latest date": "2021-12-26",
+    "Description": "Alias of B.1.617.2.4.14, lineage in Denmark and other countries"
+  },
+  {
+    "Lineage": "AY.4.15",
+    "Earliest date": "2021-09-08",
+    "Latest date": "2022-01-13",
+    "Description": "Alias of B.1.617.2.4.15, Denmark lineage"
+  },
+  {
+    "Lineage": "AY.4.16",
+    "Earliest date": "2021-10-03",
+    "Latest date": "2021-12-26",
+    "Description": "Alias of B.1.617.2.4.16, Gibraltar lineage"
+  },
+  {
+    "Lineage": "AY.4.17",
+    "Earliest date": "2021-09-17",
+    "Latest date": "2022-02-01",
+    "Description": "Alias of B.1.617.2.4.17, Lithuania lineage"
+  },
+  {
+    "Lineage": "AY.5",
+    "Earliest date": "2020-11-15",
+    "Latest date": "2022-12-17",
+    "Description": "Alias of B.1.617.2.5, UK lineage, from #180"
+  },
+  {
+    "Lineage": "AY.5.1",
+    "Earliest date": "2021-06-03",
+    "Latest date": "2021-11-19",
+    "Description": "Alias of B.1.617.2.5.1, Portugal lineage"
+  },
+  {
+    "Lineage": "AY.5.2",
+    "Earliest date": "2021-05-03",
+    "Latest date": "2021-12-27",
+    "Description": "Alias of B.1.617.2.5.2, Portugal lineage"
+  },
+  {
+    "Lineage": "AY.5.3",
+    "Earliest date": "2021-07-02",
+    "Latest date": "2022-01-15",
+    "Description": "Alias of B.1.617.2.5.3, USA lineage"
+  },
+  {
+    "Lineage": "AY.5.4",
+    "Earliest date": "2021-04-30",
+    "Latest date": "2022-12-17",
+    "Description": "Alias of B.1.617.2.5.4, European lineage"
+  },
+  {
+    "Lineage": "AY.5.5",
+    "Earliest date": "2021-06-02",
+    "Latest date": "2021-11-16",
+    "Description": "Alias of B.1.617.2.5.5, European lineage, formally AY.97, from #363"
+  },
+  {
+    "Lineage": "AY.5.6",
+    "Earliest date": "2021-07-30",
+    "Latest date": "2022-01-03",
+    "Description": "Alias of B.1.617.2.5.6, lineage in Saint Vincent and the Grenadines, Grenada and other countries"
+  },
+  {
+    "Lineage": "AY.5.7",
+    "Earliest date": "2021-11-05",
+    "Latest date": "2021-12-31",
+    "Description": "Alias of B.1.617.2.5.7, mainly found in Israel, from #387"
+  },
+  {
+    "Lineage": "AY.6",
+    "Earliest date": "2021-03-09",
+    "Latest date": "2022-05-23",
+    "Description": "Alias of B.1.617.2.6, UK lineage, from #180"
+  },
+  {
+    "Lineage": "AY.7",
+    "Earliest date": "2021-05-01",
+    "Latest date": "2022-01-15",
+    "Description": "Alias of B.1.617.2.7, UK lineage, from #180"
+  },
+  {
+    "Lineage": "AY.7.1",
+    "Earliest date": "2021-02-09",
+    "Latest date": "2022-02-27",
+    "Description": "Alias of B.1.617.2.7.1, Denmark lineage"
+  },
+  {
+    "Lineage": "AY.7.2",
+    "Earliest date": "2021-03-16",
+    "Latest date": "2022-01-14",
+    "Description": "Alias of B.1.617.2.7.2, predominantly Italy lineage in multiple other European countries"
+  },
+  {
+    "Lineage": "AY.8",
+    "Earliest date": "2021-04-20",
+    "Latest date": "2021-08-31",
+    "Description": "Alias of B.1.617.2.8, UK lineage, from #180"
+  },
+  {
+    "Lineage": "AY.9",
+    "Earliest date": "2021-01-20",
+    "Latest date": "2022-07-21",
+    "Description": "Alias of B.1.617.2.9, UK lineage, from #180"
+  },
+  {
+    "Lineage": "AY.9.2",
+    "Earliest date": "2020-10-15",
+    "Latest date": "2022-12-17",
+    "Description": "Alias of B.1.617.2.9.2, European lineage"
+  },
+  {
+    "Lineage": "AY.9.2.1",
+    "Earliest date": "2021-07-27",
+    "Latest date": "2021-12-16",
+    "Description": "Alias of B.1.617.2.9.2.1, Canada lineage"
+  },
+  {
+    "Lineage": "AY.9.2.2",
+    "Earliest date": "2021-08-18",
+    "Latest date": "2023-01-14",
+    "Description": "Alias of B.1.617.2.9.2.2, Sweden lineage, from #284"
+  },
+  {
+    "Lineage": "AY.10",
+    "Earliest date": "2021-04-12",
+    "Latest date": "2021-08-08",
+    "Description": "Alias of B.1.617.2.10, UK lineage, from #180"
+  },
+  {
+    "Lineage": "AY.11",
+    "Earliest date": "2021-04-20",
+    "Latest date": "2021-09-28",
+    "Description": "Alias of B.1.617.2.11, UK lineage, from #142"
+  },
+  {
+    "Lineage": "AY.13",
+    "Earliest date": "2021-01-11",
+    "Latest date": "2022-01-21",
+    "Description": "Alias of B.1.617.2.13, USA lineage, from #198"
+  },
+  {
+    "Lineage": "AY.14",
+    "Earliest date": "2021-03-30",
+    "Latest date": "2023-01-12",
+    "Description": "Alias of B.1.617.2.14, USA lineage, from #198"
+  },
+  {
+    "Lineage": "AY.15",
+    "Earliest date": "2021-04-30",
+    "Latest date": "2021-12-08",
+    "Description": "Alias of B.1.617.2.15, Canada lineage, from #198"
+  },
+  {
+    "Lineage": "AY.16",
+    "Earliest date": "2020-10-26",
+    "Latest date": "2022-01-17",
+    "Description": "Alias of B.1.617.2.16, lineage in Kenya and multiple other countries, from #198"
+  },
+  {
+    "Lineage": "AY.16.1",
+    "Earliest date": "2021-06-24",
+    "Latest date": "2021-11-29",
+    "Description": "Alias of B.1.617.2.16.1, France lineage"
+  },
+  {
+    "Lineage": "AY.17",
+    "Earliest date": "2021-04-28",
+    "Latest date": "2021-08-19",
+    "Description": "Alias of B.1.617.2.17, Ireland and Northern Ireland lineage, from #198"
+  },
+  {
+    "Lineage": "AY.18",
+    "Earliest date": "2021-05-11",
+    "Latest date": "2021-07-22",
+    "Description": "Alias of B.1.617.2.18, Canada lineage, from #198"
+  },
+  {
+    "Lineage": "AY.19",
+    "Earliest date": "2021-05-12",
+    "Latest date": "2022-01-01",
+    "Description": "Alias of B.1.617.2.19, South Africa lineage, from #198"
+  },
+  {
+    "Lineage": "AY.20",
+    "Earliest date": "2021-01-05",
+    "Latest date": "2022-04-06",
+    "Description": "Alias of B.1.617.2.20, USA and Mexico lineage, from #198"
+  },
+  {
+    "Lineage": "AY.20.1",
+    "Earliest date": "2021-09-05",
+    "Latest date": "2022-01-28",
+    "Description": "Alias of B.1.617.2.20.1, Czech Republic lineage, from #318"
+  },
+  {
+    "Lineage": "AY.21",
+    "Earliest date": "2021-05-26",
+    "Latest date": "2021-08-27",
+    "Description": "Alias of B.1.617.2.21, lineage predominantly in Italy and Switzerland, from #198"
+  },
+  {
+    "Lineage": "AY.22",
+    "Earliest date": "2021-05-28",
+    "Latest date": "2021-12-21",
+    "Description": "Alias of B.1.617.2.22, predominantly Portugal lineage, from #198"
+  },
+  {
+    "Lineage": "AY.23",
+    "Earliest date": "2020-03-12",
+    "Latest date": "2022-11-09",
+    "Description": "Alias of B.1.617.2.23, predominantly Singapore and Indonesia lineage, from #175"
+  },
+  {
+    "Lineage": "AY.23.1",
+    "Earliest date": "2021-08-22",
+    "Latest date": "2022-04-25",
+    "Description": "Alias of B.1.617.2.23.1, Singapore lineage, from #237"
+  },
+  {
+    "Lineage": "AY.23.2",
+    "Earliest date": "2021-01-09",
+    "Latest date": "2021-12-18",
+    "Description": "Alias of B.1.617.2.23.2, European lineage, from #265"
+  },
+  {
+    "Lineage": "AY.24",
+    "Earliest date": "2020-07-29",
+    "Latest date": "2022-05-09",
+    "Description": "Alias of B.1.617.2.24, predominantly Indonesia lineage, from #175"
+  },
+  {
+    "Lineage": "AY.24.1",
+    "Earliest date": "2021-07-19",
+    "Latest date": "2022-02-03",
+    "Description": "Alias of B.1.617.2.24.1, Brunei lineage"
+  },
+  {
+    "Lineage": "AY.25",
+    "Earliest date": "2020-07-21",
+    "Latest date": "2023-05-03",
+    "Description": "Alias of B.1.617.2.25, USA lineage, from #181"
+  },
+  {
+    "Lineage": "AY.25.1",
+    "Earliest date": "2020-09-11",
+    "Latest date": "2022-12-29",
+    "Description": "Alias of B.1.617.2.25.1, Canada and USA lineage, from #313"
+  },
+  {
+    "Lineage": "AY.25.1.1",
+    "Earliest date": "2021-07-26",
+    "Latest date": "2021-12-30",
+    "Description": "Alias of B.1.617.2.25.1.1, Peru lineage, from #355"
+  },
+  {
+    "Lineage": "AY.25.1.2",
+    "Earliest date": "2021-08-03",
+    "Latest date": "2023-07-17",
+    "Description": "Alias of B.1.617.2.25.1.2, Trinidad and Tobago lineage"
+  },
+  {
+    "Lineage": "AY.25.2",
+    "Earliest date": "2021-09-17",
+    "Latest date": "2022-01-18",
+    "Description": "Alias of B.1.617.2.25.2, Argentina lineage"
+  },
+  {
+    "Lineage": "AY.25.3",
+    "Earliest date": "2021-07-15",
+    "Latest date": "2022-06-23",
+    "Description": "Alias of B.1.617.2.25.3, Canada and USA lineage"
+  },
+  {
+    "Lineage": "AY.26",
+    "Earliest date": "2021-01-07",
+    "Latest date": "2023-01-05",
+    "Description": "Alias of B.1.617.2.26, USA and Mexico lineage, from #188"
+  },
+  {
+    "Lineage": "AY.26.1",
+    "Earliest date": "2021-06-25",
+    "Latest date": "2021-12-24",
+    "Description": "Alias of B.1.617.2.26.1, Peru lineage, from #278"
+  },
+  {
+    "Lineage": "AY.27",
+    "Earliest date": "2021-04-09",
+    "Latest date": "2022-04-28",
+    "Description": "Alias of B.1.617.2.27, Canada lineage, from #196"
+  },
+  {
+    "Lineage": "AY.28",
+    "Earliest date": "2021-05-22",
+    "Latest date": "2022-01-07",
+    "Description": "Alias of B.1.617.2.28, Sri Lanka lineage, from #199"
+  },
+  {
+    "Lineage": "AY.29",
+    "Earliest date": "2021-01-28",
+    "Latest date": "2023-11-06",
+    "Description": "Alias of B.1.617.2.29, Japan lineage, from #208"
+  },
+  {
+    "Lineage": "AY.29.1",
+    "Earliest date": "2021-07-09",
+    "Latest date": "2021-12-17",
+    "Description": "Alias of B.1.617.2.29.1, Japan lineage, from #224"
+  },
+  {
+    "Lineage": "AY.29.2",
+    "Earliest date": "2021-08-04",
+    "Latest date": "2022-03-14",
+    "Description": "Alias of B.1.617.2.29.2, Japan lineage, from #381"
+  },
+  {
+    "Lineage": "AY.30",
+    "Earliest date": "2021-03-27",
+    "Latest date": "2022-05-02",
+    "Description": "Alias of B.1.617.2.30, Thailand and Cambodia lineage, from #207"
+  },
+  {
+    "Lineage": "AY.31",
+    "Earliest date": "2020-08-10",
+    "Latest date": "2021-08-17",
+    "Description": "Alias of B.1.617.2.31, lineage associated with Myanmar. At the time of designation, almost all sequences in this lineage were from Myanmar or had travel history from Myanmar, from #206"
+  },
+  {
+    "Lineage": "AY.32",
+    "Earliest date": "2021-04-16",
+    "Latest date": "2022-04-19",
+    "Description": "Alias of B.1.617.2.32, South Africa lineage, from #209"
+  },
+  {
+    "Lineage": "AY.33",
+    "Earliest date": "2020-10-26",
+    "Latest date": "2022-12-17",
+    "Description": "Alias of B.1.617.2.33, Lineage circulating mostly in Belgium, Denmark, France, Netherlands, Germany, from #215 and #219"
+  },
+  {
+    "Lineage": "AY.33.1",
+    "Earliest date": "2021-10-12",
+    "Latest date": "2022-01-04",
+    "Description": "Alias of B.1.617.2.33.1, Reunion and France lineage, from #370"
+  },
+  {
+    "Lineage": "AY.33.2",
+    "Earliest date": "2021-04-30",
+    "Latest date": "2023-01-13",
+    "Description": "Alias of B.1.617.2.33.2, mainly found in Germany, Poland, Gibraltar and Spain, from #403"
+  },
+  {
+    "Lineage": "AY.34",
+    "Earliest date": "2020-11-18",
+    "Latest date": "2022-08-30",
+    "Description": "Alias of B.1.617.2.34, lineage with spike Q677H circulating in multiple countries, from #217"
+  },
+  {
+    "Lineage": "AY.34.1",
+    "Earliest date": "2020-04-01",
+    "Latest date": "2022-12-17",
+    "Description": "Alias of B.1.617.2.34.1, lineage in multiple countries including Gambia, Senegal, Benin and Mali, from #255"
+  },
+  {
+    "Lineage": "AY.34.1.1",
+    "Earliest date": "2020-09-18",
+    "Latest date": "2022-01-13",
+    "Description": "Alias of B.1.617.2.34.1.1, Brazil and Chile lineage, from #255"
+  },
+  {
+    "Lineage": "AY.34.2",
+    "Earliest date": "2021-07-12",
+    "Latest date": "2022-02-03",
+    "Description": "Alias of B.1.617.2.34.2, lineage in multiple countries including Martinique, from #269"
+  },
+  {
+    "Lineage": "AY.35",
+    "Earliest date": "2021-01-11",
+    "Latest date": "2022-01-21",
+    "Description": "Alias of B.1.617.2.35, lineage with spike E484Q circulating in USA, from #217"
+  },
+  {
+    "Lineage": "AY.36",
+    "Earliest date": "2020-08-11",
+    "Latest date": "2022-02-23",
+    "Description": "Alias of B.1.617.2.36, lineage predominantly in Nigeria, UK and USA, from #225"
+  },
+  {
+    "Lineage": "AY.36.1",
+    "Earliest date": "2021-04-30",
+    "Latest date": "2022-02-23",
+    "Description": "Alias of B.1.617.2.36.1, lineage in Germany and other countries, from #434"
+  },
+  {
+    "Lineage": "AY.37",
+    "Earliest date": "2021-02-18",
+    "Latest date": "2022-01-06",
+    "Description": "Alias of B.1.617.2.37, lineage predominantly in Liberia, USA and France, from #228"
+  },
+  {
+    "Lineage": "AY.38",
+    "Earliest date": "2021-03-12",
+    "Latest date": "2022-05-09",
+    "Description": "Alias of B.1.617.2.38, lineage predominantly in South Africa, from #229"
+  },
+  {
+    "Lineage": "AY.39",
+    "Earliest date": "2021-01-08",
+    "Latest date": "2022-10-23",
+    "Description": "Alias of B.1.617.2.39, predominantly USA lineage, from #234"
+  },
+  {
+    "Lineage": "AY.39.1",
+    "Earliest date": "2021-01-06",
+    "Latest date": "2022-09-28",
+    "Description": "Alias of B.1.617.2.39.1, Australia and USA lineage, from #234"
+  },
+  {
+    "Lineage": "AY.39.1.1",
+    "Earliest date": "2021-05-09",
+    "Latest date": "2022-02-14",
+    "Description": "Alias of B.1.617.2.39.1.1, predominantly New Zealand lineage, from #234"
+  },
+  {
+    "Lineage": "AY.39.1.2",
+    "Earliest date": "2021-06-25",
+    "Latest date": "2022-06-14",
+    "Description": "Alias of B.1.617.2.39.1.2, Australia lineage, from #307"
+  },
+  {
+    "Lineage": "AY.39.1.3",
+    "Earliest date": "2021-07-25",
+    "Latest date": "2021-12-21",
+    "Description": "Alias of B.1.617.2.39.1.3, Australia lineage, from #339"
+  },
+  {
+    "Lineage": "AY.39.1.4",
+    "Earliest date": "2021-09-14",
+    "Latest date": "2022-02-13",
+    "Description": "Alias of B.1.617.2.39.1.4, Australian lineage, from #438"
+  },
+  {
+    "Lineage": "AY.39.2",
+    "Earliest date": "2021-07-06",
+    "Latest date": "2022-05-05",
+    "Description": "Alias of B.1.617.2.39.2, Peru lineage, from #295"
+  },
+  {
+    "Lineage": "AY.39.3",
+    "Earliest date": "2021-08-07",
+    "Latest date": "2022-01-30",
+    "Description": "Alias of B.1.617.2.39.3, Trinidad and Tobago lineage"
+  },
+  {
+    "Lineage": "AY.40",
+    "Earliest date": "2021-07-10",
+    "Latest date": "2021-10-27",
+    "Description": "Alias of B.1.617.2.40, Reunion lineage, from #237"
+  },
+  {
+    "Lineage": "AY.41",
+    "Earliest date": "2020-10-20",
+    "Latest date": "2022-01-25",
+    "Description": "Alias of B.1.617.2.41, European lineage, from #237"
+  },
+  {
+    "Lineage": "AY.42",
+    "Earliest date": "2020-10-15",
+    "Latest date": "2022-12-17",
+    "Description": "Alias of B.1.617.2.42, European lineage, from #239"
+  },
+  {
+    "Lineage": "AY.42.1",
+    "Earliest date": "2021-07-12",
+    "Latest date": "2022-01-07",
+    "Description": "Alias of B.1.617.2.42.1, lineage in Bonaire, Curacao and other countries, from #331"
+  },
+  {
+    "Lineage": "AY.43",
+    "Earliest date": "2020-05-11",
+    "Latest date": "2023-03-08",
+    "Description": "Alias of B.1.617.2.43, European lineage, from #240"
+  },
+  {
+    "Lineage": "AY.43.1",
+    "Earliest date": "2020-10-01",
+    "Latest date": "2022-01-02",
+    "Description": "Alias of B.1.617.2.43.1, Brazil lineage, from #319"
+  },
+  {
+    "Lineage": "AY.43.2",
+    "Earliest date": "2021-06-30",
+    "Latest date": "2022-01-20",
+    "Description": "Alias of B.1.617.2.43.2, Brazil lineage, from #319"
+  },
+  {
+    "Lineage": "AY.43.3",
+    "Earliest date": "2021-08-11",
+    "Latest date": "2022-02-09",
+    "Description": "Alias of B.1.617.2.43.3, Chile lineage, from #337"
+  },
+  {
+    "Lineage": "AY.43.4",
+    "Earliest date": "2020-10-28",
+    "Latest date": "2022-04-19",
+    "Description": "Alias of B.1.617.2.43.4, Switzerland lineage, from #317"
+  },
+  {
+    "Lineage": "AY.43.5",
+    "Earliest date": "2021-10-22",
+    "Latest date": "2022-01-24",
+    "Description": "Alias of B.1.617.2.43.5, Portugal lineage, from #335"
+  },
+  {
+    "Lineage": "AY.43.6",
+    "Earliest date": "2021-08-31",
+    "Latest date": "2022-01-24",
+    "Description": "Alias of B.1.617.2.43.6, Denmark lineage, from #315"
+  },
+  {
+    "Lineage": "AY.43.7",
+    "Earliest date": "2021-07-20",
+    "Latest date": "2022-01-23",
+    "Description": "Alias of B.1.617.2.43.7, Brazil lineage, from #378"
+  },
+  {
+    "Lineage": "AY.43.8",
+    "Earliest date": "2021-01-12",
+    "Latest date": "2022-02-15",
+    "Description": "Alias of B.1.617.2.43.8, lineage in Netherlands, Suriname and other countries"
+  },
+  {
+    "Lineage": "AY.43.9",
+    "Earliest date": "2021-05-03",
+    "Latest date": "2022-02-01",
+    "Description": "Alias of B.1.617.2.43.9, Slovakia lineage"
+  },
+  {
+    "Lineage": "AY.44",
+    "Earliest date": "2020-09-09",
+    "Latest date": "2022-12-21",
+    "Description": "Alias of B.1.617.2.44, USA lineage, from #242"
+  },
+  {
+    "Lineage": "AY.45",
+    "Earliest date": "2021-01-01",
+    "Latest date": "2022-07-04",
+    "Description": "Alias of B.1.617.2.45, South Africa lineage, from #246"
+  },
+  {
+    "Lineage": "AY.46",
+    "Earliest date": "2020-06-01",
+    "Latest date": "2022-09-15",
+    "Description": "Alias of B.1.617.2.46, Africa lineage, from #247"
+  },
+  {
+    "Lineage": "AY.46.1",
+    "Earliest date": "2021-06-25",
+    "Latest date": "2022-11-23",
+    "Description": "Alias of B.1.617.2.46.1, USA lineage, from #247"
+  },
+  {
+    "Lineage": "AY.46.2",
+    "Earliest date": "2021-03-09",
+    "Latest date": "2022-01-27",
+    "Description": "Alias of B.1.617.2.46.2, Germany and Turkey lineage, from #247"
+  },
+  {
+    "Lineage": "AY.46.3",
+    "Earliest date": "2021-06-21",
+    "Latest date": "2022-03-10",
+    "Description": "Alias of B.1.617.2.46.3, Brazil lineage, from #247"
+  },
+  {
+    "Lineage": "AY.46.4",
+    "Earliest date": "2020-11-09",
+    "Latest date": "2022-02-09",
+    "Description": "Alias of B.1.617.2.46.4, USA lineage, from #247"
+  },
+  {
+    "Lineage": "AY.46.5",
+    "Earliest date": "2021-02-06",
+    "Latest date": "2022-02-03",
+    "Description": "Alias of B.1.617.2.46.5, UK lineage, from #247"
+  },
+  {
+    "Lineage": "AY.46.6",
+    "Earliest date": "2020-08-11",
+    "Latest date": "2022-11-09",
+    "Description": "Alias of B.1.617.2.46.6, European lineage, from #247"
+  },
+  {
+    "Lineage": "AY.46.6.1",
+    "Earliest date": "2021-10-17",
+    "Latest date": "2022-02-17",
+    "Description": "Alias of B.1.617.2.46.6.1, Italy lineage, from #369"
+  },
+  {
+    "Lineage": "AY.47",
+    "Earliest date": "2020-11-13",
+    "Latest date": "2022-04-19",
+    "Description": "Alias of B.1.617.2.47, USA lineage, from #254"
+  },
+  {
+    "Lineage": "AY.48",
+    "Earliest date": "2021-04-22",
+    "Latest date": "2022-01-03",
+    "Description": "Alias of B.1.617.2.48, USA lineage"
+  },
+  {
+    "Lineage": "AY.49",
+    "Earliest date": "2021-04-10",
+    "Latest date": "2021-11-15",
+    "Description": "Alias of B.1.617.2.49, USA lineage"
+  },
+  {
+    "Lineage": "AY.50",
+    "Earliest date": "2021-05-27",
+    "Latest date": "2021-11-27",
+    "Description": "Alias of B.1.617.2.50, Ireland lineage"
+  },
+  {
+    "Lineage": "AY.51",
+    "Earliest date": "2021-06-17",
+    "Latest date": "2022-09-15",
+    "Description": "Alias of B.1.617.2.51, European lineage"
+  },
+  {
+    "Lineage": "AY.52",
+    "Earliest date": "2021-05-12",
+    "Latest date": "2021-11-25",
+    "Description": "Alias of B.1.617.2.52, USA lineage"
+  },
+  {
+    "Lineage": "AY.53",
+    "Earliest date": "2021-04-03",
+    "Latest date": "2022-12-17",
+    "Description": "Alias of B.1.617.2.53, European lineage"
+  },
+  {
+    "Lineage": "AY.54",
+    "Earliest date": "2021-02-09",
+    "Latest date": "2022-02-10",
+    "Description": "Alias of B.1.617.2.54, USA lineage"
+  },
+  {
+    "Lineage": "AY.55",
+    "Earliest date": "2021-01-29",
+    "Latest date": "2021-12-22",
+    "Description": "Alias of B.1.617.2.55, lineage in Rwanda and other countries"
+  },
+  {
+    "Lineage": "AY.56",
+    "Earliest date": "2021-05-07",
+    "Latest date": "2022-01-05",
+    "Description": "Alias of B.1.617.2.56, USA lineage"
+  },
+  {
+    "Lineage": "AY.57",
+    "Earliest date": "2021-01-30",
+    "Latest date": "2022-06-20",
+    "Description": "Alias of B.1.617.2.57, Vietnam lineage"
+  },
+  {
+    "Lineage": "AY.58",
+    "Earliest date": "2021-03-16",
+    "Latest date": "2022-01-30",
+    "Description": "Alias of B.1.617.2.58, European lineage, from #286"
+  },
+  {
+    "Lineage": "AY.59",
+    "Earliest date": "2021-01-08",
+    "Latest date": "2022-10-11",
+    "Description": "Alias of B.1.617.2.59, Malaysia lineage"
+  },
+  {
+    "Lineage": "AY.60",
+    "Earliest date": "2021-05-03",
+    "Latest date": "2022-02-02",
+    "Description": "Alias of B.1.617.2.60, European lineage"
+  },
+  {
+    "Lineage": "AY.61",
+    "Earliest date": "2021-04-22",
+    "Latest date": "2022-01-14",
+    "Description": "Alias of B.1.617.2.61, Italy lineage"
+  },
+  {
+    "Lineage": "AY.62",
+    "Earliest date": "2021-04-21",
+    "Latest date": "2022-08-12",
+    "Description": "Alias of B.1.617.2.62, USA and Mexico lineage"
+  },
+  {
+    "Lineage": "AY.63",
+    "Earliest date": "2021-06-10",
+    "Latest date": "2021-12-16",
+    "Description": "Alias of B.1.617.2.63, Norway lineage, from #286"
+  },
+  {
+    "Lineage": "AY.64",
+    "Earliest date": "2021-05-22",
+    "Latest date": "2021-12-29",
+    "Description": "Alias of B.1.617.2.64, USA lineage"
+  },
+  {
+    "Lineage": "AY.65",
+    "Earliest date": "2020-09-11",
+    "Latest date": "2022-04-02",
+    "Description": "Alias of B.1.617.2.65, lineage in Bahrain and other countries"
+  },
+  {
+    "Lineage": "AY.66",
+    "Earliest date": "2021-01-07",
+    "Latest date": "2022-01-05",
+    "Description": "Alias of B.1.617.2.66, European lineage, from #271"
+  },
+  {
+    "Lineage": "AY.67",
+    "Earliest date": "2021-05-09",
+    "Latest date": "2022-01-10",
+    "Description": "Alias of B.1.617.2.67, USA lineage"
+  },
+  {
+    "Lineage": "AY.68",
+    "Earliest date": "2021-02-11",
+    "Latest date": "2022-01-17",
+    "Description": "Alias of B.1.617.2.68, European lineage"
+  },
+  {
+    "Lineage": "AY.69",
+    "Earliest date": "2021-05-15",
+    "Latest date": "2022-02-10",
+    "Description": "Alias of B.1.617.2.69, South Korea lineage, from #260"
+  },
+  {
+    "Lineage": "AY.70",
+    "Earliest date": "2021-01-07",
+    "Latest date": "2021-12-31",
+    "Description": "Alias of B.1.617.2.70, European lineage"
+  },
+  {
+    "Lineage": "AY.71",
+    "Earliest date": "2021-03-09",
+    "Latest date": "2022-12-17",
+    "Description": "Alias of B.1.617.2.71, European lineage"
+  },
+  {
+    "Lineage": "AY.72",
+    "Earliest date": "2021-05-24",
+    "Latest date": "2022-02-08",
+    "Description": "Alias of B.1.617.2.72, European lineage"
+  },
+  {
+    "Lineage": "AY.73",
+    "Earliest date": "2021-05-03",
+    "Latest date": "2022-02-05",
+    "Description": "Alias of B.1.617.2.73, European lineage"
+  },
+  {
+    "Lineage": "AY.74",
+    "Earliest date": "2021-04-09",
+    "Latest date": "2023-08-20",
+    "Description": "Alias of B.1.617.2.74, Canada lineage"
+  },
+  {
+    "Lineage": "AY.75",
+    "Earliest date": "2020-06-27",
+    "Latest date": "2022-10-04",
+    "Description": "Alias of B.1.617.2.75, USA and European lineage"
+  },
+  {
+    "Lineage": "AY.75.2",
+    "Earliest date": "2021-04-30",
+    "Latest date": "2022-04-24",
+    "Description": "Alias of B.1.617.2.75.2, Philippines lineage"
+  },
+  {
+    "Lineage": "AY.75.3",
+    "Earliest date": "2021-05-17",
+    "Latest date": "2021-09-30",
+    "Description": "Alias of B.1.617.2.75.3, Japan lineage"
+  },
+  {
+    "Lineage": "AY.76",
+    "Earliest date": "2021-05-04",
+    "Latest date": "2022-04-16",
+    "Description": "Alias of B.1.617.2.76, predominantly Malaysia lineage"
+  },
+  {
+    "Lineage": "AY.77",
+    "Earliest date": "2021-05-07",
+    "Latest date": "2022-01-25",
+    "Description": "Alias of B.1.617.2.77, USA lineage"
+  },
+  {
+    "Lineage": "AY.78",
+    "Earliest date": "2021-06-19",
+    "Latest date": "2022-01-11",
+    "Description": "Alias of B.1.617.2.78, Germany and Turkey lineage"
+  },
+  {
+    "Lineage": "AY.79",
+    "Earliest date": "2021-01-03",
+    "Latest date": "2022-06-08",
+    "Description": "Alias of B.1.617.2.79, predominantly Malaysia lineage"
+  },
+  {
+    "Lineage": "AY.80",
+    "Earliest date": "2021-06-02",
+    "Latest date": "2022-01-08",
+    "Description": "Alias of B.1.617.2.80, European lineage"
+  },
+  {
+    "Lineage": "AY.81",
+    "Earliest date": "2021-05-20",
+    "Latest date": "2021-12-28",
+    "Description": "Alias of B.1.617.2.81, USA lineage"
+  },
+  {
+    "Lineage": "AY.82",
+    "Earliest date": "2020-08-25",
+    "Latest date": "2021-12-31",
+    "Description": "Alias of B.1.617.2.82, Fiji lineage"
+  },
+  {
+    "Lineage": "AY.83",
+    "Earliest date": "2021-05-17",
+    "Latest date": "2022-01-28",
+    "Description": "Alias of B.1.617.2.83, USA lineage"
+  },
+  {
+    "Lineage": "AY.84",
+    "Earliest date": "2020-05-11",
+    "Latest date": "2022-01-24",
+    "Description": "Alias of B.1.617.2.84, European lineage"
+  },
+  {
+    "Lineage": "AY.85",
+    "Earliest date": "2021-01-09",
+    "Latest date": "2022-03-28",
+    "Description": "Alias of B.1.617.2.85, Thailand lineage"
+  },
+  {
+    "Lineage": "AY.86",
+    "Earliest date": "2021-04-22",
+    "Latest date": "2022-02-18",
+    "Description": "Alias of B.1.617.2.86, Canada and USA lineage"
+  },
+  {
+    "Lineage": "AY.87",
+    "Earliest date": "2021-05-18",
+    "Latest date": "2022-01-22",
+    "Description": "Alias of B.1.617.2.87, UK lineage"
+  },
+  {
+    "Lineage": "AY.88",
+    "Earliest date": "2021-04-12",
+    "Latest date": "2022-09-05",
+    "Description": "Alias of B.1.617.2.88, lineage in Ghana and other countries"
+  },
+  {
+    "Lineage": "AY.90",
+    "Earliest date": "2021-05-02",
+    "Latest date": "2022-01-19",
+    "Description": "Alias of B.1.617.2.90, UK lineage"
+  },
+  {
+    "Lineage": "AY.91",
+    "Earliest date": "2021-02-08",
+    "Latest date": "2022-05-22",
+    "Description": "Alias of B.1.617.2.91, lineage in South Africa, Namibia and other countries"
+  },
+  {
+    "Lineage": "AY.91.1",
+    "Earliest date": "2021-06-10",
+    "Latest date": "2021-12-20",
+    "Description": "Alias of B.1.617.2.91.1, European lineage"
+  },
+  {
+    "Lineage": "AY.92",
+    "Earliest date": "2021-04-10",
+    "Latest date": "2022-12-07",
+    "Description": "Alias of B.1.617.2.92, European lineage"
+  },
+  {
+    "Lineage": "AY.93",
+    "Earliest date": "2021-04-25",
+    "Latest date": "2022-01-16",
+    "Description": "Alias of B.1.617.2.93, Canada lineage"
+  },
+  {
+    "Lineage": "AY.94",
+    "Earliest date": "2021-03-08",
+    "Latest date": "2022-01-13",
+    "Description": "Alias of B.1.617.2.94, European lineage"
+  },
+  {
+    "Lineage": "AY.95",
+    "Earliest date": "2021-04-07",
+    "Latest date": "2022-01-24",
+    "Description": "Alias of B.1.617.2.95, Maldives and European lineage"
+  },
+  {
+    "Lineage": "AY.98",
+    "Earliest date": "2020-10-14",
+    "Latest date": "2022-12-17",
+    "Description": "Alias of B.1.617.2.98, UK lineage"
+  },
+  {
+    "Lineage": "AY.98.1",
+    "Earliest date": "2020-11-04",
+    "Latest date": "2022-12-17",
+    "Description": "Alias of B.1.617.2.98.1, European lineage"
+  },
+  {
+    "Lineage": "AY.98.1.1",
+    "Earliest date": "2021-08-24",
+    "Latest date": "2022-04-25",
+    "Description": "Alias of B.1.617.2.98.1.1, mainly found in Germany and Denmark, from #604"
+  },
+  {
+    "Lineage": "AY.99",
+    "Earliest date": "2021-04-16",
+    "Latest date": "2022-01-13",
+    "Description": "Alias of B.1.617.2.99, South Africa and Nigeria lineage, from #258"
+  },
+  {
+    "Lineage": "AY.99.1",
+    "Earliest date": "2021-01-03",
+    "Latest date": "2022-06-16",
+    "Description": "Alias of B.1.617.2.99.1, Brazil lineage, from #258"
+  },
+  {
+    "Lineage": "AY.99.2",
+    "Earliest date": "2021-02-28",
+    "Latest date": "2022-10-10",
+    "Description": "Alias of B.1.617.2.99.2, Brazil lineage, from #258"
+  },
+  {
+    "Lineage": "AY.100",
+    "Earliest date": "2020-08-31",
+    "Latest date": "2022-08-04",
+    "Description": "Alias of B.1.617.2.100, USA lineage"
+  },
+  {
+    "Lineage": "AY.101",
+    "Earliest date": "2021-05-01",
+    "Latest date": "2022-10-01",
+    "Description": "Alias of B.1.617.2.101, Brazil and Chile lineage"
+  },
+  {
+    "Lineage": "AY.102",
+    "Earliest date": "2021-04-17",
+    "Latest date": "2022-01-14",
+    "Description": "Alias of B.1.617.2.102, Peru and Chile lineage, from #272"
+  },
+  {
+    "Lineage": "AY.102.1",
+    "Earliest date": "2021-05-31",
+    "Latest date": "2022-01-03",
+    "Description": "Alias of B.1.617.2.102.1, Peru lineage, from #325"
+  },
+  {
+    "Lineage": "AY.102.2",
+    "Earliest date": "2021-07-12",
+    "Latest date": "2022-01-27",
+    "Description": "Alias of B.1.617.2.102.2, Peru lineage, from #330"
+  },
+  {
+    "Lineage": "AY.103",
+    "Earliest date": "2020-05-14",
+    "Latest date": "2023-02-01",
+    "Description": "Alias of B.1.617.2.103, USA lineage"
+  },
+  {
+    "Lineage": "AY.103.1",
+    "Earliest date": "2021-08-25",
+    "Latest date": "2022-01-04",
+    "Description": "Alias of B.1.617.2.103.1, Argentina lineage"
+  },
+  {
+    "Lineage": "AY.103.2",
+    "Earliest date": "2021-09-01",
+    "Latest date": "2022-01-20",
+    "Description": "Alias of B.1.617.2.103.2, Canada lineage"
+  },
+  {
+    "Lineage": "AY.104",
+    "Earliest date": "2021-03-11",
+    "Latest date": "2022-01-25",
+    "Description": "Alias of B.1.617.2.104, Sri Lanka lineage, from #289"
+  },
+  {
+    "Lineage": "AY.105",
+    "Earliest date": "2021-05-12",
+    "Latest date": "2022-02-01",
+    "Description": "Alias of B.1.617.2.105, USA lineage"
+  },
+  {
+    "Lineage": "AY.106",
+    "Earliest date": "2021-03-06",
+    "Latest date": "2022-07-13",
+    "Description": "Alias of B.1.617.2.106, lineage in Jordan and other countries, from #287"
+  },
+  {
+    "Lineage": "AY.107",
+    "Earliest date": "2021-01-05",
+    "Latest date": "2022-05-29",
+    "Description": "Alias of B.1.617.2.107, USA lineage"
+  },
+  {
+    "Lineage": "AY.108",
+    "Earliest date": "2021-05-25",
+    "Latest date": "2022-04-12",
+    "Description": "Alias of B.1.617.2.108, lineage in Pakistan and other countries"
+  },
+  {
+    "Lineage": "AY.109",
+    "Earliest date": "2021-06-25",
+    "Latest date": "2022-03-24",
+    "Description": "Alias of B.1.617.2.109, lineage in Nigeria and other countries"
+  },
+  {
+    "Lineage": "AY.110",
+    "Earliest date": "2021-03-09",
+    "Latest date": "2022-06-16",
+    "Description": "Alias of B.1.617.2.110, USA lineage"
+  },
+  {
+    "Lineage": "AY.111",
+    "Earliest date": "2021-02-05",
+    "Latest date": "2022-02-23",
+    "Description": "Alias of B.1.617.2.111, UK lineage"
+  },
+  {
+    "Lineage": "AY.112",
+    "Earliest date": "2020-08-11",
+    "Latest date": "2022-09-15",
+    "Description": "Alias of B.1.617.2.112, lineage in India and other countries, from #283"
+  },
+  {
+    "Lineage": "AY.112.1",
+    "Earliest date": "2021-07-18",
+    "Latest date": "2022-01-05",
+    "Description": "Alias of B.1.617.2.112.1, Bahrain lineage, from #283"
+  },
+  {
+    "Lineage": "AY.112.2",
+    "Earliest date": "2021-01-10",
+    "Latest date": "2022-04-12",
+    "Description": "Alias of B.1.617.2.112.2, mainly found in India, from #385"
+  },
+  {
+    "Lineage": "AY.112.3",
+    "Earliest date": "2021-08-23",
+    "Latest date": "2022-01-09",
+    "Description": "Alias of B.1.617.2.112.3, mainly found in Israel, from #388"
+  },
+  {
+    "Lineage": "AY.113",
+    "Earliest date": "2020-12-16",
+    "Latest date": "2022-12-21",
+    "Description": "Alias of B.1.617.2.113, USA and Mexico lineage"
+  },
+  {
+    "Lineage": "AY.114",
+    "Earliest date": "2021-05-17",
+    "Latest date": "2022-02-01",
+    "Description": "Alias of B.1.617.2.114, USA lineage"
+  },
+  {
+    "Lineage": "AY.116",
+    "Earliest date": "2021-02-01",
+    "Latest date": "2022-01-19",
+    "Description": "Alias of B.1.617.2.116, Africa lineage"
+  },
+  {
+    "Lineage": "AY.116.1",
+    "Earliest date": "2021-06-07",
+    "Latest date": "2022-02-01",
+    "Description": "Alias of B.1.617.2.116.1, USA lineage"
+  },
+  {
+    "Lineage": "AY.117",
+    "Earliest date": "2020-05-11",
+    "Latest date": "2022-06-02",
+    "Description": "Alias of B.1.617.2.117, USA lineage"
+  },
+  {
+    "Lineage": "AY.118",
+    "Earliest date": "2021-02-09",
+    "Latest date": "2022-09-13",
+    "Description": "Alias of B.1.617.2.118, USA lineage"
+  },
+  {
+    "Lineage": "AY.119",
+    "Earliest date": "2020-10-29",
+    "Latest date": "2022-10-24",
+    "Description": "Alias of B.1.617.2.119, USA lineage"
+  },
+  {
+    "Lineage": "AY.119.1",
+    "Earliest date": "2020-11-09",
+    "Latest date": "2022-05-30",
+    "Description": "Alias of B.1.617.2.119.1, Chile and Peru lineage, from #336"
+  },
+  {
+    "Lineage": "AY.119.2",
+    "Earliest date": "2021-01-11",
+    "Latest date": "2022-05-26",
+    "Description": "Alias of B.1.617.2.119.2, USA lineage, from #288"
+  },
+  {
+    "Lineage": "AY.120",
+    "Earliest date": "2020-10-26",
+    "Latest date": "2022-09-28",
+    "Description": "Alias of B.1.617.2.120, UK lineage"
+  },
+  {
+    "Lineage": "AY.120.1",
+    "Earliest date": "2020-12-27",
+    "Latest date": "2022-02-15",
+    "Description": "Alias of B.1.617.2.120.1, USA lineage"
+  },
+  {
+    "Lineage": "AY.120.2",
+    "Earliest date": "2021-03-17",
+    "Latest date": "2022-01-31",
+    "Description": "Alias of B.1.617.2.120.2, South Africa lineage"
+  },
+  {
+    "Lineage": "AY.120.2.1",
+    "Earliest date": "2021-05-03",
+    "Latest date": "2021-12-09",
+    "Description": "Alias of B.1.617.2.120.2.1, European lineage"
+  },
+  {
+    "Lineage": "AY.121",
+    "Earliest date": "2020-05-11",
+    "Latest date": "2022-10-14",
+    "Description": "Alias of B.1.617.2.121, European lineage, from #301"
+  },
+  {
+    "Lineage": "AY.121.1",
+    "Earliest date": "2021-01-02",
+    "Latest date": "2022-03-01",
+    "Description": "Alias of B.1.617.2.121.1, Poland and Germany lineage, from #344"
+  },
+  {
+    "Lineage": "AY.122",
+    "Earliest date": "2020-05-11",
+    "Latest date": "2024-07-23",
+    "Description": "Alias of B.1.617.2.122, European lineage, from #320"
+  },
+  {
+    "Lineage": "AY.122.1",
+    "Earliest date": "2021-01-11",
+    "Latest date": "2022-03-27",
+    "Description": "Alias of B.1.617.2.122.1, Israel lineage, formally AY.12 but renamed as descends from AY.122 which was designated after AY.12, from #170"
+  },
+  {
+    "Lineage": "AY.122.2",
+    "Earliest date": "2021-06-22",
+    "Latest date": "2022-01-18",
+    "Description": "Alias of B.1.617.2.122.2, Finland and Estonia lineage, from #273"
+  },
+  {
+    "Lineage": "AY.122.3",
+    "Earliest date": "2021-10-04",
+    "Latest date": "2022-02-03",
+    "Description": "Alias of B.1.617.2.122.3, Denmark and Sweden lineage, from #371"
+  },
+  {
+    "Lineage": "AY.122.4",
+    "Earliest date": "2021-08-30",
+    "Latest date": "2022-04-04",
+    "Description": "Alias of B.1.617.2.122.4, South America and USA lineage"
+  },
+  {
+    "Lineage": "AY.122.5",
+    "Earliest date": "2021-08-08",
+    "Latest date": "2022-03-04",
+    "Description": "Alias of B.1.617.2.122.5, South Korea lineage"
+  },
+  {
+    "Lineage": "AY.122.6",
+    "Earliest date": "2021-05-03",
+    "Latest date": "2022-07-14",
+    "Description": "Alias of B.1.617.2.122.6, mainly found in France, from #394"
+  },
+  {
+    "Lineage": "AY.123",
+    "Earliest date": "2021-03-11",
+    "Latest date": "2022-03-17",
+    "Description": "Alias of B.1.617.2.123, Predominantly Belgium and France lineage, from #306"
+  },
+  {
+    "Lineage": "AY.123.1",
+    "Earliest date": "2021-01-12",
+    "Latest date": "2022-02-13",
+    "Description": "Alias of B.1.617.2.123.1, Belgium lineage, from #354"
+  },
+  {
+    "Lineage": "AY.124",
+    "Earliest date": "2020-05-11",
+    "Latest date": "2022-12-17",
+    "Description": "Alias of B.1.617.2.124, lineage in Portugal and other European countries, from #281"
+  },
+  {
+    "Lineage": "AY.124.1",
+    "Earliest date": "2021-06-21",
+    "Latest date": "2022-01-30",
+    "Description": "Alias of B.1.617.2.124.1, lineage in Portugal and other European countries, from #345"
+  },
+  {
+    "Lineage": "AY.124.1.1",
+    "Earliest date": "2021-06-26",
+    "Latest date": "2022-05-31",
+    "Description": "Alias of B.1.617.2.124.1.1, lineage in Mauritius and other countries"
+  },
+  {
+    "Lineage": "AY.125",
+    "Earliest date": "2020-08-11",
+    "Latest date": "2022-12-17",
+    "Description": "Alias of B.1.617.2.125, European lineage, from #328"
+  },
+  {
+    "Lineage": "AY.125.1",
+    "Earliest date": "2021-08-16",
+    "Latest date": "2022-01-03",
+    "Description": "Alias of B.1.617.2.125.1, Australia lineage"
+  },
+  {
+    "Lineage": "AY.126",
+    "Earliest date": "2020-10-14",
+    "Latest date": "2022-05-15",
+    "Description": "Alias of B.1.617.2.126, European lineage, from #253"
+  },
+  {
+    "Lineage": "AY.127",
+    "Earliest date": "2021-01-09",
+    "Latest date": "2022-12-17",
+    "Description": "Alias of B.1.617.2.127, lineage in India and other countries, from #342"
+  },
+  {
+    "Lineage": "AY.127.1",
+    "Earliest date": "2021-09-04",
+    "Latest date": "2022-01-01",
+    "Description": "Alias of B.1.617.2.127.1, lineage in Djibouti and other countries, from #352"
+  },
+  {
+    "Lineage": "AY.127.2",
+    "Earliest date": "2021-10-02",
+    "Latest date": "2022-01-05",
+    "Description": "Alias of B.1.617.2.127.2, Qatar lineage"
+  },
+  {
+    "Lineage": "AY.127.3",
+    "Earliest date": "2022-01-26",
+    "Latest date": "2022-04-17",
+    "Description": "Alias of B.1.617.2.127.3, Qatar lineage, from #525"
+  },
+  {
+    "Lineage": "AY.128",
+    "Earliest date": "2021-05-15",
+    "Latest date": "2022-01-15",
+    "Description": "Alias of B.1.617.2.128, lineage in Estonia, Georgia and other countries, from #309"
+  },
+  {
+    "Lineage": "AY.129",
+    "Earliest date": "2020-05-11",
+    "Latest date": "2022-12-17",
+    "Description": "Alias of B.1.617.2.129, European lineage, from #329"
+  },
+  {
+    "Lineage": "AY.130",
+    "Earliest date": "2021-09-30",
+    "Latest date": "2021-11-08",
+    "Description": "Alias of B.1.617.2.130, Bahrain lineage, from #351"
+  },
+  {
+    "Lineage": "AY.131",
+    "Earliest date": "2021-08-12",
+    "Latest date": "2022-08-01",
+    "Description": "Alias of B.1.617.2.131, mainly reported from Bangladesh, from #373"
+  },
+  {
+    "Lineage": "AY.132",
+    "Earliest date": "2021-10-27",
+    "Latest date": "2022-01-16",
+    "Description": "Alias of B.1.617.2.132, Denmark lineage, from #379"
+  },
+  {
+    "Lineage": "AY.133",
+    "Earliest date": "2021-04-08",
+    "Latest date": "2022-01-19",
+    "Description": "Alias of B.1.617.2.133, France Germany and UK lineage (with some samples from elsewhere, notably Senegal and Ghana), from #380"
+  },
+  {
+    "Lineage": "AY.134",
+    "Earliest date": "2021-11-08",
+    "Latest date": "2022-01-17",
+    "Description": "Alias of B.1.617.2.134, European lineage, previously assigned AY.39.4, from #406"
+  },
+  {
+    "Lineage": "B.1.617.3",
+    "Earliest date": "2021-01-03",
+    "Latest date": "2022-07-09",
+    "Description": "Predominantly India lineage with 484Q, from #49"
+  },
+  {
+    "Lineage": "B.1.618",
+    "Earliest date": "2020-10-25",
+    "Latest date": "2021-04-23",
+    "Description": "India lineage in West Bengal, from #46"
+  },
+  {
+    "Lineage": "B.1.619",
+    "Earliest date": "2020-03-10",
+    "Latest date": "2021-08-05",
+    "Description": "Lineage in multiple countries, potentially originated in Cameroon and introduced into Europe, from #44"
+  },
+  {
+    "Lineage": "B.1.619.1",
+    "Earliest date": "2021-02-22",
+    "Latest date": "2021-09-21",
+    "Description": "South Korea lineage, from #160"
+  },
+  {
+    "Lineage": "B.1.620",
+    "Earliest date": "2020-04-05",
+    "Latest date": "2021-09-06",
+    "Description": "Lineage in multiple countries, potentially originated in Cameroon and spread within Europe post-introduction, from #54"
+  },
+  {
+    "Lineage": "B.1.621",
+    "Earliest date": "2020-12-15",
+    "Latest date": "2024-05-07",
+    "Description": "Lineage predominantly in Colombia with several spike mutations, from #57"
+  },
+  {
+    "Lineage": "B.1.621.1",
+    "Earliest date": "2021-04-09",
+    "Latest date": "2022-05-25",
+    "Description": "Lineage in multiple countries, from #115"
+  },
+  {
+    "Lineage": "BB.2",
+    "Earliest date": "2021-05-19",
+    "Latest date": "2021-10-12",
+    "Description": "Alias of B.1.621.1.2, from #232"
+  },
+  {
+    "Lineage": "B.1.621.2",
+    "Earliest date": "2021-04-11",
+    "Latest date": "2021-12-22",
+    "Description": "Lineage in multiple countries, from #232"
+  },
+  {
+    "Lineage": "B.1.622",
+    "Earliest date": "2021-01-19",
+    "Latest date": "2021-04-13",
+    "Description": "Reunion lineage, from #58"
+  },
+  {
+    "Lineage": "B.1.623",
+    "Earliest date": "2020-07-08",
+    "Latest date": "2021-07-06",
+    "Description": "Predominantly USA lineage with mutations of interest, from #25"
+  },
+  {
+    "Lineage": "B.1.625",
+    "Earliest date": "2020-11-16",
+    "Latest date": "2021-11-06",
+    "Description": "Predominantly Colombia and USA lineage, from #93"
+  },
+  {
+    "Lineage": "B.1.626",
+    "Earliest date": "2021-04-15",
+    "Latest date": "2021-10-14",
+    "Description": "Europe and USA lineage, from #118"
+  },
+  {
+    "Lineage": "B.1.627",
+    "Earliest date": "2021-01-09",
+    "Latest date": "2021-08-21",
+    "Description": "USA, Mexico and Honduras lineage, from #130"
+  },
+  {
+    "Lineage": "B.1.629",
+    "Earliest date": "2021-02-23",
+    "Latest date": "2021-07-17",
+    "Description": "Lineage circulating in several countries, from #132"
+  },
+  {
+    "Lineage": "B.1.630",
+    "Earliest date": "2021-03-17",
+    "Latest date": "2022-08-22",
+    "Description": "Lineage in several countries, from #137"
+  },
+  {
+    "Lineage": "B.1.631",
+    "Earliest date": "2020-12-16",
+    "Latest date": "2021-09-06",
+    "Description": "USA and Mexico lineage, from #146"
+  },
+  {
+    "Lineage": "B.1.632",
+    "Earliest date": "2021-04-19",
+    "Latest date": "2021-09-21",
+    "Description": "Predominantly Mexico lineage, from #156"
+  },
+  {
+    "Lineage": "B.1.633",
+    "Earliest date": "2021-03-17",
+    "Latest date": "2021-06-23",
+    "Description": "India lineage, from #155"
+  },
+  {
+    "Lineage": "B.1.634",
+    "Earliest date": "2021-03-02",
+    "Latest date": "2021-08-16",
+    "Description": "Mexico and USA lineage, from #159"
+  },
+  {
+    "Lineage": "B.1.635",
+    "Earliest date": "2021-01-13",
+    "Latest date": "2021-06-18",
+    "Description": "Mexico and USA lineage, from #159"
+  },
+  {
+    "Lineage": "B.1.636",
+    "Earliest date": "2021-01-06",
+    "Latest date": "2021-07-10",
+    "Description": "USA, Mexico and Honduras lineage, from #173"
+  },
+  {
+    "Lineage": "B.1.637",
+    "Earliest date": "2020-04-16",
+    "Latest date": "2022-05-25",
+    "Description": "Added as B.1.526.1 15 Mar 2021, but turned out not to be a descendant of B.1.526; was folded into B.1.526 from 14 Jun - 18 Aug 2021; now a separate lineage to leave B.1.526 more congruent with Iota (Nextstrain 21F / original B.1.526), from #154"
+  },
+  {
+    "Lineage": "B.1.637.1",
+    "Earliest date": "2021-09-21",
+    "Latest date": "2022-01-12",
+    "Description": "USA lineage, from #353"
+  },
+  {
+    "Lineage": "B.1.638",
+    "Earliest date": "2021-05-24",
+    "Latest date": "2021-06-10",
+    "Description": "South Africa lineage, from #205"
+  },
+  {
+    "Lineage": "B.1.639",
+    "Earliest date": "2021-01-19",
+    "Latest date": "2021-11-15",
+    "Description": "Lineage sequenced in USA, potentially associated with Puerto Rico, from #161"
+  },
+  {
+    "Lineage": "B.1.640",
+    "Earliest date": "2021-10-06",
+    "Latest date": "2022-01-17",
+    "Description": "Lineage in Africa and Europe, from #297"
+  },
+  {
+    "Lineage": "B.1.640.1",
+    "Earliest date": "2021-01-01",
+    "Latest date": "2022-06-03",
+    "Description": "Lineage in Africa and Europe, from #362"
+  },
+  {
+    "Lineage": "B.1.640.2",
+    "Earliest date": "2021-10-15",
+    "Latest date": "2022-01-10",
+    "Description": "Lineage, from #362"
+  },
+  {
+    "Lineage": "B.1.641",
+    "Earliest date": "2021-12-01",
+    "Latest date": "2021-12-01",
+    "Description": "Lineage in white-tailed deer, from #453"
+  },
+  {
+    "Lineage": "B.1.9",
+    "Earliest date": "2020-03-04",
+    "Latest date": "2021-08-26",
+    "Description": "European wide lineage with active sublineages"
+  },
+  {
+    "Lineage": "B.1.9.1",
+    "Earliest date": "2020-03-31",
+    "Latest date": "2021-09-29",
+    "Description": "Scottish Lineage"
+  },
+  {
+    "Lineage": "B.1.9.2",
+    "Earliest date": "2020-04-20",
+    "Latest date": "2020-07-13",
+    "Description": "USA"
+  },
+  {
+    "Lineage": "B.1.9.3",
+    "Earliest date": "2020-03-17",
+    "Latest date": "2020-05-23",
+    "Description": "Belgium"
+  },
+  {
+    "Lineage": "B.1.9.4",
+    "Earliest date": "2020-03-21",
+    "Latest date": "2021-06-28",
+    "Description": "European wide lineage with active cases with activity in Switzerland"
+  },
+  {
+    "Lineage": "B.1.9.5",
+    "Earliest date": "2020-03-14",
+    "Latest date": "2021-06-28",
+    "Description": "European sublineage highly represented in Turkey"
+  },
+  {
+    "Lineage": "B.3",
+    "Earliest date": "2020-02-11",
+    "Latest date": "2021-04-01",
+    "Description": "A European lineage - Germany & UK predominantly"
+  },
+  {
+    "Lineage": "B.3.1",
+    "Earliest date": "2020-01-21",
+    "Latest date": "2020-06-18",
+    "Description": "Welsh lineage"
+  },
+  {
+    "Lineage": "B.4",
+    "Earliest date": "2020-01-18",
+    "Latest date": "2021-09-02",
+    "Description": "Iranian lineage and global exports"
+  },
+  {
+    "Lineage": "B.4.1",
+    "Earliest date": "2020-03-22",
+    "Latest date": "2020-04-26",
+    "Description": "Lineage from Kazakhstan within the B.4 diversity"
+  },
+  {
+    "Lineage": "B.4.2",
+    "Earliest date": "2020-02-25",
+    "Latest date": "2020-04-08",
+    "Description": "Bahrain lineage"
+  },
+  {
+    "Lineage": "B.4.4",
+    "Earliest date": "2020-03-06",
+    "Latest date": "2020-04-27",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.4.5",
+    "Earliest date": "2020-03-09",
+    "Latest date": "2020-05-13",
+    "Description": "Australian lineage"
+  },
+  {
+    "Lineage": "B.4.6",
+    "Earliest date": "2020-02-29",
+    "Latest date": "2020-06-12",
+    "Description": "Australian lineage"
+  },
+  {
+    "Lineage": "B.4.7",
+    "Earliest date": "2020-03-14",
+    "Latest date": "2020-07-11",
+    "Description": "Africa and UAE"
+  },
+  {
+    "Lineage": "B.4.8",
+    "Earliest date": "2020-05-17",
+    "Latest date": "2021-02-12",
+    "Description": "Cryptic lineage in Iran? Occasional international appearances, most recently Nov 2020"
+  },
+  {
+    "Lineage": "B.5",
+    "Earliest date": "2020-02-05",
+    "Latest date": "2020-03-18",
+    "Description": "Japanese lineage"
+  },
+  {
+    "Lineage": "B.6",
+    "Earliest date": "2020-02-14",
+    "Latest date": "2022-11-21",
+    "Description": "Indian lineage"
+  },
+  {
+    "Lineage": "B.6.1",
+    "Earliest date": "2020-03-11",
+    "Latest date": "2020-05-04",
+    "Description": "Malaysian lineage"
+  },
+  {
+    "Lineage": "B.6.2",
+    "Earliest date": "2020-05-23",
+    "Latest date": "2020-06-11",
+    "Description": "Malaysian lineage"
+  },
+  {
+    "Lineage": "B.6.3",
+    "Earliest date": "2020-03-10",
+    "Latest date": "2020-07-01",
+    "Description": "Singapore lineage"
+  },
+  {
+    "Lineage": "B.6.4",
+    "Earliest date": "2020-04-18",
+    "Latest date": "2020-07-29",
+    "Description": "Singapore lineage"
+  },
+  {
+    "Lineage": "B.6.5",
+    "Earliest date": "2020-03-19",
+    "Latest date": "2020-04-06",
+    "Description": "Australian lineage"
+  },
+  {
+    "Lineage": "B.6.6",
+    "Earliest date": "2020-03-10",
+    "Latest date": "2021-04-25",
+    "Description": "Singapore lineage"
+  },
+  {
+    "Lineage": "B.6.8",
+    "Earliest date": "2020-07-13",
+    "Latest date": "2021-04-19",
+    "Description": "Papua New Guinea"
+  },
+  {
+    "Lineage": "B.10",
+    "Earliest date": "2020-03-12",
+    "Latest date": "2020-05-15",
+    "Description": "Northern Irish lineage"
+  },
+  {
+    "Lineage": "B.11",
+    "Earliest date": "2020-02-27",
+    "Latest date": "2023-11-21",
+    "Description": "European lineage with sequences from the Netherlands, UK, Austria, Slovakia"
+  },
+  {
+    "Lineage": "B.12",
+    "Earliest date": "2020-01-20",
+    "Latest date": "2021-04-11",
+    "Description": "Japanese lineage"
+  },
+  {
+    "Lineage": "B.13",
+    "Earliest date": "2020-04-03",
+    "Latest date": "2020-05-05",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.15",
+    "Earliest date": "2020-03-11",
+    "Latest date": "2020-09-07",
+    "Description": "UK lineage"
+  },
+  {
+    "Lineage": "B.18",
+    "Earliest date": "2020-03-16",
+    "Latest date": "2021-04-15",
+    "Description": "European lineage (Iceland and England)"
+  },
+  {
+    "Lineage": "B.19",
+    "Earliest date": "2020-03-29",
+    "Latest date": "2021-08-03",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.20",
+    "Earliest date": "2020-03-31",
+    "Latest date": "2020-05-13",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.23",
+    "Earliest date": "2020-02-28",
+    "Latest date": "2020-12-18",
+    "Description": "Lineage with representation from mainly UK sequences, but also sequences from Portugal, Iceland and Brazil"
+  },
+  {
+    "Lineage": "B.26",
+    "Earliest date": "2020-03-17",
+    "Latest date": "2021-09-29",
+    "Description": "Scottish lineage"
+  },
+  {
+    "Lineage": "B.27",
+    "Earliest date": "2020-03-03",
+    "Latest date": "2020-04-24",
+    "Description": "UK lineage, Curacao, Switzerland"
+  },
+  {
+    "Lineage": "B.28",
+    "Earliest date": "2020-03-06",
+    "Latest date": "2021-02-10",
+    "Description": "UK lineage"
+  },
+  {
+    "Lineage": "B.29",
+    "Earliest date": "2020-02-27",
+    "Latest date": "2020-06-14",
+    "Description": "Spanish/UK/ Australian lineage"
+  },
+  {
+    "Lineage": "B.30",
+    "Earliest date": "2020-03-09",
+    "Latest date": "2021-07-20",
+    "Description": "Reassigned from B.2.12, USA lineage"
+  },
+  {
+    "Lineage": "B.31",
+    "Earliest date": "2020-03-03",
+    "Latest date": "2020-07-03",
+    "Description": "Reassigned from B.2.5, UK/ Australia/ New Zealand lineage"
+  },
+  {
+    "Lineage": "B.32",
+    "Earliest date": "2020-03-13",
+    "Latest date": "2020-06-18",
+    "Description": "Scottish lineage"
+  },
+  {
+    "Lineage": "B.33",
+    "Earliest date": "2020-01-20",
+    "Latest date": "2021-12-19",
+    "Description": "UK lineage"
+  },
+  {
+    "Lineage": "B.34",
+    "Earliest date": "2020-03-13",
+    "Latest date": "2020-04-10",
+    "Description": "Scottish lineage"
+  },
+  {
+    "Lineage": "B.35",
+    "Earliest date": "2020-03-05",
+    "Latest date": "2020-12-30",
+    "Description": "Previously B.2.6, USA lineage"
+  },
+  {
+    "Lineage": "B.36",
+    "Earliest date": "2020-03-17",
+    "Latest date": "2020-04-11",
+    "Description": "Previously B.2.11, Israel lineage"
+  },
+  {
+    "Lineage": "B.37",
+    "Earliest date": "2020-03-12",
+    "Latest date": "2020-04-16",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.38",
+    "Earliest date": "2020-03-07",
+    "Latest date": "2020-04-29",
+    "Description": "Belgium lineage"
+  },
+  {
+    "Lineage": "B.39",
+    "Earliest date": "2020-02-25",
+    "Latest date": "2020-08-02",
+    "Description": "Previously B.2.2, USA/ UK/ Australian lineage"
+  },
+  {
+    "Lineage": "B.40",
+    "Earliest date": "2020-02-09",
+    "Latest date": "2020-09-03",
+    "Description": "Previously B.2.1. Large lineage majoritively from UK and Australia with representation from Europe, Jordan, USA, India, Ghana, South Korea"
+  },
+  {
+    "Lineage": "B.41",
+    "Earliest date": "2020-02-06",
+    "Latest date": "2020-04-18",
+    "Description": "Previously B.2.10, South Korean lineage"
+  },
+  {
+    "Lineage": "B.42",
+    "Earliest date": "2020-01-29",
+    "Latest date": "2020-03-06",
+    "Description": "Hong Kong lineage"
+  },
+  {
+    "Lineage": "B.43",
+    "Earliest date": "2020-01-26",
+    "Latest date": "2020-03-09",
+    "Description": "Hong Kong lineage"
+  },
+  {
+    "Lineage": "B.44",
+    "Earliest date": "2020-03-17",
+    "Latest date": "2020-04-30",
+    "Description": "Portugal lineage"
+  },
+  {
+    "Lineage": "B.45",
+    "Earliest date": "2020-02-23",
+    "Latest date": "2020-06-23",
+    "Description": "Scottish lineage"
+  },
+  {
+    "Lineage": "B.46",
+    "Earliest date": "2020-03-18",
+    "Latest date": "2020-05-13",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.47",
+    "Earliest date": "2020-03-06",
+    "Latest date": "2020-05-27",
+    "Description": "English lineage"
+  },
+  {
+    "Lineage": "B.49",
+    "Earliest date": "2020-03-09",
+    "Latest date": "2020-04-13",
+    "Description": "Danish lineage"
+  },
+  {
+    "Lineage": "B.50",
+    "Earliest date": "2020-03-14",
+    "Latest date": "2021-09-09",
+    "Description": "Indonesian lineage"
+  },
+  {
+    "Lineage": "B.51",
+    "Earliest date": "2020-03-18",
+    "Latest date": "2020-04-14",
+    "Description": "USA lineage"
+  },
+  {
+    "Lineage": "B.52",
+    "Earliest date": "2020-03-12",
+    "Latest date": "2021-02-03",
+    "Description": "UK lineage"
+  },
+  {
+    "Lineage": "B.53",
+    "Earliest date": "2020-02-07",
+    "Latest date": "2020-05-17",
+    "Description": "Lithuanian lineage"
+  },
+  {
+    "Lineage": "B.55",
+    "Earliest date": "2020-01-29",
+    "Latest date": "2021-02-10",
+    "Description": "Redesignated from B.11 (split), UK/Danish"
+  },
+  {
+    "Lineage": "B.56",
+    "Earliest date": "2020-03-14",
+    "Latest date": "2020-08-12",
+    "Description": "Singapore/Malaysia/Indonesia"
+  },
+  {
+    "Lineage": "B.57",
+    "Earliest date": "2020-03-02",
+    "Latest date": "2020-05-21",
+    "Description": "Largely Scottish"
+  },
+  {
+    "Lineage": "B.58",
+    "Earliest date": "2020-03-04",
+    "Latest date": "2021-04-13",
+    "Description": "Largely English, UK/Canada/Australia"
+  },
+  {
+    "Lineage": "B.60",
+    "Earliest date": "2020-03-04",
+    "Latest date": "2020-04-21",
+    "Description": "England"
+  },
+  {
+    "Lineage": "B.61",
+    "Earliest date": "2020-02-09",
+    "Latest date": "2020-05-07",
+    "Description": "Redesignated from B.40 (split), UK"
+  },
+  {
+    "Lineage": "XA",
+    "Earliest date": "2021-01-30",
+    "Latest date": "2021-04-03",
+    "Description": "Recombinant lineage with parental lineages B.1.1.7 and B.1.177, UK lineage, from #63"
+  },
+  {
+    "Lineage": "XB",
+    "Earliest date": "2020-07-08",
+    "Latest date": "2021-09-29",
+    "Description": "Recombinant lineage with parental lineages B.1.634 and B.1.631, Central and North America lineage, Formally B.1.628, from #189"
+  },
+  {
+    "Lineage": "XC",
+    "Earliest date": "2021-08-12",
+    "Latest date": "2021-10-16",
+    "Description": "Recombinant lineage with parental lineages AY.29 and B.1.1.7, Japan lineage, from #263"
+  },
+  {
+    "Lineage": "XD",
+    "Earliest date": "2022-01-03",
+    "Latest date": "2022-05-09",
+    "Description": "Recombinant lineage of Delta and BA.1, France and Denmark lineage, from #444"
+  },
+  {
+    "Lineage": "XE",
+    "Earliest date": "2022-01-19",
+    "Latest date": "2022-10-25",
+    "Description": "Recombinant lineage of BA.1 and BA.2, UK lineage, from #454"
+  },
+  {
+    "Lineage": "XF",
+    "Earliest date": "2022-01-07",
+    "Latest date": "2022-02-14",
+    "Description": "Recombinant lineage of Delta and BA.1, UK lineage, from #445"
+  },
+  {
+    "Lineage": "XG",
+    "Earliest date": "2022-01-11",
+    "Latest date": "2022-06-18",
+    "Description": "Recombinant lineage of BA.1 and BA.2, Denmark lineage, from #447"
+  },
+  {
+    "Lineage": "XH",
+    "Earliest date": "2021-12-30",
+    "Latest date": "2022-06-08",
+    "Description": "Recombinant lineage of BA.1 and BA.2, Denmark lineage, from #448"
+  },
+  {
+    "Lineage": "XJ",
+    "Earliest date": "2022-01-19",
+    "Latest date": "2022-07-01",
+    "Description": "Recombinant lineage of BA.1 and BA.2, Finland lineage, from #449"
+  },
+  {
+    "Lineage": "XK",
+    "Earliest date": "2022-02-10",
+    "Latest date": "2022-04-27",
+    "Description": "Recombinant lineage of BA.1 and BA.2, Belgium lineage, from #460"
+  },
+  {
+    "Lineage": "XL",
+    "Earliest date": "2022-02-02",
+    "Latest date": "2022-05-22",
+    "Description": "Recombinant lineage of BA.1 and BA.2, UK lineage, from #464"
+  },
+  {
+    "Lineage": "XM",
+    "Earliest date": "2022-01-06",
+    "Latest date": "2022-07-21",
+    "Description": "Recombinant lineage of BA.1.1 and BA.2, European lineage, from #472"
+  },
+  {
+    "Lineage": "XN",
+    "Earliest date": "2022-02-13",
+    "Latest date": "2022-06-07",
+    "Description": "Recombinant lineage of BA.1 and BA.2, UK lineage, from #480"
+  },
+  {
+    "Lineage": "XP",
+    "Earliest date": "2022-02-22",
+    "Latest date": "2022-04-15",
+    "Description": "Recombinant lineage of BA.1.1 and BA.2, UK lineage, from #481"
+  },
+  {
+    "Lineage": "XQ",
+    "Earliest date": "2022-02-12",
+    "Latest date": "2022-06-20",
+    "Description": "Recombinant lineage of BA.1.1 and BA.2, UK lineage, from #468"
+  },
+  {
+    "Lineage": "XR",
+    "Earliest date": "2022-02-13",
+    "Latest date": "2022-04-27",
+    "Description": "Recombinant lineage of BA.1.1 and BA.2, UK lineage, from #469"
+  },
+  {
+    "Lineage": "XS",
+    "Earliest date": "2022-01-19",
+    "Latest date": "2022-03-30",
+    "Description": "Recombinant lineage of Delta and BA.1.1, USA lineage, from #471"
+  },
+  {
+    "Lineage": "XT",
+    "Earliest date": "2021-12-13",
+    "Latest date": "2022-03-24",
+    "Description": "Recombinant lineage of BA.1 and BA.2, South Africa lineage, from #478"
+  },
+  {
+    "Lineage": "XU",
+    "Earliest date": "2022-01-20",
+    "Latest date": "2022-06-05",
+    "Description": "Recombinant lineage of BA.1 and BA.2, lineage in India and other countries, from #522"
+  },
+  {
+    "Lineage": "XV",
+    "Earliest date": "2022-01-31",
+    "Latest date": "2022-04-27",
+    "Description": "Recombinant lineage of BA.1 and BA.2, lineage in Denmark and Italy, from #463"
+  },
+  {
+    "Lineage": "XW",
+    "Earliest date": "2022-03-09",
+    "Latest date": "2022-06-30",
+    "Description": "Recombinant lineage of BA.1 and BA.2, USA, Germany, England lineage, from #591"
+  },
+  {
+    "Lineage": "XY",
+    "Earliest date": "2022-02-28",
+    "Latest date": "2022-08-09",
+    "Description": "Recombinant lineage of BA.1 and BA.2, predominantly in USA, from #606"
+  },
+  {
+    "Lineage": "XZ",
+    "Earliest date": "2022-03-19",
+    "Latest date": "2022-07-08",
+    "Description": "Recombinant lineage of BA.2 and BA.1, USA lineage, from #636"
+  },
+  {
+    "Lineage": "XAA",
+    "Earliest date": "2022-02-12",
+    "Latest date": "2022-07-08",
+    "Description": "Recombinant lineage of BA.1 and BA.2, USA lineage, from #664"
+  },
+  {
+    "Lineage": "XAB",
+    "Earliest date": "2022-02-25",
+    "Latest date": "2022-06-16",
+    "Description": "Recombinant lineage of BA.1 and BA.2, Germany lineage, from #665"
+  },
+  {
+    "Lineage": "XAC",
+    "Earliest date": "2022-01-11",
+    "Latest date": "2022-11-07",
+    "Description": "Recombinant lineage of BA.1 and BA.2, Canada and USA lineage, from #590"
+  },
+  {
+    "Lineage": "XAD",
+    "Earliest date": "2022-02-07",
+    "Latest date": "2022-08-04",
+    "Description": "Recombinant lineage of BA.2 and BA.1, Germany lineage, from #607"
+  },
+  {
+    "Lineage": "XAE",
+    "Earliest date": "2022-02-26",
+    "Latest date": "2022-11-19",
+    "Description": "Recombinant lineage of BA.2 and BA.1, USA and Chile lineage, from #637"
+  },
+  {
+    "Lineage": "XAF",
+    "Earliest date": "2022-02-22",
+    "Latest date": "2022-08-25",
+    "Description": "Recombinant lineage of BA.1 and BA.2, Costa Rica lineage, from #676"
+  },
+  {
+    "Lineage": "XAG",
+    "Earliest date": "2022-02-26",
+    "Latest date": "2022-07-29",
+    "Description": "Recombinant lineage of BA.1 and BA.2, lineage in Brazil and other countries, from #709"
+  },
+  {
+    "Lineage": "XAH",
+    "Earliest date": "2022-02-22",
+    "Latest date": "2022-12-27",
+    "Description": "Recombinant lineage of BA.2 and BA.1, lineage in Slovenia and other countries, from #755"
+  },
+  {
+    "Lineage": "XAJ",
+    "Earliest date": "2022-05-23",
+    "Latest date": "2022-09-10",
+    "Description": "Recombinant lineage of BA.2.12.1 and BA.4, predominantly in England, from #826"
+  },
+  {
+    "Lineage": "XAK",
+    "Earliest date": "2022-06-01",
+    "Latest date": "2022-10-17",
+    "Description": "Recombinant lineage of BA.1 and BA.2, Germany lineage, from #823"
+  },
+  {
+    "Lineage": "XAL",
+    "Earliest date": "2021-12-03",
+    "Latest date": "2022-06-27",
+    "Description": "Recombinant lineage of BA.1 and BA.2, Germany lineage, from #757"
+  },
+  {
+    "Lineage": "XAM",
+    "Earliest date": "2022-03-19",
+    "Latest date": "2022-08-19",
+    "Description": "Recombinant lineage of BA.1.1 and BA.2.9, lineage mainly found in Panama and USA, from #759"
+  },
+  {
+    "Lineage": "XAN",
+    "Earliest date": "2022-05-10",
+    "Latest date": "2022-12-17",
+    "Description": "Recombinant lineage of BA.2 and BA.5.1, lineage found most often in Spain and Denmark, from #771"
+  },
+  {
+    "Lineage": "XAP",
+    "Earliest date": "2022-04-11",
+    "Latest date": "2022-07-15",
+    "Description": "Recombinant lineage of BA.2* and BA.1*, USA lineage, from #789"
+  },
+  {
+    "Lineage": "XAQ",
+    "Earliest date": "2022-03-05",
+    "Latest date": "2022-06-29",
+    "Description": "Recombinant lineage of BA.1* and BA.2*, lineage mainly found in Canada, from #798"
+  },
+  {
+    "Lineage": "XAR",
+    "Earliest date": "2022-02-02",
+    "Latest date": "2022-08-01",
+    "Description": "Recombinant lineage of BA.1* and BA.2*, Reunion lineage, from #860"
+  },
+  {
+    "Lineage": "XAS",
+    "Earliest date": "2022-05-27",
+    "Latest date": "2023-03-11",
+    "Description": "Recombinant lineage of BA.5* and BA.2*, USA lineage, from #882"
+  },
+  {
+    "Lineage": "XAT",
+    "Earliest date": "2022-03-14",
+    "Latest date": "2022-08-03",
+    "Description": "Recombinant lineage of BA.2.3.13 and BA.1*, Japan lineage, from #885"
+  },
+  {
+    "Lineage": "XAU",
+    "Earliest date": "2022-03-14",
+    "Latest date": "2022-07-14",
+    "Description": "Recombinant lineage of BA.1.1* and BA.2.9*, predominantly in Spain, England and France, from #894"
+  },
+  {
+    "Lineage": "XAV",
+    "Earliest date": "2022-06-10",
+    "Latest date": "2022-11-26",
+    "Description": "Recombinant lineage of BA.2* and BA.5*, mainly France, USA, and Scotland lineage, from #911"
+  },
+  {
+    "Lineage": "XAW",
+    "Earliest date": "2022-06-27",
+    "Latest date": "2022-09-29",
+    "Description": "Recombinant lineage of BA.2* and AY.122, Russia lineage, from #895"
+  },
+  {
+    "Lineage": "XAY",
+    "Earliest date": "2022-06-28",
+    "Latest date": "2022-09-27",
+    "Description": "Recombinant lineage of BA.2 and AY.45, South Africa lineage, from #844"
+  },
+  {
+    "Lineage": "XAY.1",
+    "Earliest date": "2022-08-29",
+    "Latest date": "2023-02-25",
+    "Description": "South Africa/USA lineage with 4 AA substitutions including S:D253G, from #1208"
+  },
+  {
+    "Lineage": "XAY.1.1",
+    "Earliest date": "2022-10-11",
+    "Latest date": "2023-04-20",
+    "Description": "South Africa with S:R346T and ORF1a:K2108N, from #1255"
+  },
+  {
+    "Lineage": "XAY.1.1.1",
+    "Earliest date": "2022-12-05",
+    "Latest date": "2023-08-01",
+    "Description": "Europe, S:D1153Y, from #1569"
+  },
+  {
+    "Lineage": "GL.1",
+    "Earliest date": "2023-03-26",
+    "Latest date": "2024-02-20",
+    "Description": "Alias of XAY.1.1.1.1, Europe, S:D420N, C19441T, from #2032"
+  },
+  {
+    "Lineage": "GL.2",
+    "Earliest date": "2023-04-16",
+    "Latest date": "2023-10-03",
+    "Description": "Alias of XAY.1.1.1.2, ORF1a:S723P, South Korea/Japan/HongKong"
+  },
+  {
+    "Lineage": "GL.3",
+    "Earliest date": "2022-12-29",
+    "Latest date": "2023-06-02",
+    "Description": "Alias of XAY.1.1.1.3, ORF1a:P1640S, Germany"
+  },
+  {
+    "Lineage": "XAY.1.1.2",
+    "Earliest date": "2022-11-23",
+    "Latest date": "2023-06-12",
+    "Description": "Germany/South Africa, C14838T"
+  },
+  {
+    "Lineage": "XAY.1.1.3",
+    "Earliest date": "2022-12-19",
+    "Latest date": "2023-05-23",
+    "Description": "Germany/China/Luxembourg, C6040T, C8290T, T15153C"
+  },
+  {
+    "Lineage": "XAY.1.2",
+    "Earliest date": "2022-11-07",
+    "Latest date": "2023-02-27",
+    "Description": "Europe, ORF1a:T3646I"
+  },
+  {
+    "Lineage": "XAY.2",
+    "Earliest date": "2022-08-31",
+    "Latest date": "2023-04-10",
+    "Description": "South Africa/Denmark/Israel lineage with ORF1a:Y3765C"
+  },
+  {
+    "Lineage": "XAY.2.1",
+    "Earliest date": "2022-11-07",
+    "Latest date": "2023-03-27",
+    "Description": "Denmark, N:T24A"
+  },
+  {
+    "Lineage": "XAY.2.2",
+    "Earliest date": "2022-11-18",
+    "Latest date": "2023-04-18",
+    "Description": "Denmark, ORF1a:N447S"
+  },
+  {
+    "Lineage": "XAY.2.3",
+    "Earliest date": "2022-11-25",
+    "Latest date": "2023-05-08",
+    "Description": "Denmark, ORF1a:A131V, from #1896"
+  },
+  {
+    "Lineage": "XAY.3",
+    "Earliest date": "2022-10-18",
+    "Latest date": "2023-02-20",
+    "Description": "South Africa/Mauritius/Switzerland/France, ORF1b:D1869Y"
+  },
+  {
+    "Lineage": "XAZ",
+    "Earliest date": "2021-11-15",
+    "Latest date": "2023-04-15",
+    "Description": "Recombinant lineage of BA.2.5, BA.5. and BA.2.5, predominantly found in France, Germany, Croatia, Denmark and USA, from #797"
+  },
+  {
+    "Lineage": "XBA",
+    "Earliest date": "2022-05-30",
+    "Latest date": "2022-06-24",
+    "Description": "Recombinant lineage of perhaps AY.45 and perhaps BA.2 (with perhaps 5 breakpoints), South_Africa lineage, constellation 2, from #844"
+  },
+  {
+    "Lineage": "XBB",
+    "Earliest date": "2022-01-10",
+    "Latest date": "2024-01-14",
+    "Description": "Recombinant lineage of BJ.1 and BM.1.1.1 with breakpoint in S1, found in USA and Singapore, from #1058"
+  },
+  {
+    "Lineage": "XBB.1",
+    "Earliest date": "2022-01-04",
+    "Latest date": "2024-07-10",
+    "Description": "Mostly Bangladesh and Singapore, defined by S:G252V, from #1088"
+  },
+  {
+    "Lineage": "XBB.1.1",
+    "Earliest date": "2022-05-12",
+    "Latest date": "2023-05-21",
+    "Description": "Singapore/Denmark, defined by ORF1a:P309L"
+  },
+  {
+    "Lineage": "XBB.1.2",
+    "Earliest date": "2022-10-03",
+    "Latest date": "2022-10-11",
+    "Description": "Singapore, defined by S:S640F"
+  },
+  {
+    "Lineage": "XBB.1.3",
+    "Earliest date": "2022-09-14",
+    "Latest date": "2023-02-16",
+    "Description": "Singapore, India/Italy, defined by S:A484T, pre ORF8:8*"
+  },
+  {
+    "Lineage": "XBB.1.4",
+    "Earliest date": "2022-07-13",
+    "Latest date": "2023-07-24",
+    "Description": "Europe, S:T883I"
+  },
+  {
+    "Lineage": "XBB.1.4.1",
+    "Earliest date": "2022-10-10",
+    "Latest date": "2023-05-05",
+    "Description": "Mainly Denmark, Norway and Sweden, defined by S:S673G, from #1352"
+  },
+  {
+    "Lineage": "XBB.1.4.2",
+    "Earliest date": "2023-02-05",
+    "Latest date": "2023-12-05",
+    "Description": "S:486P, ORf1a:V3595F, Brazil, from #2031"
+  },
+  {
+    "Lineage": "XBB.1.5",
+    "Earliest date": "2020-04-04",
+    "Latest date": "2024-08-22",
+    "Description": "USA, S:F486P"
+  },
+  {
+    "Lineage": "XBB.1.5.1",
+    "Earliest date": "2022-11-28",
+    "Latest date": "2024-03-11",
+    "Description": "USA, S:T573I"
+  },
+  {
+    "Lineage": "HJ.1",
+    "Earliest date": "2022-12-04",
+    "Latest date": "2023-06-09",
+    "Description": "Alias of XBB.1.5.1.1, S:E324K, C4543T, USA"
+  },
+  {
+    "Lineage": "XBB.1.5.2",
+    "Earliest date": "2022-03-27",
+    "Latest date": "2023-09-13",
+    "Description": "USA, S:T284I, S:K147I"
+  },
+  {
+    "Lineage": "XBB.1.5.3",
+    "Earliest date": "2022-11-29",
+    "Latest date": "2023-08-27",
+    "Description": "USA, S:A411S"
+  },
+  {
+    "Lineage": "JK.1",
+    "Earliest date": "2023-01-18",
+    "Latest date": "2023-07-22",
+    "Description": "Alias of XBB.1.5.3.1, S:K304Q, USA, from #1798"
+  },
+  {
+    "Lineage": "XBB.1.5.4",
+    "Earliest date": "2022-10-18",
+    "Latest date": "2023-11-15",
+    "Description": "USA, S:T883I directly on XBB.1.5 polytomy"
+  },
+  {
+    "Lineage": "KM.1",
+    "Earliest date": "2023-08-21",
+    "Latest date": "2023-11-07",
+    "Description": "Alias of XBB.1.5.4.1, S:K478R, S:M177I, S:N185D,  N:A155V, ORF1a:T3696A, Guinea/Senegal"
+  },
+  {
+    "Lineage": "XBB.1.5.5",
+    "Earliest date": "2022-03-05",
+    "Latest date": "2023-11-07",
+    "Description": "USA, S:K1181I"
+  },
+  {
+    "Lineage": "XBB.1.5.6",
+    "Earliest date": "2022-11-25",
+    "Latest date": "2023-09-12",
+    "Description": "USA, S:V952I"
+  },
+  {
+    "Lineage": "XBB.1.5.7",
+    "Earliest date": "2022-02-19",
+    "Latest date": "2023-11-02",
+    "Description": "USA, ORF1b:V248F"
+  },
+  {
+    "Lineage": "EM.1",
+    "Earliest date": "2022-12-02",
+    "Latest date": "2023-11-22",
+    "Description": "Alias of XBB.1.5.7.1, UK, S:R214L"
+  },
+  {
+    "Lineage": "XBB.1.5.8",
+    "Earliest date": "2022-11-25",
+    "Latest date": "2023-08-07",
+    "Description": "USA, N:R10Q"
+  },
+  {
+    "Lineage": "XBB.1.5.9",
+    "Earliest date": "2022-11-20",
+    "Latest date": "2024-03-25",
+    "Description": "USA, N:S327L"
+  },
+  {
+    "Lineage": "XBB.1.5.10",
+    "Earliest date": "2021-01-22",
+    "Latest date": "2023-12-31",
+    "Description": "S:F456L (T22928C), USA-NC, from #1614"
+  },
+  {
+    "Lineage": "XBB.1.5.11",
+    "Earliest date": "2022-10-31",
+    "Latest date": "2023-09-05",
+    "Description": "ORF1a:G401S"
+  },
+  {
+    "Lineage": "XBB.1.5.12",
+    "Earliest date": "2022-12-07",
+    "Latest date": "2024-07-30",
+    "Description": "S:T323I"
+  },
+  {
+    "Lineage": "XBB.1.5.13",
+    "Earliest date": "2022-02-20",
+    "Latest date": "2023-12-22",
+    "Description": "T21880C, G28079T"
+  },
+  {
+    "Lineage": "EK.1",
+    "Earliest date": "2023-01-18",
+    "Latest date": "2023-05-16",
+    "Description": "Alias of XBB.1.5.13.1, S:K417S, Austria, from #1638"
+  },
+  {
+    "Lineage": "EK.2",
+    "Earliest date": "2023-01-10",
+    "Latest date": "2023-08-04",
+    "Description": "Alias of XBB.1.5.13.2, S:T259I, USA"
+  },
+  {
+    "Lineage": "EK.2.1",
+    "Earliest date": "2023-01-17",
+    "Latest date": "2023-09-17",
+    "Description": "Alias of XBB.1.5.13.2.1, S:478R, USA/Canada/Scotland"
+  },
+  {
+    "Lineage": "EK.3",
+    "Earliest date": "2022-12-24",
+    "Latest date": "2023-05-30",
+    "Description": "Alias of XBB.1.5.13.3, S:P251S, Scotland/England/Ireland, from #1684"
+  },
+  {
+    "Lineage": "EK.4",
+    "Earliest date": "2022-12-10",
+    "Latest date": "2023-08-26",
+    "Description": "Alias of XBB.1.5.13.4, S:Q675K, USA/France"
+  },
+  {
+    "Lineage": "XBB.1.5.14",
+    "Earliest date": "2022-11-14",
+    "Latest date": "2023-09-17",
+    "Description": "C2695T, Europe/US"
+  },
+  {
+    "Lineage": "EL.1",
+    "Earliest date": "2022-12-06",
+    "Latest date": "2023-10-11",
+    "Description": "Alias of XBB.1.5.14.1, S:Q675H, Europe, from #1631"
+  },
+  {
+    "Lineage": "XBB.1.5.15",
+    "Earliest date": "2022-04-11",
+    "Latest date": "2023-10-03",
+    "Description": "G15957T, USA"
+  },
+  {
+    "Lineage": "FD.1",
+    "Earliest date": "2022-12-29",
+    "Latest date": "2023-09-09",
+    "Description": "Alias of XBB.1.5.15.1, ORF7b:E3*, England/Canada"
+  },
+  {
+    "Lineage": "FD.1.1",
+    "Earliest date": "2022-12-31",
+    "Latest date": "2024-03-24",
+    "Description": "Alias of XBB.1.5.15.1.1, S:F456L (T22928C), Canada-QC"
+  },
+  {
+    "Lineage": "FD.2",
+    "Earliest date": "2022-11-30",
+    "Latest date": "2023-11-18",
+    "Description": "Alias of XBB.1.5.15.2, S:Q146K, ORF1a:G519S, USA, from #1600"
+  },
+  {
+    "Lineage": "FD.2.1",
+    "Earliest date": "2023-02-22",
+    "Latest date": "2023-09-01",
+    "Description": "Alias of XBB.1.5.15.2.1, ORF1a:D3022N, Peru"
+  },
+  {
+    "Lineage": "FD.3",
+    "Earliest date": "2023-01-01",
+    "Latest date": "2023-10-02",
+    "Description": "Alias of XBB.1.5.15.3, S:A348S, T8503C, USA/Finland/Japan"
+  },
+  {
+    "Lineage": "FD.4",
+    "Earliest date": "2022-12-01",
+    "Latest date": "2023-11-17",
+    "Description": "Alias of XBB.1.5.15.4, ORF1a:L4191F, USA"
+  },
+  {
+    "Lineage": "FD.4.1",
+    "Earliest date": "2022-12-31",
+    "Latest date": "2023-10-29",
+    "Description": "Alias of XBB.1.5.15.4.1, ORF1a:T4355I, ORF1b:I2634F"
+  },
+  {
+    "Lineage": "FD.5",
+    "Earliest date": "2023-01-04",
+    "Latest date": "2023-08-12",
+    "Description": "Alias of XBB.1.5.15.5, ORF10:A8V, Peru"
+  },
+  {
+    "Lineage": "FD.5.1",
+    "Earliest date": "2023-04-25",
+    "Latest date": "2024-01-11",
+    "Description": "Alias of XBB.1.5.15.5.1, S:F456L (T22928C), S:N185D, Peru, from sars-cov-2-variants/lineage-proposals#385"
+  },
+  {
+    "Lineage": "XBB.1.5.16",
+    "Earliest date": "2022-11-24",
+    "Latest date": "2024-03-05",
+    "Description": "T14766C, USA"
+  },
+  {
+    "Lineage": "FG.1",
+    "Earliest date": "2023-01-14",
+    "Latest date": "2023-10-02",
+    "Description": "Alias of XBB.1.5.16.1, S:T284I, S:R403K, S:L513F, USA, from #1751"
+  },
+  {
+    "Lineage": "FG.2",
+    "Earliest date": "2023-01-07",
+    "Latest date": "2024-02-18",
+    "Description": "Alias of XBB.1.5.16.2, S:D178N, USA/Europe"
+  },
+  {
+    "Lineage": "FG.3",
+    "Earliest date": "2022-12-28",
+    "Latest date": "2023-07-03",
+    "Description": "Alias of XBB.1.5.16.3, S:I934V, England/Wales"
+  },
+  {
+    "Lineage": "XBB.1.5.17",
+    "Earliest date": "2022-11-21",
+    "Latest date": "2024-01-05",
+    "Description": "C23635T, USA"
+  },
+  {
+    "Lineage": "FH.1",
+    "Earliest date": "2023-01-03",
+    "Latest date": "2023-10-06",
+    "Description": "Alias of XBB.1.5.17.1, S:T883I, C4633T, USA"
+  },
+  {
+    "Lineage": "XBB.1.5.18",
+    "Earliest date": "2021-07-16",
+    "Latest date": "2024-07-03",
+    "Description": "ORF1a:T2300I, England/Europe"
+  },
+  {
+    "Lineage": "XBB.1.5.19",
+    "Earliest date": "2022-11-15",
+    "Latest date": "2023-10-02",
+    "Description": "ORF1b:R172C, USA"
+  },
+  {
+    "Lineage": "XBB.1.5.20",
+    "Earliest date": "2022-03-22",
+    "Latest date": "2024-03-31",
+    "Description": "C9532T, USA"
+  },
+  {
+    "Lineage": "XBB.1.5.21",
+    "Earliest date": "2022-12-02",
+    "Latest date": "2024-01-22",
+    "Description": "ORF1a:K322R, C22945T, USA"
+  },
+  {
+    "Lineage": "GC.1",
+    "Earliest date": "2023-02-01",
+    "Latest date": "2023-06-05",
+    "Description": "Alias of XBB.1.5.21.1, S:T323I, Spain"
+  },
+  {
+    "Lineage": "GC.2",
+    "Earliest date": "2022-12-29",
+    "Latest date": "2023-04-05",
+    "Description": "Alias of XBB.1.5.21.2, S:A352S, USA"
+  },
+  {
+    "Lineage": "XBB.1.5.22",
+    "Earliest date": "2022-12-07",
+    "Latest date": "2023-06-15",
+    "Description": "ORF1a:E1498A, pre T17124C, Australia"
+  },
+  {
+    "Lineage": "XBB.1.5.23",
+    "Earliest date": "2022-07-14",
+    "Latest date": "2023-09-22",
+    "Description": "ORF1a:P4220L, pre T17124C"
+  },
+  {
+    "Lineage": "XBB.1.5.24",
+    "Earliest date": "2022-12-19",
+    "Latest date": "2023-09-18",
+    "Description": "C2710T, pre T17124C"
+  },
+  {
+    "Lineage": "GF.1",
+    "Earliest date": "2023-01-27",
+    "Latest date": "2023-11-24",
+    "Description": "Alias of XBB.1.5.24.1, S:E748V, C19524T, from #1921"
+  },
+  {
+    "Lineage": "XBB.1.5.25",
+    "Earliest date": "2022-07-21",
+    "Latest date": "2023-09-05",
+    "Description": "S:97T on T10204C branch, South Africa, from #1643"
+  },
+  {
+    "Lineage": "XBB.1.5.26",
+    "Earliest date": "2022-11-28",
+    "Latest date": "2023-10-01",
+    "Description": "920T, USA, from #1688"
+  },
+  {
+    "Lineage": "EU.1",
+    "Earliest date": "2023-01-05",
+    "Latest date": "2023-12-08",
+    "Description": "Alias of XBB.1.5.26.1, S:P521S, Germany/Netherlands, from #1688"
+  },
+  {
+    "Lineage": "EU.1.1",
+    "Earliest date": "2021-07-16",
+    "Latest date": "2024-01-02",
+    "Description": "Alias of XBB.1.5.26.1.1, S:I410V, Germany/Netherlands, from #1688"
+  },
+  {
+    "Lineage": "EU.1.1.1",
+    "Earliest date": "2021-07-16",
+    "Latest date": "2024-02-14",
+    "Description": "Alias of XBB.1.5.26.1.1.1, C21646T, Germany"
+  },
+  {
+    "Lineage": "EU.1.1.2",
+    "Earliest date": "2023-03-05",
+    "Latest date": "2023-08-08",
+    "Description": "Alias of XBB.1.5.26.1.1.2, S:A1070S, Germany/Finland/Denmark/Sweden"
+  },
+  {
+    "Lineage": "EU.1.1.3",
+    "Earliest date": "2023-03-11",
+    "Latest date": "2023-11-28",
+    "Description": "Alias of XBB.1.5.26.1.1.3, S:F157L, Europe, from sars-cov-2-variants/lineage-proposals#312"
+  },
+  {
+    "Lineage": "XBB.1.5.27",
+    "Earliest date": "2023-01-13",
+    "Latest date": "2024-03-07",
+    "Description": "S:K478R, on T11431C branch, USA"
+  },
+  {
+    "Lineage": "XBB.1.5.28",
+    "Earliest date": "2022-12-26",
+    "Latest date": "2024-02-18",
+    "Description": "S:K478R, on 17124C polytomy, USA"
+  },
+  {
+    "Lineage": "XBB.1.5.29",
+    "Earliest date": "2023-01-16",
+    "Latest date": "2023-04-14",
+    "Description": "S:A348V, USA-NE"
+  },
+  {
+    "Lineage": "XBB.1.5.30",
+    "Earliest date": "2022-12-06",
+    "Latest date": "2023-10-03",
+    "Description": "S:A348T, USA, from #1660"
+  },
+  {
+    "Lineage": "HM.1",
+    "Earliest date": "2023-03-24",
+    "Latest date": "2023-07-07",
+    "Description": "Alias of XBB.1.5.30.1, S:N481K, Canada/Australia, from sars-cov-2-variants/lineage-proposals#59"
+  },
+  {
+    "Lineage": "XBB.1.5.31",
+    "Earliest date": "2022-11-28",
+    "Latest date": "2023-09-16",
+    "Description": "T24976C, USA"
+  },
+  {
+    "Lineage": "XBB.1.5.32",
+    "Earliest date": "2022-11-21",
+    "Latest date": "2023-10-28",
+    "Description": "ORF1a:T2823I, USA"
+  },
+  {
+    "Lineage": "XBB.1.5.33",
+    "Earliest date": "2022-03-23",
+    "Latest date": "2023-10-25",
+    "Description": "G370A, USA"
+  },
+  {
+    "Lineage": "XBB.1.5.34",
+    "Earliest date": "2022-11-28",
+    "Latest date": "2023-08-23",
+    "Description": "ORF1a:T1754I, USA"
+  },
+  {
+    "Lineage": "XBB.1.5.35",
+    "Earliest date": "2022-12-10",
+    "Latest date": "2023-12-04",
+    "Description": "S:N978S, USA, from #1699"
+  },
+  {
+    "Lineage": "XBB.1.5.36",
+    "Earliest date": "2022-11-29",
+    "Latest date": "2023-08-14",
+    "Description": "C9442T, USA"
+  },
+  {
+    "Lineage": "XBB.1.5.37",
+    "Earliest date": "2022-03-05",
+    "Latest date": "2024-03-31",
+    "Description": "S:K1045R, Europe"
+  },
+  {
+    "Lineage": "XBB.1.5.38",
+    "Earliest date": "2023-01-06",
+    "Latest date": "2023-07-19",
+    "Description": "S:I666V, ORF1a:T403I"
+  },
+  {
+    "Lineage": "GG.1",
+    "Earliest date": "2023-02-08",
+    "Latest date": "2024-01-16",
+    "Description": "Alias of XBB.1.5.38.1 S:478R, Europe, from sars-cov-2-variants/lineage-proposals#48"
+  },
+  {
+    "Lineage": "XBB.1.5.39",
+    "Earliest date": "2022-12-02",
+    "Latest date": "2023-10-07",
+    "Description": "ORF1a:M3684T, USA/Canada"
+  },
+  {
+    "Lineage": "FT.1",
+    "Earliest date": "2023-01-04",
+    "Latest date": "2023-05-14",
+    "Description": "Alias of XBB.1.5.39.1, S:I197V, Canada, from #1745"
+  },
+  {
+    "Lineage": "FT.2",
+    "Earliest date": "2023-02-14",
+    "Latest date": "2023-07-04",
+    "Description": "Alias of XBB.1.5.39.2, S:K1045N, Canada-QC/USA-NY"
+  },
+  {
+    "Lineage": "FT.3",
+    "Earliest date": "2023-01-04",
+    "Latest date": "2023-10-12",
+    "Description": "Alias of XBB.1.5.39.3, S:Q52H, USA, from sars-cov-2-variants/lineage-proposals#266"
+  },
+  {
+    "Lineage": "FT.3.1",
+    "Earliest date": "2023-05-17",
+    "Latest date": "2024-01-17",
+    "Description": "Alias of XBB.1.5.39.3.1, S:K478R, S:D1168H, Canada/USA, from sars-cov-2-variants/lineage-proposals#266"
+  },
+  {
+    "Lineage": "FT.3.1.1",
+    "Earliest date": "2023-05-02",
+    "Latest date": "2023-12-26",
+    "Description": "Alias of XBB.1.5.39.3.1.1, S:A348S, USA, from #2140"
+  },
+  {
+    "Lineage": "FT.4",
+    "Earliest date": "2023-01-12",
+    "Latest date": "2023-05-20",
+    "Description": "Alias of XBB.1.5.39.4, S:E180Q, Germany"
+  },
+  {
+    "Lineage": "XBB.1.5.40",
+    "Earliest date": "2023-01-04",
+    "Latest date": "2023-12-15",
+    "Description": "S:478I, USA"
+  },
+  {
+    "Lineage": "XBB.1.5.41",
+    "Earliest date": "2022-12-26",
+    "Latest date": "2023-11-28",
+    "Description": "S:V772I, S:P521T, USA, from #1941"
+  },
+  {
+    "Lineage": "GU.1",
+    "Earliest date": "2023-01-18",
+    "Latest date": "2023-10-12",
+    "Description": "Alias of XBB.1.5.41.1, S:N481S, USA/Canada"
+  },
+  {
+    "Lineage": "XBB.1.5.42",
+    "Earliest date": "2023-01-13",
+    "Latest date": "2023-06-19",
+    "Description": "S:E281D, Asia/USA, from #1933"
+  },
+  {
+    "Lineage": "GR.1",
+    "Earliest date": "2023-02-01",
+    "Latest date": "2023-11-11",
+    "Description": "Alias of XBB.1.5.42.1, S:445S, Vietnam, from #1966"
+  },
+  {
+    "Lineage": "XBB.1.5.43",
+    "Earliest date": "2023-01-05",
+    "Latest date": "2023-07-28",
+    "Description": "C18501T, pre T17124C, Singapore/Malaysia/Indonesia"
+  },
+  {
+    "Lineage": "XBB.1.5.44",
+    "Earliest date": "2023-03-01",
+    "Latest date": "2023-12-04",
+    "Description": "S:K356T, S:T572I, USA, from #1907"
+  },
+  {
+    "Lineage": "HC.1",
+    "Earliest date": "2023-03-30",
+    "Latest date": "2023-09-19",
+    "Description": "Alias of XBB.1.5.44.1, S:P631S, USA, from sars-cov-2-variants/lineage-proposals#106"
+  },
+  {
+    "Lineage": "HC.2",
+    "Earliest date": "2023-06-11",
+    "Latest date": "2024-01-02",
+    "Description": "Alias of XBB.1.5.44.2, S:F157L, Canada, from #2202"
+  },
+  {
+    "Lineage": "HC.3",
+    "Earliest date": "2023-05-08",
+    "Latest date": "2023-12-09",
+    "Description": "Alias of XBB.1.5.44.3, S:P793S, USA"
+  },
+  {
+    "Lineage": "HC.4",
+    "Earliest date": "2023-06-18",
+    "Latest date": "2023-10-13",
+    "Description": "Alias of XBB.1.5.44.4, S:D1084H, ORF1a:A1352V, UK/Canada"
+  },
+  {
+    "Lineage": "XBB.1.5.45",
+    "Earliest date": "2023-02-08",
+    "Latest date": "2023-11-21",
+    "Description": "S:478R, C27425T, G28079T, pre T17124C, India-GJ/MH, from #1792"
+  },
+  {
+    "Lineage": "XBB.1.5.46",
+    "Earliest date": "2022-11-21",
+    "Latest date": "2024-07-23",
+    "Description": "C5770T, C15279T, Germany/France"
+  },
+  {
+    "Lineage": "GB.1",
+    "Earliest date": "2023-01-10",
+    "Latest date": "2023-11-24",
+    "Description": "Alias of XBB.1.5.46.1, S:L518V, France, from #1969"
+  },
+  {
+    "Lineage": "GB.2",
+    "Earliest date": "2023-02-09",
+    "Latest date": "2023-08-22",
+    "Description": "Alias of XBB.1.5.46.2, S:478R, England/China, from #1891"
+  },
+  {
+    "Lineage": "XBB.1.5.47",
+    "Earliest date": "2022-12-19",
+    "Latest date": "2023-10-30",
+    "Description": "C1912T, USA/England"
+  },
+  {
+    "Lineage": "FZ.1",
+    "Earliest date": "2022-12-22",
+    "Latest date": "2023-05-08",
+    "Description": "Alias of XBB.1.5.47.1, S:E583D, England/Scotland"
+  },
+  {
+    "Lineage": "FZ.1.1",
+    "Earliest date": "2022-05-12",
+    "Latest date": "2024-01-12",
+    "Description": "Alias of XBB.1.5.47.1.1, S:L858I, England/Scotland"
+  },
+  {
+    "Lineage": "FZ.2",
+    "Earliest date": "2023-01-15",
+    "Latest date": "2023-07-31",
+    "Description": "Alias of XBB.1.5.47.2, S:Q836R, USA"
+  },
+  {
+    "Lineage": "XBB.1.5.48",
+    "Earliest date": "2022-11-28",
+    "Latest date": "2023-12-18",
+    "Description": "A24730T, USA/Canada/England"
+  },
+  {
+    "Lineage": "GV.1",
+    "Earliest date": "2022-12-16",
+    "Latest date": "2024-02-02",
+    "Description": "Alias of XBB.1.5.48.1, S:478R"
+  },
+  {
+    "Lineage": "XBB.1.5.49",
+    "Earliest date": "2022-03-09",
+    "Latest date": "2024-01-21",
+    "Description": "T6886C, USA"
+  },
+  {
+    "Lineage": "HT.1",
+    "Earliest date": "2022-12-27",
+    "Latest date": "2023-09-30",
+    "Description": "Alias of XBB.1.5.49.1, S:148T, T4798C, Mexico"
+  },
+  {
+    "Lineage": "HT.2",
+    "Earliest date": "2023-01-23",
+    "Latest date": "2023-10-20",
+    "Description": "Alias of XBB.1.5.49.2, S:T51I"
+  },
+  {
+    "Lineage": "XBB.1.5.50",
+    "Earliest date": "2023-01-08",
+    "Latest date": "2023-10-03",
+    "Description": "S:621S, N:T49I, USA/Canada"
+  },
+  {
+    "Lineage": "XBB.1.5.51",
+    "Earliest date": "2022-12-12",
+    "Latest date": "2023-10-17",
+    "Description": "ORF1a:D3009A, USA"
+  },
+  {
+    "Lineage": "XBB.1.5.52",
+    "Earliest date": "2022-11-22",
+    "Latest date": "2023-11-19",
+    "Description": "C3589T"
+  },
+  {
+    "Lineage": "XBB.1.5.53",
+    "Earliest date": "2023-02-01",
+    "Latest date": "2023-11-12",
+    "Description": "S:F140I, S:L582F, S:R403K, South Africa, from #1804"
+  },
+  {
+    "Lineage": "JB.1",
+    "Earliest date": "2023-03-05",
+    "Latest date": "2023-09-14",
+    "Description": "Alias of XBB.1.5.53.1, S:N148T, South Africa"
+  },
+  {
+    "Lineage": "JB.1.1",
+    "Earliest date": "2023-08-03",
+    "Latest date": "2023-10-17",
+    "Description": "Alias of XBB.1.5.53.1.1, S:K478R, South Africa"
+  },
+  {
+    "Lineage": "JB.2",
+    "Earliest date": "2023-04-26",
+    "Latest date": "2023-12-02",
+    "Description": "Alias of XBB.1.5.53.2, S:K478R, South Africa/USA, from sars-cov-2-variants/lineage-proposals#209"
+  },
+  {
+    "Lineage": "JB.2.1",
+    "Earliest date": "2023-01-30",
+    "Latest date": "2023-11-01",
+    "Description": "Alias of XBB.1.5.53.2.1, S:H245Y, S:E554D, South Africa, from sars-cov-2-variants/lineage-proposals#209"
+  },
+  {
+    "Lineage": "XBB.1.5.54",
+    "Earliest date": "2023-01-30",
+    "Latest date": "2024-01-23",
+    "Description": "C14358T,C20016T,C29311T, Central/Eastern Europe"
+  },
+  {
+    "Lineage": "XBB.1.5.55",
+    "Earliest date": "2022-01-25",
+    "Latest date": "2023-08-10",
+    "Description": "ORF1a:T3356I, USA/Canada"
+  },
+  {
+    "Lineage": "HP.1",
+    "Earliest date": "2023-01-21",
+    "Latest date": "2023-08-10",
+    "Description": "Alias of XBB.1.5.55.1, N:L13F, USA/Mexico, from sars-cov-2-variants/lineage-proposals#277"
+  },
+  {
+    "Lineage": "HP.1.1",
+    "Earliest date": "2023-04-29",
+    "Latest date": "2024-02-08",
+    "Description": "Alias of XBB.1.5.55.1.1, S:478R, Mexico, from sars-cov-2-variants/lineage-proposals#277"
+  },
+  {
+    "Lineage": "XBB.1.5.56",
+    "Earliest date": "2022-11-28",
+    "Latest date": "2023-08-30",
+    "Description": "S:A852S, USA"
+  },
+  {
+    "Lineage": "XBB.1.5.57",
+    "Earliest date": "2022-12-01",
+    "Latest date": "2023-09-19",
+    "Description": "A20379G, C28312T, pre-T17124C, probable Spike-donor of XBL, from #1973"
+  },
+  {
+    "Lineage": "XBB.1.5.58",
+    "Earliest date": "2023-01-16",
+    "Latest date": "2023-11-01",
+    "Description": "S:704L, ORF1b:V1607I, ORF6:D6G, pre T17124C, Guinea, from #1860"
+  },
+  {
+    "Lineage": "XBB.1.5.59",
+    "Earliest date": "2022-12-22",
+    "Latest date": "2024-01-18",
+    "Description": "S:F456L (T22928C), ORF1a:S2822P, England, from #1949"
+  },
+  {
+    "Lineage": "XBB.1.5.60",
+    "Earliest date": "2023-01-04",
+    "Latest date": "2023-08-22",
+    "Description": "S:M177I, ORF1a:T2106I, S:Q146K, Netherlands/Germany"
+  },
+  {
+    "Lineage": "XBB.1.5.61",
+    "Earliest date": "2022-12-04",
+    "Latest date": "2023-12-01",
+    "Description": "T11536C, USA"
+  },
+  {
+    "Lineage": "XBB.1.5.62",
+    "Earliest date": "2022-12-12",
+    "Latest date": "2023-11-20",
+    "Description": "C29095T"
+  },
+  {
+    "Lineage": "XBB.1.5.63",
+    "Earliest date": "2022-04-17",
+    "Latest date": "2023-08-24",
+    "Description": "C346T, Germany/Mauritius"
+  },
+  {
+    "Lineage": "XBB.1.5.64",
+    "Earliest date": "2022-12-11",
+    "Latest date": "2023-08-30",
+    "Description": "G8137A, C29708T, South Korea"
+  },
+  {
+    "Lineage": "XBB.1.5.65",
+    "Earliest date": "2023-01-01",
+    "Latest date": "2023-10-06",
+    "Description": "C583T, Germany"
+  },
+  {
+    "Lineage": "XBB.1.5.66",
+    "Earliest date": "2022-11-30",
+    "Latest date": "2024-05-13",
+    "Description": "ORF1a:G519S, USA"
+  },
+  {
+    "Lineage": "XBB.1.5.67",
+    "Earliest date": "2022-11-17",
+    "Latest date": "2024-01-12",
+    "Description": "C21691T, USA"
+  },
+  {
+    "Lineage": "XBB.1.5.68",
+    "Earliest date": "2023-01-15",
+    "Latest date": "2023-10-10",
+    "Description": "S:P521T, ORF3a:L71I, C18501T, USA"
+  },
+  {
+    "Lineage": "HZ.1",
+    "Earliest date": "2023-03-12",
+    "Latest date": "2024-07-07",
+    "Description": "Alias of XBB.1.5.68.1, S:K478R, 23266T, USA, from sars-cov-2-variants/lineage-proposals#514"
+  },
+  {
+    "Lineage": "HZ.2",
+    "Earliest date": "2022-05-17",
+    "Latest date": "2024-01-06",
+    "Description": "Alias of XBB.1.5.68.2, ORF1a:H3580Y, USA"
+  },
+  {
+    "Lineage": "HZ.3",
+    "Earliest date": "2023-01-23",
+    "Latest date": "2023-10-13",
+    "Description": "Alias of XBB.1.5.68.3, ORF1a:I3693T, USA"
+  },
+  {
+    "Lineage": "XBB.1.5.69",
+    "Earliest date": "2022-12-05",
+    "Latest date": "2023-09-07",
+    "Description": "ORF1a:V2943I,C22513T, USA"
+  },
+  {
+    "Lineage": "XBB.1.5.70",
+    "Earliest date": "2022-10-18",
+    "Latest date": "2024-01-12",
+    "Description": "S:L455F (G22927T), S:F456L (T22928C), ORF1a:A4068S, Brazil, from #1982"
+  },
+  {
+    "Lineage": "GK.1",
+    "Earliest date": "2022-12-16",
+    "Latest date": "2024-02-04",
+    "Description": "Alias of XBB.1.5.70.1, S:S704L, Brazil, from #2025"
+  },
+  {
+    "Lineage": "GK.1.1",
+    "Earliest date": "2021-07-16",
+    "Latest date": "2024-04-21",
+    "Description": "Alias of XBB.1.5.70.1.1, S:T573I, Brazil"
+  },
+  {
+    "Lineage": "GK.1.1.1",
+    "Earliest date": "2022-10-02",
+    "Latest date": "2024-05-23",
+    "Description": "Alias of XBB.1.5.70.1.1.1, C28432T"
+  },
+  {
+    "Lineage": "GK.1.2",
+    "Earliest date": "2023-05-17",
+    "Latest date": "2023-12-05",
+    "Description": "Alias of XBB.1.5.70.1.2, S:N185D, Brazil, from #2093"
+  },
+  {
+    "Lineage": "GK.1.2.1",
+    "Earliest date": "2023-08-21",
+    "Latest date": "2024-03-16",
+    "Description": "Alias of XBB.1.5.70.1.2.1, S:A475V, ORF1a:D147G, ORF1a:D2592Y, ORF1a:T4175I, ORF1b:N1426K, Brazil/Colombia, from #2314"
+  },
+  {
+    "Lineage": "GK.1.3",
+    "Earliest date": "2023-01-24",
+    "Latest date": "2023-12-18",
+    "Description": "Alias of XBB.1.5.70.1.3, ORF1a:E633A, ORF1b:D1130G, USA/Canada, from sars-cov-2-variants/lineage-proposals#179"
+  },
+  {
+    "Lineage": "GK.1.4",
+    "Earliest date": "2023-07-11",
+    "Latest date": "2024-01-25",
+    "Description": "Alias of XBB.1.5.70.1.4, S:478R, S:98F, Brazil, from sars-cov-2-variants/lineage-proposals#504"
+  },
+  {
+    "Lineage": "GK.1.5",
+    "Earliest date": "2023-06-10",
+    "Latest date": "2024-01-22",
+    "Description": "Alias of XBB.1.5.70.1.5, S:F186L, ORF1a:T1597I, Brazil"
+  },
+  {
+    "Lineage": "GK.1.6",
+    "Earliest date": "2023-06-26",
+    "Latest date": "2024-01-11",
+    "Description": "Alias of XBB.1.5.70.1.6, ORF3a:V50I, Colombia, from sars-cov-2-variants/lineage-proposals#643"
+  },
+  {
+    "Lineage": "GK.1.6.1",
+    "Earliest date": "2023-08-06",
+    "Latest date": "2024-01-30",
+    "Description": "Alias of XBB.1.5.70.1.6.1, S:A475V, ORF1a:I114V, Colombia, from sars-cov-2-variants/lineage-proposals#643"
+  },
+  {
+    "Lineage": "GK.1.7",
+    "Earliest date": "2023-06-18",
+    "Latest date": "2023-12-04",
+    "Description": "Alias of XBB.1.5.70.1.7, S:F186L, T11695C, Europe"
+  },
+  {
+    "Lineage": "GK.1.8",
+    "Earliest date": "2023-07-15",
+    "Latest date": "2024-02-16",
+    "Description": "Alias of XBB.1.5.70.1.8, S:E554K, S:A475V, Brazil, from sars-cov-2-variants/lineage-proposals#643"
+  },
+  {
+    "Lineage": "GK.1.8.1",
+    "Earliest date": "2023-09-13",
+    "Latest date": "2024-01-04",
+    "Description": "Alias of XBB.1.5.70.1.8.1, S:K187I, S:A222P, Brazil/Paraguay, from sars-cov-2-variants/lineage-proposals#1127"
+  },
+  {
+    "Lineage": "GK.1.9",
+    "Earliest date": "2023-05-09",
+    "Latest date": "2023-11-19",
+    "Description": "Alias of XBB.1.5.70.1.9, C17010T, USA"
+  },
+  {
+    "Lineage": "GK.1.10",
+    "Earliest date": "2023-06-15",
+    "Latest date": "2024-02-06",
+    "Description": "Alias of XBB.1.5.70.1.10, Orf1a:I573V, Orf1a:T4129I, Orf9b:T95M, Brazil, from #2375"
+  },
+  {
+    "Lineage": "GK.1.10.1",
+    "Earliest date": "2023-09-11",
+    "Latest date": "2023-12-26",
+    "Description": "Alias of XBB.1.5.70.1.10.1, S:A475V, C29668T, Brazil, from #2479"
+  },
+  {
+    "Lineage": "KN.1",
+    "Earliest date": "2023-09-20",
+    "Latest date": "2024-02-21",
+    "Description": "Alias of XBB.1.5.70.1.10.1.1, S:Y200C, Brazil, from #2479"
+  },
+  {
+    "Lineage": "KN.1.1",
+    "Earliest date": "2023-11-22",
+    "Latest date": "2024-02-17",
+    "Description": "Alias of XBB.1.5.70.1.10.1.1.1, S:N450D, Brazil, from #2479"
+  },
+  {
+    "Lineage": "GK.1.11",
+    "Earliest date": "2023-07-03",
+    "Latest date": "2023-12-29",
+    "Description": "Alias of XBB.1.5.70.1.11, S:A475V, ORF1a:P309L, Brazil, from sars-cov-2-variants/lineage-proposals#643"
+  },
+  {
+    "Lineage": "GK.1.11.1",
+    "Earliest date": "2023-08-07",
+    "Latest date": "2024-01-17",
+    "Description": "Alias of XBB.1.5.70.1.11.1, S:I68V, Brazil"
+  },
+  {
+    "Lineage": "GK.2",
+    "Earliest date": "2023-02-21",
+    "Latest date": "2024-01-26",
+    "Description": "Alias of XBB.1.5.70.2, S:V511I, from sars-cov-2-variants/lineage-proposals#300"
+  },
+  {
+    "Lineage": "GK.2.1",
+    "Earliest date": "2021-07-16",
+    "Latest date": "2024-02-22",
+    "Description": "Alias of XBB.1.5.70.2.1, ORF1a:L624I, ORF1a:L3641S, ORF1b:S763C"
+  },
+  {
+    "Lineage": "GK.2.1.1",
+    "Earliest date": "2023-06-25",
+    "Latest date": "2023-10-26",
+    "Description": "Alias of XBB.1.5.70.2.1.1, S:P1162S, from sars-cov-2-variants/lineage-proposals#716"
+  },
+  {
+    "Lineage": "GK.2.2",
+    "Earliest date": "2023-06-06",
+    "Latest date": "2023-10-28",
+    "Description": "Alias of XBB.1.5.70.2.2, S:E554D, from sars-cov-2-variants/lineage-proposals#470"
+  },
+  {
+    "Lineage": "GK.2.3",
+    "Earliest date": "2023-08-04",
+    "Latest date": "2023-12-16",
+    "Description": "Alias of XBB.1.5.70.2.3, S:K356T, England, from sars-cov-2-variants/lineage-proposals#813"
+  },
+  {
+    "Lineage": "GK.2.4",
+    "Earliest date": "2023-08-30",
+    "Latest date": "2024-01-21",
+    "Description": "Alias of XBB.1.5.70.2.4, S:K356T, USA-NY, from sars-cov-2-variants/lineage-proposals#823"
+  },
+  {
+    "Lineage": "GK.3",
+    "Earliest date": "2023-05-02",
+    "Latest date": "2023-10-18",
+    "Description": "Alias of XBB.1.5.70.3, ORF1a:A876S, Brazil/USA/Canada"
+  },
+  {
+    "Lineage": "GK.3.1",
+    "Earliest date": "2023-07-11",
+    "Latest date": "2024-01-17",
+    "Description": "Alias of XBB.1.5.70.3.1, S:A475V, USA, from sars-cov-2-variants/lineage-proposals#643"
+  },
+  {
+    "Lineage": "GK.3.2",
+    "Earliest date": "2023-07-13",
+    "Latest date": "2023-11-23",
+    "Description": "Alias of XBB.1.5.70.3.2, S:T572I, USA, from #2272"
+  },
+  {
+    "Lineage": "GK.4",
+    "Earliest date": "2022-10-18",
+    "Latest date": "2023-12-23",
+    "Description": "Alias of XBB.1.5.70.4, S:A475V, ORF1a:T2859I, ORF1ab:T4711I, from #2276"
+  },
+  {
+    "Lineage": "GK.5",
+    "Earliest date": "2023-05-21",
+    "Latest date": "2023-08-21",
+    "Description": "Alias of XBB.1.5.70.5, S:G181V, Brazil, from sars-cov-2-variants/lineage-proposals#736"
+  },
+  {
+    "Lineage": "GK.5.1",
+    "Earliest date": "2023-07-11",
+    "Latest date": "2024-01-22",
+    "Description": "Alias of XBB.1.5.70.5.1, S:E180K, from sars-cov-2-variants/lineage-proposals#736"
+  },
+  {
+    "Lineage": "GK.6",
+    "Earliest date": "2023-05-30",
+    "Latest date": "2023-12-11",
+    "Description": "Alias of XBB.1.5.70.6, S:N556K, S:E583A, from sars-cov-2-variants/lineage-proposals#715"
+  },
+  {
+    "Lineage": "GK.7",
+    "Earliest date": "2023-05-30",
+    "Latest date": "2023-12-09",
+    "Description": "Alias of XBB.1.5.70.7, N:D3G, from sars-cov-2-variants/lineage-proposals#907"
+  },
+  {
+    "Lineage": "GK.8",
+    "Earliest date": "2023-03-27",
+    "Latest date": "2023-11-26",
+    "Description": "Alias of XBB.1.5.70.8, ORF6:E55Q, Brazil, from sars-cov-2-variants/lineage-proposals#909"
+  },
+  {
+    "Lineage": "GK.8.1",
+    "Earliest date": "2023-09-06",
+    "Latest date": "2024-01-12",
+    "Description": "Alias of XBB.1.5.70.8.1, S:N185I, S:A475V, from sars-cov-2-variants/lineage-proposals#909"
+  },
+  {
+    "Lineage": "GK.9",
+    "Earliest date": "2023-05-10",
+    "Latest date": "2023-12-04",
+    "Description": "Alias of XBB.1.5.70.9, S:T307S, Brazil"
+  },
+  {
+    "Lineage": "GK.10",
+    "Earliest date": "2023-05-18",
+    "Latest date": "2024-02-29",
+    "Description": "Alias of XBB.1.5.70.10, S:E554G, Brazil, from sars-cov-2-variants/lineage-proposals#761"
+  },
+  {
+    "Lineage": "GK.11",
+    "Earliest date": "2023-05-28",
+    "Latest date": "2023-11-29",
+    "Description": "Alias of XBB.1.5.70.11, S:T883I, Brazil"
+  },
+  {
+    "Lineage": "GK.12",
+    "Earliest date": "2023-08-28",
+    "Latest date": "2023-10-30",
+    "Description": "Alias of XBB.1.5.70.12, S:T76I, S:N450D, Brazil"
+  },
+  {
+    "Lineage": "XBB.1.5.71",
+    "Earliest date": "2023-02-01",
+    "Latest date": "2023-12-29",
+    "Description": "S:V511I, Spain"
+  },
+  {
+    "Lineage": "XBB.1.5.72",
+    "Earliest date": "2022-10-18",
+    "Latest date": "2024-07-12",
+    "Description": "S:F456L (T22928C), ORF1a:G445S, T9823C, T10204C, South America"
+  },
+  {
+    "Lineage": "XBB.1.5.73",
+    "Earliest date": "2022-12-22",
+    "Latest date": "2024-01-31",
+    "Description": "T28271C, USA/Peru"
+  },
+  {
+    "Lineage": "GN.1",
+    "Earliest date": "2023-03-05",
+    "Latest date": "2024-01-12",
+    "Description": "Alias of XBB.1.5.73.1, S:F456L (T22928C), Peru/Costa Rica"
+  },
+  {
+    "Lineage": "GN.1.1",
+    "Earliest date": "2023-05-05",
+    "Latest date": "2024-01-12",
+    "Description": "Alias of XBB.1.5.73.1.1, ORF1b:A1643V, Peru"
+  },
+  {
+    "Lineage": "GN.1.2",
+    "Earliest date": "2023-06-16",
+    "Latest date": "2024-01-20",
+    "Description": "Alias of XBB.1.5.73.1.2, S:Q321L"
+  },
+  {
+    "Lineage": "GN.1.3",
+    "Earliest date": "2023-08-30",
+    "Latest date": "2024-05-04",
+    "Description": "Alias of XBB.1.5.73.1.3, S:L455F (G22927T), from sars-cov-2-variants/lineage-proposals#816"
+  },
+  {
+    "Lineage": "GN.1.4",
+    "Earliest date": "2023-08-17",
+    "Latest date": "2024-01-14",
+    "Description": "Alias of XBB.1.5.73.1.4, S:G181V, Peru, from #2349"
+  },
+  {
+    "Lineage": "GN.2",
+    "Earliest date": "2023-04-07",
+    "Latest date": "2023-09-18",
+    "Description": "Alias of XBB.1.5.73.2, ORF3a:A99G, Peru"
+  },
+  {
+    "Lineage": "GN.3",
+    "Earliest date": "2023-02-21",
+    "Latest date": "2023-12-04",
+    "Description": "Alias of XBB.1.5.73.3, C27143T, Peru"
+  },
+  {
+    "Lineage": "GN.4",
+    "Earliest date": "2023-03-23",
+    "Latest date": "2023-10-10",
+    "Description": "Alias of XBB.1.5.73.4, ORF1a:Q3966L, Peru"
+  },
+  {
+    "Lineage": "GN.5",
+    "Earliest date": "2022-12-07",
+    "Latest date": "2023-07-10",
+    "Description": "Alias of XBB.1.5.73.5, ORF1a:L1110I, ORF1a:S4135F, Peru"
+  },
+  {
+    "Lineage": "XBB.1.5.74",
+    "Earliest date": "2023-03-18",
+    "Latest date": "2023-07-19",
+    "Description": "S:K462R, ORF1b:V728I, Peru, from #1998"
+  },
+  {
+    "Lineage": "XBB.1.5.75",
+    "Earliest date": "2022-12-05",
+    "Latest date": "2023-09-05",
+    "Description": "C3695T, Peru/France"
+  },
+  {
+    "Lineage": "XBB.1.5.76",
+    "Earliest date": "2023-01-09",
+    "Latest date": "2023-11-30",
+    "Description": "ORF1a:T3696A, Chile"
+  },
+  {
+    "Lineage": "XBB.1.5.77",
+    "Earliest date": "2021-07-16",
+    "Latest date": "2023-12-11",
+    "Description": "T18732C, Colombia/USA"
+  },
+  {
+    "Lineage": "HR.1",
+    "Earliest date": "2021-07-16",
+    "Latest date": "2023-11-23",
+    "Description": "Alias of XBB.1.5.77.1, S:478R, N:I292V, Costa Rica/USA, from sars-cov-2-variants/lineage-proposals#323"
+  },
+  {
+    "Lineage": "HR.1.1",
+    "Earliest date": "2023-07-05",
+    "Latest date": "2024-01-17",
+    "Description": "Alias of XBB.1.5.77.1.1, S:K304N, Costa Rica, from #2372"
+  },
+  {
+    "Lineage": "XBB.1.5.78",
+    "Earliest date": "2022-12-15",
+    "Latest date": "2023-11-13",
+    "Description": "ORF1a:N460D, Mexico"
+  },
+  {
+    "Lineage": "XBB.1.5.79",
+    "Earliest date": "2022-01-23",
+    "Latest date": "2023-08-01",
+    "Description": "N:Q260L, Mexico/USA"
+  },
+  {
+    "Lineage": "XBB.1.5.80",
+    "Earliest date": "2022-12-16",
+    "Latest date": "2023-09-22",
+    "Description": "A16812G, C21812T, USA/Romania"
+  },
+  {
+    "Lineage": "XBB.1.5.81",
+    "Earliest date": "2023-02-26",
+    "Latest date": "2023-11-25",
+    "Description": "S:478R, G4657A, South Africa"
+  },
+  {
+    "Lineage": "XBB.1.5.82",
+    "Earliest date": "2023-01-27",
+    "Latest date": "2024-02-19",
+    "Description": "S:K444R, Sweden/Reunion"
+  },
+  {
+    "Lineage": "XBB.1.5.83",
+    "Earliest date": "2023-01-21",
+    "Latest date": "2023-12-20",
+    "Description": "A10624G, South Africa"
+  },
+  {
+    "Lineage": "XBB.1.5.84",
+    "Earliest date": "2023-01-11",
+    "Latest date": "2023-09-25",
+    "Description": "S:M177I, South Africa"
+  },
+  {
+    "Lineage": "XBB.1.5.85",
+    "Earliest date": "2023-01-18",
+    "Latest date": "2023-10-14",
+    "Description": "S:L176F, S:478R, Trinidad and Tobago/Hong Kong"
+  },
+  {
+    "Lineage": "XBB.1.5.86",
+    "Earliest date": "2022-12-01",
+    "Latest date": "2023-12-22",
+    "Description": "ORF1a:G2868S, Brazil"
+  },
+  {
+    "Lineage": "HA.1",
+    "Earliest date": "2023-04-10",
+    "Latest date": "2023-11-30",
+    "Description": "Alias of XBB.1.5.86.1, S:F456L (T22930A), Brazil/Canada"
+  },
+  {
+    "Lineage": "HA.2",
+    "Earliest date": "2023-04-05",
+    "Latest date": "2023-11-15",
+    "Description": "Alias of XBB.1.5.86.2, S:P521S, Brazil"
+  },
+  {
+    "Lineage": "XBB.1.5.87",
+    "Earliest date": "2023-03-13",
+    "Latest date": "2023-06-14",
+    "Description": "S:478R, ORF1a:E1633K, ORF1a:M1588K, C9763T, C20946T, pre T17124C, Indonesia"
+  },
+  {
+    "Lineage": "XBB.1.5.88",
+    "Earliest date": "2021-10-04",
+    "Latest date": "2023-09-23",
+    "Description": "C2299T, South Africa"
+  },
+  {
+    "Lineage": "XBB.1.5.89",
+    "Earliest date": "2023-03-27",
+    "Latest date": "2023-12-20",
+    "Description": "S:478R, S:554A, Canada/Italy/France, from sars-cov-2-variants/lineage-proposals#175"
+  },
+  {
+    "Lineage": "XBB.1.5.90",
+    "Earliest date": "2023-01-02",
+    "Latest date": "2023-11-03",
+    "Description": "S:P621S, ORF1ab:S6713L, Belgium/France, from #1849"
+  },
+  {
+    "Lineage": "XBB.1.5.91",
+    "Earliest date": "2022-03-22",
+    "Latest date": "2024-06-06",
+    "Description": "S:P621S, USA"
+  },
+  {
+    "Lineage": "XBB.1.5.92",
+    "Earliest date": "2022-12-28",
+    "Latest date": "2023-08-30",
+    "Description": "ORF1a:T1168I, Ecuador"
+  },
+  {
+    "Lineage": "HQ.1",
+    "Earliest date": "2023-02-05",
+    "Latest date": "2023-10-12",
+    "Description": "Alias of XBB.1.5.92.1, S:E554K, Ecuador, from sars-cov-2-variants/lineage-proposals#170"
+  },
+  {
+    "Lineage": "XBB.1.5.93",
+    "Earliest date": "2023-01-23",
+    "Latest date": "2023-06-27",
+    "Description": "C337T, C19186T, USA, from sars-cov-2-variants/lineage-proposals#363"
+  },
+  {
+    "Lineage": "HD.1",
+    "Earliest date": "2023-05-05",
+    "Latest date": "2023-07-19",
+    "Description": "Alias of XBB.1.5.93.1, S:T346I, USA/Dominican Republic, from sars-cov-2-variants/lineage-proposals#363"
+  },
+  {
+    "Lineage": "HD.1.1",
+    "Earliest date": "2023-05-16",
+    "Latest date": "2023-08-17",
+    "Description": "Alias of XBB.1.5.93.1.1, S:K356T, Dominican Republic, from sars-cov-2-variants/lineage-proposals#363"
+  },
+  {
+    "Lineage": "XBB.1.5.94",
+    "Earliest date": "2022-12-19",
+    "Latest date": "2023-10-30",
+    "Description": "S:Q613H, T25461C, France"
+  },
+  {
+    "Lineage": "XBB.1.5.95",
+    "Earliest date": "2022-12-12",
+    "Latest date": "2023-11-18",
+    "Description": "ORF1a:A1851V"
+  },
+  {
+    "Lineage": "HS.1",
+    "Earliest date": "2023-01-27",
+    "Latest date": "2023-11-23",
+    "Description": "Alias of XBB.1.5.95.1, S:478R, Mexico"
+  },
+  {
+    "Lineage": "HS.1.1",
+    "Earliest date": "2023-05-05",
+    "Latest date": "2023-11-18",
+    "Description": "Alias of XBB.1.5.95.1.1, S:F456L (T22928C), USA, from #2237"
+  },
+  {
+    "Lineage": "XBB.1.5.96",
+    "Earliest date": "2022-12-03",
+    "Latest date": "2023-09-08",
+    "Description": "C28603T"
+  },
+  {
+    "Lineage": "XBB.1.5.97",
+    "Earliest date": "2023-01-04",
+    "Latest date": "2023-08-25",
+    "Description": "S:T941S, C7834T, New Zealand/Australia"
+  },
+  {
+    "Lineage": "XBB.1.5.98",
+    "Earliest date": "2023-03-08",
+    "Latest date": "2023-11-18",
+    "Description": "S:E554K, ORF8:V32L, Ghana"
+  },
+  {
+    "Lineage": "XBB.1.5.99",
+    "Earliest date": "2021-11-22",
+    "Latest date": "2023-06-20",
+    "Description": "ORF1a:V1122A, ORF1a:T2121I, Slovakia/Austria"
+  },
+  {
+    "Lineage": "XBB.1.5.100",
+    "Earliest date": "2023-01-03",
+    "Latest date": "2023-12-14",
+    "Description": "S:V1122M, USA/Mexico"
+  },
+  {
+    "Lineage": "HY.1",
+    "Earliest date": "2022-10-18",
+    "Latest date": "2024-01-02",
+    "Description": "Alias of XBB.1.5.100.1, S:478R, USA/Mexico, from sars-cov-2-variants/lineage-proposals#453"
+  },
+  {
+    "Lineage": "XBB.1.5.101",
+    "Earliest date": "2023-02-07",
+    "Latest date": "2023-07-31",
+    "Description": "ORF7a:E3Q, C14877T, Scandinavia/Poland/Vietnam"
+  },
+  {
+    "Lineage": "XBB.1.5.102",
+    "Earliest date": "2022-12-09",
+    "Latest date": "2024-01-22",
+    "Description": "C6896T, C14085T, C19488T, Brazil-Amazonas"
+  },
+  {
+    "Lineage": "JD.1",
+    "Earliest date": "2023-05-11",
+    "Latest date": "2024-04-26",
+    "Description": "Alias of XBB.1.5.102.1, S:L455F (G22927T), S:F456L (T22928C), A14634G, T28282C, Brazil, from #2071"
+  },
+  {
+    "Lineage": "JD.1.1",
+    "Earliest date": "2021-07-16",
+    "Latest date": "2024-05-12",
+    "Description": "Alias of XBB.1.5.102.1.1, S:A475V, Brazil/USA/Spain, from #2174"
+  },
+  {
+    "Lineage": "JD.1.1.1",
+    "Earliest date": "2021-09-21",
+    "Latest date": "2024-03-26",
+    "Description": "Alias of XBB.1.5.102.1.1.1, S:Y248H, from sars-cov-2-variants/lineage-proposals#864"
+  },
+  {
+    "Lineage": "JD.1.1.2",
+    "Earliest date": "2023-07-27",
+    "Latest date": "2024-02-01",
+    "Description": "Alias of XBB.1.5.102.1.1.2, S:E583D, Ireland/UK, from sars-cov-2-variants/lineage-proposals#754"
+  },
+  {
+    "Lineage": "JD.1.1.3",
+    "Earliest date": "2023-08-14",
+    "Latest date": "2024-03-18",
+    "Description": "Alias of XBB.1.5.102.1.1.3, S:T470N, ORF1a:V1584M, France/Denmark, from sars-cov-2-variants/lineage-proposals#896"
+  },
+  {
+    "Lineage": "JD.1.1.4",
+    "Earliest date": "2023-09-22",
+    "Latest date": "2024-03-07",
+    "Description": "Alias of XBB.1.5.102.1.1.4, S:E554G, Australia, from #2380"
+  },
+  {
+    "Lineage": "JD.1.1.5",
+    "Earliest date": "2023-09-18",
+    "Latest date": "2024-02-18",
+    "Description": "Alias of XBB.1.5.102.1.1.5, S:Q677R, USA/Canada, from sars-cov-2-variants/lineage-proposals#1079"
+  },
+  {
+    "Lineage": "JD.1.1.6",
+    "Earliest date": "2023-09-27",
+    "Latest date": "2024-02-24",
+    "Description": "Alias of XBB.1.5.102.1.1.6, S:M153V, Brazil"
+  },
+  {
+    "Lineage": "JD.1.1.7",
+    "Earliest date": "2022-10-30",
+    "Latest date": "2024-03-29",
+    "Description": "Alias of XBB.1.5.102.1.1.7, ORF1b:R2257S"
+  },
+  {
+    "Lineage": "JD.1.1.8",
+    "Earliest date": "2023-07-22",
+    "Latest date": "2024-05-08",
+    "Description": "Alias of XBB.1.5.102.1.1.8, ORF1a:N1094K, without C19185T, Brazil"
+  },
+  {
+    "Lineage": "KK.1",
+    "Earliest date": "2023-08-24",
+    "Latest date": "2024-03-15",
+    "Description": "Alias of XBB.1.5.102.1.1.8.1, S:D1153H, Brazil/USA, from sars-cov-2-variants/lineage-proposals#1210"
+  },
+  {
+    "Lineage": "KK.2",
+    "Earliest date": "2023-10-05",
+    "Latest date": "2024-02-06",
+    "Description": "Alias of XBB.1.5.102.1.1.8.2, S:N481K, Brazil, from sars-cov-2-variants/lineage-proposals#1277"
+  },
+  {
+    "Lineage": "JD.1.2",
+    "Earliest date": "2023-03-11",
+    "Latest date": "2023-12-22",
+    "Description": "Alias of XBB.1.5.102.1.2, S:P1162S, Brazil, from sars-cov-2-variants/lineage-proposals#136"
+  },
+  {
+    "Lineage": "JD.1.2.1",
+    "Earliest date": "2023-08-08",
+    "Latest date": "2024-01-23",
+    "Description": "Alias of XBB.1.5.102.1.2.1, S:E554Q, from sars-cov-2-variants/lineage-proposals#870"
+  },
+  {
+    "Lineage": "JD.1.2.2",
+    "Earliest date": "2023-06-02",
+    "Latest date": "2023-12-28",
+    "Description": "Alias of XBB.1.5.102.1.2.2, S:A1078T, Brazil"
+  },
+  {
+    "Lineage": "JD.2",
+    "Earliest date": "2022-12-11",
+    "Latest date": "2023-08-03",
+    "Description": "Alias of XBB.1.5.102.2, ORF1b:H2388Y, G4255A, Brazil"
+  },
+  {
+    "Lineage": "JD.2.1",
+    "Earliest date": "2023-05-01",
+    "Latest date": "2023-10-17",
+    "Description": "Alias of XBB.1.5.102.2.1, S:E554K, Brazil"
+  },
+  {
+    "Lineage": "XBB.1.5.103",
+    "Earliest date": "2023-04-18",
+    "Latest date": "2024-01-27",
+    "Description": "S:F456L (T22928C), S:180/184del, S:N185D, ORF1a:T1437I, ORF7b:C41W, T21357C, Argentina, from #2192"
+  },
+  {
+    "Lineage": "KA.1",
+    "Earliest date": "2023-06-06",
+    "Latest date": "2024-01-30",
+    "Description": "Alias of XBB.1.5.103.1, S:E554K, Argentina/France/Spain, from sars-cov-2-variants/lineage-proposals#822"
+  },
+  {
+    "Lineage": "XBB.1.5.104",
+    "Earliest date": "2023-01-18",
+    "Latest date": "2023-10-21",
+    "Description": "S:K304Q, USA, from #1798"
+  },
+  {
+    "Lineage": "XBB.1.5.105",
+    "Earliest date": "2023-04-20",
+    "Latest date": "2023-11-27",
+    "Description": "S:K304N, USA/Europe"
+  },
+  {
+    "Lineage": "XBB.1.5.106",
+    "Earliest date": "2023-03-20",
+    "Latest date": "2024-02-09",
+    "Description": "S:A623V, ORF1a:V28I, ORF1a:R3542H, Guatemala, from #2270"
+  },
+  {
+    "Lineage": "XBB.1.5.107",
+    "Earliest date": "2022-11-28",
+    "Latest date": "2023-12-06",
+    "Description": "C24130T, Argentina/Uruguay/Bolivia"
+  },
+  {
+    "Lineage": "JZ.1",
+    "Earliest date": "2023-03-30",
+    "Latest date": "2023-12-11",
+    "Description": "Alias of XBB.1.5.107.1, S:F456L (T22928C), Argentina/Brazil, from sars-cov-2-variants/lineage-proposals#224"
+  },
+  {
+    "Lineage": "XBB.1.5.108",
+    "Earliest date": "2023-06-09",
+    "Latest date": "2023-12-01",
+    "Description": "S:F456L (T22930A), S:K304N , from sars-cov-2-variants/lineage-proposals#550"
+  },
+  {
+    "Lineage": "XBB.1.5.109",
+    "Earliest date": "2023-05-11",
+    "Latest date": "2024-01-26",
+    "Description": "S:F456L (T22928C), ORF1a:T654A, from #2262"
+  },
+  {
+    "Lineage": "XBB.1.5.110",
+    "Earliest date": "2022-12-23",
+    "Latest date": "2024-02-06",
+    "Description": "ORF1aT4129I, Mexico"
+  },
+  {
+    "Lineage": "XBB.1.6",
+    "Earliest date": "2022-10-07",
+    "Latest date": "2023-02-16",
+    "Description": "USA, S:L216F, S:H146K, from #1428"
+  },
+  {
+    "Lineage": "XBB.1.7",
+    "Earliest date": "2022-11-03",
+    "Latest date": "2023-03-15",
+    "Description": "USA-NY, S:V608I"
+  },
+  {
+    "Lineage": "XBB.1.8",
+    "Earliest date": "2022-10-26",
+    "Latest date": "2023-01-30",
+    "Description": "Denmark, S:186insSGG, C3241T, from #1455"
+  },
+  {
+    "Lineage": "XBB.1.9",
+    "Earliest date": "2022-09-29",
+    "Latest date": "2024-02-01",
+    "Description": "ORF1a:G1819S, ORF1a:T4175I, on ORF9b:I5T branch"
+  },
+  {
+    "Lineage": "XBB.1.9.1",
+    "Earliest date": "2021-03-01",
+    "Latest date": "2024-05-26",
+    "Description": "S:F486P (after C11956T), Indonesia/Singapore/Malaysia/England"
+  },
+  {
+    "Lineage": "FL.1",
+    "Earliest date": "2023-01-14",
+    "Latest date": "2023-12-04",
+    "Description": "Alias of XBB.1.9.1.1, S:701V, ORF1a:G993S, from #1808"
+  },
+  {
+    "Lineage": "FL.1.1",
+    "Earliest date": "2023-01-16",
+    "Latest date": "2023-12-03",
+    "Description": "Alias of XBB.1.9.1.1.1, ORF1b:Q2635P, USA/Australia"
+  },
+  {
+    "Lineage": "FL.1.1.1",
+    "Earliest date": "2023-02-22",
+    "Latest date": "2023-07-04",
+    "Description": "Alias of XBB.1.9.1.1.1.1, S:A688S, Australia/Mauritius"
+  },
+  {
+    "Lineage": "FL.1.2",
+    "Earliest date": "2022-10-18",
+    "Latest date": "2023-09-12",
+    "Description": "Alias of XBB.1.9.1.1.2, ORF1a:T4311I, South Korea/Italy/Spain"
+  },
+  {
+    "Lineage": "FL.1.3",
+    "Earliest date": "2023-02-28",
+    "Latest date": "2023-10-03",
+    "Description": "Alias of XBB.1.9.1.1.3, ORF1a:T1881I, ORF1b:M606I, South Korea"
+  },
+  {
+    "Lineage": "FL.1.4",
+    "Earliest date": "2023-03-16",
+    "Latest date": "2023-10-12",
+    "Description": "Alias of XBB.1.9.1.1.4, S:478R, S:Q1208H, Vietnam, from #1985"
+  },
+  {
+    "Lineage": "FL.1.5",
+    "Earliest date": "2023-04-11",
+    "Latest date": "2023-12-22",
+    "Description": "Alias of XBB.1.9.1.1.5, S:F456L (T22928C), ORF1b:K2557R, from #2036"
+  },
+  {
+    "Lineage": "FL.1.5.1",
+    "Earliest date": "2022-10-12",
+    "Latest date": "2024-04-18",
+    "Description": "Alias of XBB.1.9.1.1.5.1, S:478R, from #2036"
+  },
+  {
+    "Lineage": "HN.1",
+    "Earliest date": "2023-02-20",
+    "Latest date": "2024-02-12",
+    "Description": "Alias of XBB.1.9.1.1.5.1.1, S:A67S, Dominican Republic, from sars-cov-2-variants/lineage-proposals#408"
+  },
+  {
+    "Lineage": "HN.2",
+    "Earliest date": "2023-02-17",
+    "Latest date": "2024-01-16",
+    "Description": "Alias of XBB.1.9.1.1.5.1.2, ORF1b:P223S, from sars-cov-2-variants/lineage-proposals#676"
+  },
+  {
+    "Lineage": "HN.2.1",
+    "Earliest date": "2021-12-22",
+    "Latest date": "2024-04-29",
+    "Description": "Alias of XBB.1.9.1.1.5.1.2.1, S:Q836R, from sars-cov-2-variants/lineage-proposals#676"
+  },
+  {
+    "Lineage": "HN.3",
+    "Earliest date": "2023-06-12",
+    "Latest date": "2023-11-22",
+    "Description": "Alias of XBB.1.9.1.1.5.1.3, S:S494P"
+  },
+  {
+    "Lineage": "HN.3.1",
+    "Earliest date": "2023-07-28",
+    "Latest date": "2023-12-29",
+    "Description": "Alias of XBB.1.9.1.1.5.1.3.1, S:D253G, from sars-cov-2-variants/lineage-proposals#383"
+  },
+  {
+    "Lineage": "HN.4",
+    "Earliest date": "2022-07-26",
+    "Latest date": "2024-01-31",
+    "Description": "Alias of XBB.1.9.1.1.5.1.4, ORF1a:T403I"
+  },
+  {
+    "Lineage": "HN.4.1",
+    "Earliest date": "2023-07-10",
+    "Latest date": "2023-12-10",
+    "Description": "Alias of XBB.1.9.1.1.5.1.4.1, S:A1020S, from sars-cov-2-variants/lineage-proposals#1054"
+  },
+  {
+    "Lineage": "HN.4.1.1",
+    "Earliest date": "2023-10-17",
+    "Latest date": "2024-02-07",
+    "Description": "Alias of XBB.1.9.1.1.5.1.4.1.1, S:I68T, S:L452R, S:E554K, New Zealand/Canada, from sars-cov-2-variants/lineage-proposals#1054"
+  },
+  {
+    "Lineage": "HN.4.2",
+    "Earliest date": "2023-08-18",
+    "Latest date": "2023-12-18",
+    "Description": "Alias of XBB.1.9.1.1.5.1.4.2, S:Q14H, Georgia/Russia, from sars-cov-2-variants/lineage-proposals#971"
+  },
+  {
+    "Lineage": "HN.5",
+    "Earliest date": "2023-01-12",
+    "Latest date": "2024-03-08",
+    "Description": "Alias of XBB.1.9.1.1.5.1.5, S:E554K, from sars-cov-2-variants/lineage-proposals#936"
+  },
+  {
+    "Lineage": "HN.6",
+    "Earliest date": "2023-05-26",
+    "Latest date": "2024-01-06",
+    "Description": "Alias of XBB.1.9.1.1.5.1.6, ORF1a:D1933A"
+  },
+  {
+    "Lineage": "HN.7",
+    "Earliest date": "2023-06-16",
+    "Latest date": "2024-01-10",
+    "Description": "Alias of XBB.1.9.1.1.5.1.7, C6388T, T20028C, C20115T, Europe"
+  },
+  {
+    "Lineage": "HN.8",
+    "Earliest date": "2023-09-11",
+    "Latest date": "2024-02-01",
+    "Description": "Alias of XBB.1.9.1.1.5.1.8, S:ins248KRD, ORF1a:E2042D, not requiring S:494P, Haiti/USA, from #2438"
+  },
+  {
+    "Lineage": "FL.1.5.2",
+    "Earliest date": "2023-06-26",
+    "Latest date": "2024-03-06",
+    "Description": "Alias of XBB.1.9.1.1.5.2, S:N481K, S:H681R, England/France/Denmark, from sars-cov-2-variants/lineage-proposals#614"
+  },
+  {
+    "Lineage": "KC.1",
+    "Earliest date": "2022-10-18",
+    "Latest date": "2024-03-15",
+    "Description": "Alias of XBB.1.9.1.1.5.2.1, S:S490P, ORF1a:T4129I, ORF1a:S723F, Europe, from sars-cov-2-variants/lineage-proposals#614"
+  },
+  {
+    "Lineage": "KC.1.1",
+    "Earliest date": "2023-09-08",
+    "Latest date": "2024-01-23",
+    "Description": "Alias of XBB.1.9.1.1.5.2.1.1, S:V1228L, England"
+  },
+  {
+    "Lineage": "FL.1.6",
+    "Earliest date": "2023-04-03",
+    "Latest date": "2023-09-07",
+    "Description": "Alias of XBB.1.9.1.1.6, S:N481K, S:Q1208H, from sars-cov-2-variants/lineage-proposals#59"
+  },
+  {
+    "Lineage": "FL.1.7",
+    "Earliest date": "2023-02-27",
+    "Latest date": "2023-06-22",
+    "Description": "Alias of XBB.1.9.1.1.7, S:478R, S:C1235F, Indonesia, from #1985"
+  },
+  {
+    "Lineage": "FL.1.8",
+    "Earliest date": "2023-06-05",
+    "Latest date": "2024-02-08",
+    "Description": "Alias of XBB.1.9.1.1.8, S:K478R, S:P521T, M:I8V, Russia, from sars-cov-2-variants/lineage-proposals#1058"
+  },
+  {
+    "Lineage": "FL.2",
+    "Earliest date": "2022-12-04",
+    "Latest date": "2023-10-24",
+    "Description": "Alias of XBB.1.9.1.2, T4579A"
+  },
+  {
+    "Lineage": "FL.2.1",
+    "Earliest date": "2023-01-10",
+    "Latest date": "2023-09-07",
+    "Description": "Alias of XBB.1.9.1.2.1, C10228T, Germany, global"
+  },
+  {
+    "Lineage": "FL.2.2",
+    "Earliest date": "2023-05-03",
+    "Latest date": "2023-07-04",
+    "Description": "Alias of XBB.1.9.1.2.2, S:T478R, Indonesia, from #1927"
+  },
+  {
+    "Lineage": "FL.2.2.1",
+    "Earliest date": "2023-03-03",
+    "Latest date": "2023-11-20",
+    "Description": "Alias of XBB.1.9.1.2.2.1, S:T307I, Indonesia, from #2027"
+  },
+  {
+    "Lineage": "FL.2.3",
+    "Earliest date": "2023-01-03",
+    "Latest date": "2023-11-20",
+    "Description": "Alias of XBB.1.9.1.2.3, ORF1b:K1383R, China, from #2016"
+  },
+  {
+    "Lineage": "FL.2.3.1",
+    "Earliest date": "2023-05-04",
+    "Latest date": "2023-11-29",
+    "Description": "Alias of XBB.1.9.1.2.3.1, S:K356T, China"
+  },
+  {
+    "Lineage": "FL.2.4",
+    "Earliest date": "2023-03-17",
+    "Latest date": "2023-11-07",
+    "Description": "Alias of XBB.1.9.1.2.4, ORF8:S67F, China"
+  },
+  {
+    "Lineage": "FL.2.5",
+    "Earliest date": "2023-03-18",
+    "Latest date": "2023-11-01",
+    "Description": "Alias of XBB.1.9.1.2.5, S:Q314E, from sars-cov-2-variants/lineage-proposals#342"
+  },
+  {
+    "Lineage": "FL.2.6",
+    "Earliest date": "2023-03-15",
+    "Latest date": "2023-12-13",
+    "Description": "Alias of XBB.1.9.1.2.6, S:N641K, from #2180"
+  },
+  {
+    "Lineage": "FL.2.7",
+    "Earliest date": "2022-04-24",
+    "Latest date": "2024-03-18",
+    "Description": "Alias of XBB.1.9.1.2.7, ORF1a:A2618T, from sars-cov-2-variants/lineage-proposals#552"
+  },
+  {
+    "Lineage": "FL.2.7.1",
+    "Earliest date": "2023-03-05",
+    "Latest date": "2023-10-10",
+    "Description": "Alias of XBB.1.9.1.2.7.1, S:K478R on ORF1a:V3718F branch, South Africa, from sars-cov-2-variants/lineage-proposals#552"
+  },
+  {
+    "Lineage": "FL.3",
+    "Earliest date": "2022-12-25",
+    "Latest date": "2023-12-01",
+    "Description": "Alias of XBB.1.9.1.3, T1753C, England"
+  },
+  {
+    "Lineage": "FL.3.1",
+    "Earliest date": "2023-01-15",
+    "Latest date": "2024-01-11",
+    "Description": "Alias of XBB.1.9.1.3.1, ORF1a:T2264I, England"
+  },
+  {
+    "Lineage": "FL.3.2",
+    "Earliest date": "2022-10-18",
+    "Latest date": "2024-02-09",
+    "Description": "Alias of XBB.1.9.1.3.2, T8830C, England/Spain"
+  },
+  {
+    "Lineage": "FL.3.3",
+    "Earliest date": "2023-01-08",
+    "Latest date": "2024-06-04",
+    "Description": "Alias of XBB.1.9.1.3.3, ORF1a:A4285V,ORF1a:V2998I,ORF1a:E772K, England"
+  },
+  {
+    "Lineage": "FL.3.4",
+    "Earliest date": "2023-02-09",
+    "Latest date": "2023-06-23",
+    "Description": "Alias of XBB.1.9.1.3.4, G10642C, T26232C, England"
+  },
+  {
+    "Lineage": "FL.4",
+    "Earliest date": "2022-10-18",
+    "Latest date": "2024-07-01",
+    "Description": "Alias of XBB.1.9.1.4, ORF1b:V1092F"
+  },
+  {
+    "Lineage": "FL.4.1",
+    "Earliest date": "2023-01-19",
+    "Latest date": "2023-07-18",
+    "Description": "Alias of XBB.1.9.1.4.1, S:N450I"
+  },
+  {
+    "Lineage": "FL.4.1.1",
+    "Earliest date": "2023-04-04",
+    "Latest date": "2023-06-21",
+    "Description": "Alias of XBB.1.9.1.4.1.1, S:K478R, ORF1a:I2286T, Indonesia/Australia, from sars-cov-2-variants/lineage-proposals#107"
+  },
+  {
+    "Lineage": "FL.4.2",
+    "Earliest date": "2023-04-04",
+    "Latest date": "2023-09-12",
+    "Description": "Alias of XBB.1.9.1.4.2, ORF1a:T951I, China"
+  },
+  {
+    "Lineage": "FL.4.3",
+    "Earliest date": "2023-03-15",
+    "Latest date": "2023-10-06",
+    "Description": "Alias of XBB.1.9.1.4.3, S:A766S, G7393T, Myanmar, from sars-cov-2-variants/lineage-proposals#153"
+  },
+  {
+    "Lineage": "FL.4.4",
+    "Earliest date": "2023-03-16",
+    "Latest date": "2023-11-15",
+    "Description": "Alias of XBB.1.9.1.4.4, ORF1a:T1542I, T24544C, S:478T (reversion), Indonesia"
+  },
+  {
+    "Lineage": "FL.4.5",
+    "Earliest date": "2023-02-07",
+    "Latest date": "2023-12-22",
+    "Description": "Alias of XBB.1.9.1.4.5, ORF8:S67F, ORF1a:D1228G, C23635T, from #2018"
+  },
+  {
+    "Lineage": "FL.4.6",
+    "Earliest date": "2023-02-27",
+    "Latest date": "2023-11-09",
+    "Description": "Alias of XBB.1.9.1.4.6, T5098C, C13965T, Australia/China"
+  },
+  {
+    "Lineage": "FL.4.7",
+    "Earliest date": "2023-04-04",
+    "Latest date": "2023-07-26",
+    "Description": "Alias of XBB.1.9.1.4.7, S:L452R, Singapore, from sars-cov-2-variants/lineage-proposals#92"
+  },
+  {
+    "Lineage": "FL.4.8",
+    "Earliest date": "2023-03-14",
+    "Latest date": "2023-11-01",
+    "Description": "Alias of XBB.1.9.1.4.8, S:478R, Indonesia, from #2024"
+  },
+  {
+    "Lineage": "FL.4.9",
+    "Earliest date": "2023-03-20",
+    "Latest date": "2023-11-18",
+    "Description": "Alias of XBB.1.9.1.4.9, S:S254P, ORF3a:D173G, from #2081"
+  },
+  {
+    "Lineage": "FL.4.10",
+    "Earliest date": "2023-04-23",
+    "Latest date": "2023-09-08",
+    "Description": "Alias of XBB.1.9.1.4.10, S:V1129I, China, from #2087"
+  },
+  {
+    "Lineage": "FL.4.11",
+    "Earliest date": "2023-03-13",
+    "Latest date": "2023-09-19",
+    "Description": "Alias of XBB.1.9.1.4.11, S:D1259Y, N:T334I, China/Japan，from #2074"
+  },
+  {
+    "Lineage": "FL.5",
+    "Earliest date": "2022-04-17",
+    "Latest date": "2023-12-26",
+    "Description": "Alias of XBB.1.9.1.5, N:T362I"
+  },
+  {
+    "Lineage": "FL.5.1",
+    "Earliest date": "2023-02-27",
+    "Latest date": "2023-08-22",
+    "Description": "Alias of XBB.1.9.1.5.1, S:M177T, from #2041"
+  },
+  {
+    "Lineage": "FL.6",
+    "Earliest date": "2023-02-06",
+    "Latest date": "2023-09-26",
+    "Description": "Alias of XBB.1.9.1.6, ORF1a:I849V, Bahrain/Egypt/Oman/Austria"
+  },
+  {
+    "Lineage": "FL.7",
+    "Earliest date": "2022-10-18",
+    "Latest date": "2023-11-28",
+    "Description": "Alias of XBB.1.9.1.7, S:T51I"
+  },
+  {
+    "Lineage": "FL.8",
+    "Earliest date": "2023-01-04",
+    "Latest date": "2023-10-28",
+    "Description": "Alias of XBB.1.9.1.8, ORF3a:I62F, Europe"
+  },
+  {
+    "Lineage": "FL.9",
+    "Earliest date": "2023-01-12",
+    "Latest date": "2023-12-10",
+    "Description": "Alias of XBB.1.9.1.9, C23707T, T29691C, England"
+  },
+  {
+    "Lineage": "FL.10",
+    "Earliest date": "2022-12-17",
+    "Latest date": "2023-12-05",
+    "Description": "Alias of XBB.1.9.1.10, ORF1a:C657Y, from sars-cov-2-variants/lineage-proposals#28"
+  },
+  {
+    "Lineage": "FL.10.1",
+    "Earliest date": "2023-03-02",
+    "Latest date": "2023-12-04",
+    "Description": "Alias of XBB.1.9.1.10.1, S:E554K, C4234T, 220bp deletion in ORF8, South Korea, from #2040"
+  },
+  {
+    "Lineage": "FL.10.2",
+    "Earliest date": "2023-06-10",
+    "Latest date": "2023-11-02",
+    "Description": "Alias of XBB.1.9.1.10.2, S:K356T, S:T523N, Canada/USA, from #2220"
+  },
+  {
+    "Lineage": "FL.10.3",
+    "Earliest date": "2023-03-14",
+    "Latest date": "2023-09-11",
+    "Description": "Alias of XBB.1.9.1.10.3, S:G181R"
+  },
+  {
+    "Lineage": "FL.11",
+    "Earliest date": "2023-03-01",
+    "Latest date": "2023-09-08",
+    "Description": "Alias of XBB.1.9.1.11, ORF1a:L349F, France/French Guiana, from #1947"
+  },
+  {
+    "Lineage": "FL.12",
+    "Earliest date": "2023-01-09",
+    "Latest date": "2023-09-17",
+    "Description": "Alias of XBB.1.9.1.12, ORF1a:C2210F"
+  },
+  {
+    "Lineage": "FL.13",
+    "Earliest date": "2021-07-16",
+    "Latest date": "2023-12-29",
+    "Description": "Alias of XBB.1.9.1.13, G4354A"
+  },
+  {
+    "Lineage": "FL.13.1",
+    "Earliest date": "2023-04-17",
+    "Latest date": "2023-11-18",
+    "Description": "Alias of XBB.1.9.1.13.1, S:A411S, ORF1a:P80S, China, from #1996"
+  },
+  {
+    "Lineage": "FL.13.2",
+    "Earliest date": "2023-04-03",
+    "Latest date": "2023-12-04",
+    "Description": "Alias of XBB.1.9.1.13.2, S:K356T, China, from #2073"
+  },
+  {
+    "Lineage": "FL.13.2.1",
+    "Earliest date": "2023-06-18",
+    "Latest date": "2023-11-10",
+    "Description": "Alias of XBB.1.9.1.13.2.1, S:D178H, South Korea"
+  },
+  {
+    "Lineage": "FL.13.3",
+    "Earliest date": "2023-01-16",
+    "Latest date": "2023-09-25",
+    "Description": "Alias of XBB.1.9.1.13.3, T19110C"
+  },
+  {
+    "Lineage": "FL.13.3.1",
+    "Earliest date": "2023-02-23",
+    "Latest date": "2023-06-23",
+    "Description": "Alias of XBB.1.9.1.13.3.1, S:E154Q, England"
+  },
+  {
+    "Lineage": "FL.13.4",
+    "Earliest date": "2023-05-10",
+    "Latest date": "2023-12-23",
+    "Description": "Alias of XBB.1.9.1.13.4, S:K182E, S:F456L (T22928C), Pakistan, from sars-cov-2-variants/lineage-proposals#638"
+  },
+  {
+    "Lineage": "FL.13.4.1",
+    "Earliest date": "2023-08-10",
+    "Latest date": "2024-02-01",
+    "Description": "Alias of XBB.1.9.1.13.4.1, S:Q14H, S:A484K, from sars-cov-2-variants/lineage-proposals#638"
+  },
+  {
+    "Lineage": "FL.13.5",
+    "Earliest date": "2023-07-11",
+    "Latest date": "2024-03-13",
+    "Description": "Alias of XBB.1.9.1.13.5, S:F456L (T22928C), ORF1a:T1000I, ORF1a:L2527M, Chile/Argentina, from sars-cov-2-variants/lineage-proposals#692"
+  },
+  {
+    "Lineage": "FL.14",
+    "Earliest date": "2023-02-09",
+    "Latest date": "2023-12-15",
+    "Description": "Alias of XBB.1.9.1.14, S:V1122M, C29311T, C22978T, Russia/Finland"
+  },
+  {
+    "Lineage": "FL.15",
+    "Earliest date": "2023-03-09",
+    "Latest date": "2024-01-21",
+    "Description": "Alias of XBB.1.9.1.15, S:F456L (T22928C), ORF1a:E637K, Vietnam/China/South Korea, from #1994"
+  },
+  {
+    "Lineage": "FL.15.1",
+    "Earliest date": "2023-06-30",
+    "Latest date": "2024-01-03",
+    "Description": "Alias of XBB.1.9.1.15.1, S:L455F (G22927T), ORF1a:T2007I, on ORF1a:S2185N branch, from #2293"
+  },
+  {
+    "Lineage": "FL.15.1.1",
+    "Earliest date": "2023-08-10",
+    "Latest date": "2024-06-04",
+    "Description": "Alias of XBB.1.9.1.15.1.1, S:A475V, Canada/Romania/Belgium, from sars-cov-2-variants/lineage-proposals#646"
+  },
+  {
+    "Lineage": "KF.1",
+    "Earliest date": "2023-09-07",
+    "Latest date": "2024-02-22",
+    "Description": "Alias of XBB.1.9.1.15.1.1.1, S:P251H, Australia/Canada, from sars-cov-2-variants/lineage-proposals#890"
+  },
+  {
+    "Lineage": "KF.2",
+    "Earliest date": "2023-10-01",
+    "Latest date": "2024-02-01",
+    "Description": "Alias of XBB.1.9.1.15.1.1.2, S:E183D, England/Australia/New Zealand, from sars-cov-2-variants/lineage-proposals#1111"
+  },
+  {
+    "Lineage": "FL.15.2",
+    "Earliest date": "2023-05-25",
+    "Latest date": "2023-11-13",
+    "Description": "Alias of XBB.1.9.1.15.2, S:Q14H, C1684T, China, from sars-cov-2-variants/lineage-proposals#578"
+  },
+  {
+    "Lineage": "FL.15.3",
+    "Earliest date": "2023-04-12",
+    "Latest date": "2023-11-27",
+    "Description": "Alias of XBB.1.9.1.15.3, S:G181V, North America"
+  },
+  {
+    "Lineage": "FL.15.4",
+    "Earliest date": "2023-05-15",
+    "Latest date": "2023-12-27",
+    "Description": "Alias of XBB.1.9.1.15.4, S:Q14H, on G6819A branch, from #2359"
+  },
+  {
+    "Lineage": "FL.16",
+    "Earliest date": "2023-04-25",
+    "Latest date": "2024-01-25",
+    "Description": "Alias of XBB.1.9.1.16, S:D215V, C3511T, China, from #2001"
+  },
+  {
+    "Lineage": "FL.17",
+    "Earliest date": "2023-01-10",
+    "Latest date": "2023-08-11",
+    "Description": "Alias of XBB.1.9.1.17, T3898C, C28333T"
+  },
+  {
+    "Lineage": "FL.17.1",
+    "Earliest date": "2023-02-21",
+    "Latest date": "2023-08-29",
+    "Description": "Alias of XBB.1.9.1.17.1, S:N74H, South Korea"
+  },
+  {
+    "Lineage": "FL.17.2",
+    "Earliest date": "2023-04-19",
+    "Latest date": "2023-08-03",
+    "Description": "Alias of XBB.1.9.1.17.2, S:L452R, ORF7a:V104L, from sars-cov-2-variants/lineage-proposals#53"
+  },
+  {
+    "Lineage": "FL.18",
+    "Earliest date": "2022-11-15",
+    "Latest date": "2023-12-08",
+    "Description": "Alias of XBB.1.9.1.18, ORF1a:T2007I"
+  },
+  {
+    "Lineage": "FL.18.1",
+    "Earliest date": "2023-03-10",
+    "Latest date": "2023-11-13",
+    "Description": "Alias of XBB.1.9.1.18.1, N:T166I, A27507C, from #2019"
+  },
+  {
+    "Lineage": "FL.18.1.1",
+    "Earliest date": "2023-03-29",
+    "Latest date": "2023-09-02",
+    "Description": "Alias of XBB.1.9.1.18.1.1, S:Y200C, S:478R, Australia/Indonesia, from #2019"
+  },
+  {
+    "Lineage": "FL.19",
+    "Earliest date": "2023-01-11",
+    "Latest date": "2023-09-22",
+    "Description": "Alias of XBB.1.9.1.19, T2377C, C17502T, T24505G, South Korea"
+  },
+  {
+    "Lineage": "FL.19.1",
+    "Earliest date": "2023-04-25",
+    "Latest date": "2023-12-14",
+    "Description": "Alias of XBB.1.9.1.19.1, S:F456L (T22928C), ORF1b:A1877V, Spain/Italy/Puerto Rico, from #2138"
+  },
+  {
+    "Lineage": "FL.20",
+    "Earliest date": "2023-04-29",
+    "Latest date": "2024-01-06",
+    "Description": "Alias of XBB.1.9.1.20, S:F456L (T22928C), S:Q52H, Spain, from #2072"
+  },
+  {
+    "Lineage": "FL.20.1",
+    "Earliest date": "2023-05-17",
+    "Latest date": "2024-02-26",
+    "Description": "Alias of XBB.1.9.1.20.1, S:L455W, Northern Ireland/England, from #2145"
+  },
+  {
+    "Lineage": "FL.20.2",
+    "Earliest date": "2023-04-10",
+    "Latest date": "2024-02-12",
+    "Description": "Alias of XBB.1.9.1.20.2, S:478R, from sars-cov-2-variants/lineage-proposals#571"
+  },
+  {
+    "Lineage": "FL.21",
+    "Earliest date": "2023-01-24",
+    "Latest date": "2023-12-23",
+    "Description": "Alias of XBB.1.9.1.21, A10564T"
+  },
+  {
+    "Lineage": "FL.21.1",
+    "Earliest date": "2023-04-20",
+    "Latest date": "2023-11-07",
+    "Description": "Alias of XBB.1.9.1.21.1, S:D1084N, South Korea, from #2143"
+  },
+  {
+    "Lineage": "FL.21.2",
+    "Earliest date": "2023-03-23",
+    "Latest date": "2023-11-18",
+    "Description": "Alias of XBB.1.9.1.21.2, ORF1a:V1019F, ORF1a:I2873M, China, from sars-cov-2-variants/lineage-proposals#187"
+  },
+  {
+    "Lineage": "FL.22",
+    "Earliest date": "2023-01-26",
+    "Latest date": "2024-01-29",
+    "Description": "Alias of XBB.1.9.1.22, ORF1b:I1416V, T24184C"
+  },
+  {
+    "Lineage": "FL.23",
+    "Earliest date": "2023-01-16",
+    "Latest date": "2023-09-14",
+    "Description": "Alias of XBB.1.9.1.23, ORF1b:V1132I, Philippines"
+  },
+  {
+    "Lineage": "FL.23.1",
+    "Earliest date": "2023-02-20",
+    "Latest date": "2023-09-20",
+    "Description": "Alias of XBB.1.9.1.23.1, ORF1a:A2584V, C23185T, C8311T"
+  },
+  {
+    "Lineage": "FL.23.2",
+    "Earliest date": "2023-03-05",
+    "Latest date": "2023-06-15",
+    "Description": "Alias of XBB.1.9.1.23.2, S:S494P, ORF1a:P2256S, Philippines, from sars-cov-2-variants/lineage-proposals#381"
+  },
+  {
+    "Lineage": "FL.23.2.1",
+    "Earliest date": "2023-04-25",
+    "Latest date": "2023-05-23",
+    "Description": "Alias of XBB.1.9.1.23.2.1, S:P521T, Philippines"
+  },
+  {
+    "Lineage": "FL.24",
+    "Earliest date": "2023-03-30",
+    "Latest date": "2023-12-18",
+    "Description": "Alias of XBB.1.9.1.24, S:Q613H, S:A688V, from sars-cov-2-variants/lineage-proposals#284"
+  },
+  {
+    "Lineage": "FL.24.1",
+    "Earliest date": "2023-05-08",
+    "Latest date": "2024-05-14",
+    "Description": "Alias of XBB.1.9.1.24.1, S:478R, T9139C, C24919T, Russia, from sars-cov-2-variants/lineage-proposals#789"
+  },
+  {
+    "Lineage": "FL.25",
+    "Earliest date": "2023-02-15",
+    "Latest date": "2023-12-24",
+    "Description": "Alias of XBB.1.9.1.25, S:E554K, USA/England, from #2040"
+  },
+  {
+    "Lineage": "FL.26",
+    "Earliest date": "2023-01-05",
+    "Latest date": "2023-09-01",
+    "Description": "Alias of XBB.1.9.1.26, C22264T"
+  },
+  {
+    "Lineage": "FL.26.1",
+    "Earliest date": "2023-02-21",
+    "Latest date": "2023-08-09",
+    "Description": "Alias of XBB.1.9.1.26.1, S:493L, Sweden"
+  },
+  {
+    "Lineage": "FL.27",
+    "Earliest date": "2023-01-15",
+    "Latest date": "2023-09-20",
+    "Description": "Alias of XBB.1.9.1.27, ORF1a:V3747I"
+  },
+  {
+    "Lineage": "FL.28",
+    "Earliest date": "2023-04-04",
+    "Latest date": "2023-09-01",
+    "Description": "Alias of XBB.1.9.1.28, S:K478R, ORF1a:S1520F, ORF3a:R68I, Spain"
+  },
+  {
+    "Lineage": "FL.29",
+    "Earliest date": "2023-02-16",
+    "Latest date": "2023-11-17",
+    "Description": "Alias of XBB.1.9.1.29, S:490S, ORF1b:I2331V, from #2030"
+  },
+  {
+    "Lineage": "FL.30",
+    "Earliest date": "2023-05-10",
+    "Latest date": "2023-09-01",
+    "Description": "Alias of XBB.1.9.1.30, S:484K, Greece, from #2206"
+  },
+  {
+    "Lineage": "FL.30.1",
+    "Earliest date": "2023-04-27",
+    "Latest date": "2023-09-30",
+    "Description": "Alias of XBB.1.9.1.30.1, S:A852S, Greece"
+  },
+  {
+    "Lineage": "FL.31",
+    "Earliest date": "2023-01-24",
+    "Latest date": "2023-12-17",
+    "Description": "Alias of XBB.1.9.1.31, ORF1b:M657I"
+  },
+  {
+    "Lineage": "FL.31.1",
+    "Earliest date": "2023-05-18",
+    "Latest date": "2023-12-09",
+    "Description": "Alias of XBB.1.9.1.31.1, S:478R, S:D80H, S:Q613H, Morocco/Europe/US/Canada, from sars-cov-2-variants/lineage-proposals#836"
+  },
+  {
+    "Lineage": "FL.32",
+    "Earliest date": "2023-04-19",
+    "Latest date": "2023-10-04",
+    "Description": "Alias of XBB.1.9.1.32, S:E554Q, S:V6L, from sars-cov-2-variants/lineage-proposals#719"
+  },
+  {
+    "Lineage": "FL.32.1",
+    "Earliest date": "2023-07-26",
+    "Latest date": "2023-10-23",
+    "Description": "Alias of XBB.1.9.1.32.1, S:F456L (T22928C), USA, from sars-cov-2-variants/lineage-proposals#719"
+  },
+  {
+    "Lineage": "FL.33",
+    "Earliest date": "2023-02-06",
+    "Latest date": "2024-01-11",
+    "Description": "Alias of XBB.1.9.1.33, ORF1b:A1377V"
+  },
+  {
+    "Lineage": "FL.33.1",
+    "Earliest date": "2023-05-03",
+    "Latest date": "2023-11-29",
+    "Description": "Alias of XBB.1.9.1.33.1, S:478R, Georgia, from sars-cov-2-variants/lineage-proposals#828"
+  },
+  {
+    "Lineage": "FL.34",
+    "Earliest date": "2023-03-11",
+    "Latest date": "2024-04-20",
+    "Description": "Alias of XBB.1.9.1.34, S:D1118Y"
+  },
+  {
+    "Lineage": "FL.35",
+    "Earliest date": "2023-02-16",
+    "Latest date": "2023-11-14",
+    "Description": "Alias of XBB.1.9.1.35, ORF8:S103L, South Africa"
+  },
+  {
+    "Lineage": "FL.35.1",
+    "Earliest date": "2023-06-13",
+    "Latest date": "2023-10-20",
+    "Description": "Alias of XBB.1.9.1.35.1, S:478R, South Africa"
+  },
+  {
+    "Lineage": "FL.36",
+    "Earliest date": "2023-08-21",
+    "Latest date": "2024-01-24",
+    "Description": "Alias of XBB.1.9.1.36, S:76I, S:190S, S:356T, S:572I, S:899S, S:1070T, England/US/Denmark, sars-cov-2-variants/lineage-proposals#805"
+  },
+  {
+    "Lineage": "FL.37",
+    "Earliest date": "2022-04-17",
+    "Latest date": "2023-10-05",
+    "Description": "Alias of XBB.1.9.1.37, C547T, C29614T"
+  },
+  {
+    "Lineage": "FL.38",
+    "Earliest date": "2023-07-09",
+    "Latest date": "2023-12-10",
+    "Description": "Alias of XBB.1.9.1.38, S:K478R, S:Q613H, C25482T, Russia, from sars-cov-2-variants/lineage-proposals#1001"
+  },
+  {
+    "Lineage": "FL.39",
+    "Earliest date": "2023-01-31",
+    "Latest date": "2023-11-17",
+    "Description": "Alias of XBB.1.9.1.39, ORF1a:E633K, Russia"
+  },
+  {
+    "Lineage": "FL.39.1",
+    "Earliest date": "2023-08-16",
+    "Latest date": "2024-01-19",
+    "Description": "Alias of XBB.1.9.1.39.1, S:K478R, S:P521S, Russia"
+  },
+  {
+    "Lineage": "FL.40",
+    "Earliest date": "2023-01-22",
+    "Latest date": "2023-12-11",
+    "Description": "Alias of XBB.1.9.1.40, ORF1a:I3758V, Russia"
+  },
+  {
+    "Lineage": "XBB.1.9.2",
+    "Earliest date": "2022-10-18",
+    "Latest date": "2024-03-07",
+    "Description": "S:F486P (after A27507C, A16878T), Indonesia/Singapore, from #1602"
+  },
+  {
+    "Lineage": "EG.1",
+    "Earliest date": "2022-10-18",
+    "Latest date": "2024-04-05",
+    "Description": "Alias of XBB.1.9.2.1, S:Q613H on N:L219F branch, from #1664 and jmcbroome/auto-pango-designation#193"
+  },
+  {
+    "Lineage": "EG.1.1",
+    "Earliest date": "2023-01-24",
+    "Latest date": "2023-08-02",
+    "Description": "Alias of XBB.1.9.2.1.1, S:V70F and ORF1a:T403I, Luxembourg/Belgium/France"
+  },
+  {
+    "Lineage": "EG.1.2",
+    "Earliest date": "2022-04-24",
+    "Latest date": "2023-12-01",
+    "Description": "Alias of XBB.1.9.2.1.2, ORF7b:H42Y, mostly Austria, from #1711"
+  },
+  {
+    "Lineage": "EG.1.3",
+    "Earliest date": "2022-02-20",
+    "Latest date": "2023-10-26",
+    "Description": "Alias of XBB.1.9.2.1.3, C3784T, A6613G, Europe"
+  },
+  {
+    "Lineage": "EG.1.4",
+    "Earliest date": "2023-01-14",
+    "Latest date": "2023-12-04",
+    "Description": "Alias of XBB.1.9.2.1.4, ORF1a:S2500F, Europe"
+  },
+  {
+    "Lineage": "EG.1.4.1",
+    "Earliest date": "2023-03-13",
+    "Latest date": "2023-11-21",
+    "Description": "Alias of XBB.1.9.2.1.4.1, S:P217L, South Korea"
+  },
+  {
+    "Lineage": "EG.1.5",
+    "Earliest date": "2023-03-14",
+    "Latest date": "2023-10-12",
+    "Description": "Alias of XBB.1.9.2.1.5, S:S98F, Europe"
+  },
+  {
+    "Lineage": "EG.1.6",
+    "Earliest date": "2022-10-18",
+    "Latest date": "2024-02-13",
+    "Description": "Alias of XBB.1.9.2.1.6, G26235T"
+  },
+  {
+    "Lineage": "EG.1.7",
+    "Earliest date": "2023-02-23",
+    "Latest date": "2023-08-01",
+    "Description": "Alias of XBB.1.9.2.1.7, S:E156V, Europe"
+  },
+  {
+    "Lineage": "EG.1.8",
+    "Earliest date": "2023-04-26",
+    "Latest date": "2023-10-02",
+    "Description": "Alias of XBB.1.9.2.1.8, S:S640F, ORF1b:D161G, ORF1b:P2321L, China"
+  },
+  {
+    "Lineage": "EG.2",
+    "Earliest date": "2022-10-18",
+    "Latest date": "2024-02-19",
+    "Description": "Alias of XBB.1.9.2.2, S:478R, Indonesia"
+  },
+  {
+    "Lineage": "EG.2.1",
+    "Earliest date": "2023-05-08",
+    "Latest date": "2023-07-02",
+    "Description": "Alias of XBB.1.9.2.2.1, S:F456L (T22930A), S:V327I, Indonesia"
+  },
+  {
+    "Lineage": "EG.2.2",
+    "Earliest date": "2023-03-31",
+    "Latest date": "2024-02-20",
+    "Description": "Alias of XBB.1.9.2.2.2, S:K304N, Indonesia/Japan, from sars-cov-2-variants/lineage-proposals#517"
+  },
+  {
+    "Lineage": "EG.2.3",
+    "Earliest date": "2023-04-01",
+    "Latest date": "2023-11-30",
+    "Description": "Alias of XBB.1.9.2.2.3, S:I742V, Indonesia/Singapore, from sars-cov-2-variants/lineage-proposals#587"
+  },
+  {
+    "Lineage": "EG.2.4",
+    "Earliest date": "2023-07-03",
+    "Latest date": "2023-11-17",
+    "Description": "Alias of XBB.1.9.2.2.4, S:K356T, ORF1a:G2265D, Singapore, from sars-cov-2-variants/lineage-proposals#586"
+  },
+  {
+    "Lineage": "EG.2.5",
+    "Earliest date": "2023-04-17",
+    "Latest date": "2023-09-20",
+    "Description": "Alias of XBB.1.9.2.2.4, S:Q675H, Indonesia, from sars-cov-2-variants/lineage-proposals#445"
+  },
+  {
+    "Lineage": "EG.3",
+    "Earliest date": "2023-01-01",
+    "Latest date": "2023-06-05",
+    "Description": "Alias of XBB.1.9.2.3, ORF1a:L2778F on N:L219F branch"
+  },
+  {
+    "Lineage": "EG.4",
+    "Earliest date": "2023-01-04",
+    "Latest date": "2023-12-22",
+    "Description": "Alias of XBB.1.9.2.4, C28651T"
+  },
+  {
+    "Lineage": "EG.4.1",
+    "Earliest date": "2023-01-06",
+    "Latest date": "2023-08-17",
+    "Description": "Alias of XBB.1.9.2.4.1, S:I870V, N:A119S"
+  },
+  {
+    "Lineage": "EG.4.2",
+    "Earliest date": "2023-04-14",
+    "Latest date": "2023-08-27",
+    "Description": "Alias of XBB.1.9.2.4.2, S:A623V, T14652C, China, from sars-cov-2-variants/lineage-proposals#46"
+  },
+  {
+    "Lineage": "EG.4.3",
+    "Earliest date": "2023-03-08",
+    "Latest date": "2023-11-13",
+    "Description": "Alias of XBB.1.9.2.4.3, S:Q613H (G23401C)"
+  },
+  {
+    "Lineage": "EG.4.4",
+    "Earliest date": "2023-03-30",
+    "Latest date": "2023-09-25",
+    "Description": "Alias of XBB.1.9.2.4.4, ORF1a:Y1465C, ORF1b:H873Y, Germany/Austria"
+  },
+  {
+    "Lineage": "EG.4.5",
+    "Earliest date": "2023-01-31",
+    "Latest date": "2023-12-01",
+    "Description": "Alias of XBB.1.9.2.4.5, S:478R, Indonesia/France"
+  },
+  {
+    "Lineage": "EG.5",
+    "Earliest date": "2023-02-17",
+    "Latest date": "2024-07-08",
+    "Description": "Alias of XBB.1.9.2.5, S:F456L (T22930A), ORF1a:A690V, ORF1a:A3143V, Indonesia, from #1918"
+  },
+  {
+    "Lineage": "EG.5.1",
+    "Earliest date": "2021-07-16",
+    "Latest date": "2024-07-25",
+    "Description": "Alias of XBB.1.9.2.5.1, S:Q52H"
+  },
+  {
+    "Lineage": "EG.5.1.1",
+    "Earliest date": "2020-12-22",
+    "Latest date": "2024-07-08",
+    "Description": "Alias of XBB.1.9.2.5.1.1, China, from #2020"
+  },
+  {
+    "Lineage": "HK.1",
+    "Earliest date": "2023-05-13",
+    "Latest date": "2024-04-22",
+    "Description": "Alias of XBB.1.9.2.5.1.1.1, S:G257V, China, from sars-cov-2-variants/lineage-proposals#359"
+  },
+  {
+    "Lineage": "HK.1.2",
+    "Earliest date": "2023-07-04",
+    "Latest date": "2024-04-02",
+    "Description": "Alias of XBB.1.9.2.5.1.1.1.2, S:L455F (G22927C), S:T307I, China/New Zealand , from sars-cov-2-variants/lineage-proposals#631"
+  },
+  {
+    "Lineage": "HK.2",
+    "Earliest date": "2023-05-29",
+    "Latest date": "2024-02-08",
+    "Description": "Alias of XBB.1.9.2.5.1.1.2, S:Q14H, China, from sars-cov-2-variants/lineage-proposals#432"
+  },
+  {
+    "Lineage": "HK.2.1",
+    "Earliest date": "2023-08-07",
+    "Latest date": "2024-03-13",
+    "Description": "Alias of XBB.1.9.2.5.1.1.2.1, S:L455F (G22927T), Singapore, from sars-cov-2-variants/lineage-proposals#537"
+  },
+  {
+    "Lineage": "HK.3",
+    "Earliest date": "2022-12-12",
+    "Latest date": "2024-08-07",
+    "Description": "Alias of XBB.1.9.2.5.1.1.3, S:L455F (G22927T), China, from sars-cov-2-variants/lineage-proposals#414"
+  },
+  {
+    "Lineage": "HK.3.1",
+    "Earliest date": "2023-07-31",
+    "Latest date": "2024-04-08",
+    "Description": "Alias of XBB.1.9.2.5.1.1.3.1, S:F157L, China, from #2193"
+  },
+  {
+    "Lineage": "HK.3.2",
+    "Earliest date": "2023-01-01",
+    "Latest date": "2024-05-10",
+    "Description": "Alias of XBB.1.9.2.5.1.1.3.2, S:Q14K, C853T, China，from sars-cov-2-variants/lineage-proposals#730"
+  },
+  {
+    "Lineage": "HK.3.2.1",
+    "Earliest date": "2023-08-02",
+    "Latest date": "2024-02-16",
+    "Description": "Alias of XBB.1.9.2.5.1.1.3.2.1, S:Q677H, Canada, from #2362"
+  },
+  {
+    "Lineage": "HK.3.2.2",
+    "Earliest date": "2023-09-11",
+    "Latest date": "2024-03-27",
+    "Description": "Alias of XBB.1.9.2.5.1.1.3.2.2, ORF8:M1L, S:N185D, China/Australia, from sars-cov-2-variants/lineage-proposals#867"
+  },
+  {
+    "Lineage": "HK.3.3",
+    "Earliest date": "2022-10-10",
+    "Latest date": "2024-01-20",
+    "Description": "Alias of XBB.1.9.2.5.1.1.3.3, S:S256L, N:P364L, China/Singapore, from sars-cov-2-variants/lineage-proposals#744"
+  },
+  {
+    "Lineage": "HK.3.4",
+    "Earliest date": "2023-07-31",
+    "Latest date": "2024-02-02",
+    "Description": "Alias of XBB.1.9.2.5.1.1.3.4, S:P809S, from sars-cov-2-variants/lineage-proposals#764"
+  },
+  {
+    "Lineage": "HK.3.5",
+    "Earliest date": "2023-09-04",
+    "Latest date": "2024-03-04",
+    "Description": "Alias of XBB.1.9.2.5.1.1.3.5, S:P174S, Singapore, from sars-cov-2-variants/lineage-proposals#865"
+  },
+  {
+    "Lineage": "HK.3.6",
+    "Earliest date": "2023-08-20",
+    "Latest date": "2024-03-18",
+    "Description": "Alias of XBB.1.9.2.5.1.1.3.6, S:G181R, China, from sars-cov-2-variants/lineage-proposals#809"
+  },
+  {
+    "Lineage": "HK.3.7",
+    "Earliest date": "2023-08-14",
+    "Latest date": "2024-02-15",
+    "Description": "Alias of XBB.1.9.2.5.1.1.3.7, S:V171I, Singapore/China, from sars-cov-2-variants/lineage-proposals#793"
+  },
+  {
+    "Lineage": "HK.3.8",
+    "Earliest date": "2023-08-28",
+    "Latest date": "2024-01-15",
+    "Description": "Alias of XBB.1.9.2.5.1.1.3.8, S:E554K, China/Sweden, from #2377"
+  },
+  {
+    "Lineage": "HK.3.9",
+    "Earliest date": "2023-09-08",
+    "Latest date": "2024-04-04",
+    "Description": "Alias of XBB.1.9.2.5.1.1.3.9, S:T732I, Australia, from sars-cov-2-variants/lineage-proposals#1092"
+  },
+  {
+    "Lineage": "HK.3.10",
+    "Earliest date": "2023-08-21",
+    "Latest date": "2024-07-20",
+    "Description": "Alias of XBB.1.9.2.5.1.1.3.10, S:A1078S, from sars-cov-2-variants/lineage-proposals#1055"
+  },
+  {
+    "Lineage": "HK.3.11",
+    "Earliest date": "2023-08-04",
+    "Latest date": "2024-02-06",
+    "Description": "Lineage reassigned. Withdrawn, as part of 14988C sublineage of EG.5.1.1, not HK.3: Alias of XBB.1.9.2.5.1.1.3.11, S:A475V, Finland/Denmark/Sweden"
+  },
+  {
+    "Lineage": "HK.3.12",
+    "Earliest date": "2023-08-18",
+    "Latest date": "2024-02-03",
+    "Description": "Alias of XBB.1.9.2.5.1.1.3.12, S:A688T, USA, from sars-cov-2-variants/lineage-proposals#886"
+  },
+  {
+    "Lineage": "HK.3.13",
+    "Earliest date": "2023-09-02",
+    "Latest date": "2024-04-09",
+    "Description": "Alias of XBB.1.9.2.5.1.1.3.13, S:Q14R, China, from sars-cov-2-variants/lineage-proposals#601"
+  },
+  {
+    "Lineage": "HK.3.14",
+    "Earliest date": "2023-02-01",
+    "Latest date": "2024-04-09",
+    "Description": "Alias of XBB.1.9.2.5.1.1.3.14, S:A475V, ORF1b:2378T, England/Australia, from sars-cov-2-variants/lineage-proposals#978"
+  },
+  {
+    "Lineage": "HK.4",
+    "Earliest date": "2023-05-06",
+    "Latest date": "2023-12-18",
+    "Description": "Alias of XBB.1.9.2.5.1.1.4, S:T883I, China"
+  },
+  {
+    "Lineage": "HK.5",
+    "Earliest date": "2023-05-30",
+    "Latest date": "2023-11-29",
+    "Description": "Alias of XBB.1.9.2.5.1.1.5, S:Q677H, China"
+  },
+  {
+    "Lineage": "HK.6",
+    "Earliest date": "2023-06-26",
+    "Latest date": "2024-07-03",
+    "Description": "Alias of XBB.1.9.2.5.1.1.6, S:D253G, ORF1a:A1923T, on T14988C branch UK/USA, from #2184"
+  },
+  {
+    "Lineage": "HK.7",
+    "Earliest date": "2023-05-05",
+    "Latest date": "2024-01-15",
+    "Description": "Alias of XBB.1.9.2.5.1.1.7, S:N148T, China"
+  },
+  {
+    "Lineage": "HK.8",
+    "Earliest date": "2023-06-27",
+    "Latest date": "2024-02-13",
+    "Description": "Alias of XBB.1.9.2.5.1.1.8, S:L455F (G22927T), on C11779T branch, China, from #2230"
+  },
+  {
+    "Lineage": "HK.8.1",
+    "Earliest date": "2023-07-17",
+    "Latest date": "2024-02-17",
+    "Description": "Alias of XBB.1.9.2.5.1.1.8.1, S:D1153Y, China, from #2356"
+  },
+  {
+    "Lineage": "HK.9",
+    "Earliest date": "2023-07-11",
+    "Latest date": "2023-11-17",
+    "Description": "Alias of XBB.1.9.2.5.1.1.9, S:R190K, on C11779T branch, England, from sars-cov-2-variants/lineage-proposals#564"
+  },
+  {
+    "Lineage": "HK.11",
+    "Earliest date": "2023-06-05",
+    "Latest date": "2024-01-08",
+    "Description": "Alias of XBB.1.9.2.5.1.1.11, S:G184S, China/England/SouthKorea, from #2255"
+  },
+  {
+    "Lineage": "HK.11.1",
+    "Earliest date": "2023-08-21",
+    "Latest date": "2024-03-25",
+    "Description": "Alias of XBB.1.9.2.5.1.1.11.1, S:L455F (G22927T), from sars-cov-2-variants/lineage-proposals#537"
+  },
+  {
+    "Lineage": "HK.12",
+    "Earliest date": "2023-05-16",
+    "Latest date": "2024-07-11",
+    "Description": "Alias of XBB.1.9.2.5.1.1.12, S:K356T, China/Singapore"
+  },
+  {
+    "Lineage": "HK.13",
+    "Earliest date": "2023-07-08",
+    "Latest date": "2024-02-28",
+    "Description": "Alias of XBB.1.9.2.5.1.1.13, S:L455F (G22927C), China, from sars-cov-2-variants/lineage-proposals#537"
+  },
+  {
+    "Lineage": "HK.13.1",
+    "Earliest date": "2023-07-10",
+    "Latest date": "2024-04-09",
+    "Description": "Alias of XBB.1.9.2.5.1.1.13.1, C13378T, A24604G"
+  },
+  {
+    "Lineage": "HK.13.2",
+    "Earliest date": "2023-01-03",
+    "Latest date": "2024-03-16",
+    "Description": "Alias of XBB.1.9.2.5.1.1.13.2, S:F797L, S:D1153H, from sars-cov-2-variants/lineage-proposals#943"
+  },
+  {
+    "Lineage": "HK.13.2.1",
+    "Earliest date": "2023-09-18",
+    "Latest date": "2024-01-22",
+    "Description": "Alias of XBB.1.9.2.5.1.1.13.2.1, S:T250I, N:T379I, Greece, from #2480"
+  },
+  {
+    "Lineage": "HK.14",
+    "Earliest date": "2023-07-04",
+    "Latest date": "2023-12-11",
+    "Description": "Alias of XBB.1.9.2.5.1.1.14, S:L455F (G22927C), on C11779T branch, China, from sars-cov-2-variants/lineage-proposals#537"
+  },
+  {
+    "Lineage": "HK.15",
+    "Earliest date": "2023-06-25",
+    "Latest date": "2023-12-02",
+    "Description": "Alias of XBB.1.9.2.5.1.1.15, S:A262T, on C11779T branch, from sars-cov-2-variants/lineage-proposals#588"
+  },
+  {
+    "Lineage": "HK.16",
+    "Earliest date": "2023-07-19",
+    "Latest date": "2023-12-22",
+    "Description": "Alias of XBB.1.9.2.5.1.1.16, N:P67S, S:A684V, S:V1264L, from sars-cov-2-variants/lineage-proposals#841"
+  },
+  {
+    "Lineage": "HK.17",
+    "Earliest date": "2023-06-25",
+    "Latest date": "2024-03-15",
+    "Description": "Alias of XBB.1.9.2.5.1.1.17, S:S494P, China"
+  },
+  {
+    "Lineage": "HK.18",
+    "Earliest date": "2023-08-15",
+    "Latest date": "2024-03-14",
+    "Description": "Alias of XBB.1.9.2.5.1.1.18, S:L452R, from sars-cov-2-variants/lineage-proposals#800"
+  },
+  {
+    "Lineage": "HK.19",
+    "Earliest date": "2023-06-18",
+    "Latest date": "2024-02-18",
+    "Description": "Alias of XBB.1.9.2.5.1.1.19, S:F157L"
+  },
+  {
+    "Lineage": "HK.20",
+    "Earliest date": "2023-08-13",
+    "Latest date": "2023-12-18",
+    "Description": "Alias of XBB.1.9.2.5.1.1.20, S:L455F (G22927T), on ORF1a:P2144S branch, China, from sars-cov-2-variants/lineage-proposals#537"
+  },
+  {
+    "Lineage": "HK.20.1",
+    "Earliest date": "2023-08-13",
+    "Latest date": "2024-04-15",
+    "Description": "Alias of XBB.1.9.2.5.1.1.20.1, S:G482R, from sars-cov-2-variants/lineage-proposals#537"
+  },
+  {
+    "Lineage": "HK.21",
+    "Earliest date": "2023-08-21",
+    "Latest date": "2023-12-09",
+    "Description": "Alias of XBB.1.9.2.5.1.1.21, S:T470N, S:796H, from #2367"
+  },
+  {
+    "Lineage": "HK.22",
+    "Earliest date": "2023-09-17",
+    "Latest date": "2024-04-01",
+    "Description": "Alias of XBB.1.9.2.5.1.1.22, S:L452Q, S:L455F (G22927T), Australia/China, from #2357"
+  },
+  {
+    "Lineage": "HK.23",
+    "Earliest date": "2023-06-12",
+    "Latest date": "2024-02-09",
+    "Description": "Alias of XBB.1.9.2.5.1.1.23, ORF8:A65V"
+  },
+  {
+    "Lineage": "HK.23.1",
+    "Earliest date": "2023-08-05",
+    "Latest date": "2024-02-14",
+    "Description": "Alias of XBB.1.9.2.5.1.1.23.1, S:L455F (G22927T), ORF1a:T2906N, from sars-cov-2-variants/lineage-proposals#537"
+  },
+  {
+    "Lineage": "HK.23.1.1",
+    "Earliest date": "2023-08-29",
+    "Latest date": "2024-02-05",
+    "Description": "Alias of XBB.1.9.2.5.1.1.23.1.1, S:A348S, China/Canada, from sars-cov-2-variants/lineage-proposals#537"
+  },
+  {
+    "Lineage": "HK.24",
+    "Earliest date": "2023-07-26",
+    "Latest date": "2024-02-05",
+    "Description": "Alias of XBB.1.9.2.5.1.1.24, S:E654K"
+  },
+  {
+    "Lineage": "HK.24.1",
+    "Earliest date": "2023-08-26",
+    "Latest date": "2024-02-06",
+    "Description": "Alias of XBB.1.9.2.5.1.1.24.1, S:L455F (G22927T), Australia, from sars-cov-2-variants/lineage-proposals#537"
+  },
+  {
+    "Lineage": "HK.25",
+    "Earliest date": "2023-09-28",
+    "Latest date": "2023-12-12",
+    "Description": "Alias of XBB.1.9.2.5.1.1.25, S:K356T, S:H681R, N:P365L, and 10 more nucs, Germany/Austria/France/US, from #2327 and sars-cov-2-variants/lineage-proposals#986"
+  },
+  {
+    "Lineage": "HK.26",
+    "Earliest date": "2023-08-02",
+    "Latest date": "2024-03-21",
+    "Description": "Alias of XBB.1.9.2.5.1.1.26, S:L455F (G22927T), ORF3a:L52I, on 14988C branch, Finland, from sars-cov-2-variants/lineage-proposals#763"
+  },
+  {
+    "Lineage": "HK.26.1",
+    "Earliest date": "2023-08-12",
+    "Latest date": "2024-01-18",
+    "Description": "Alias of XBB.1.9.2.5.1.1.26.1, S:A475V, Finland, formerly HK.3.11, from sars-cov-2-variants/lineage-proposals#763"
+  },
+  {
+    "Lineage": "HK.27",
+    "Earliest date": "2023-05-22",
+    "Latest date": "2024-02-05",
+    "Description": "Alias of XBB.1.9.2.5.1.1.27, ORF1a:T1589I, China"
+  },
+  {
+    "Lineage": "HK.27.1",
+    "Earliest date": "2023-06-27",
+    "Latest date": "2024-04-24",
+    "Description": "Alias of XBB.1.9.2.5.1.1.27.1, S:L455F (G22927T), China, from sars-cov-2-variants/lineage-proposals#525"
+  },
+  {
+    "Lineage": "HK.27.1.1",
+    "Earliest date": "2023-08-17",
+    "Latest date": "2024-03-26",
+    "Description": "Alias of XBB.1.9.2.5.1.1.27.1.1, S:Q14H, China"
+  },
+  {
+    "Lineage": "HK.28",
+    "Earliest date": "2023-05-15",
+    "Latest date": "2024-01-27",
+    "Description": "Alias of XBB.1.9.2.5.1.1.28, C19170T, China"
+  },
+  {
+    "Lineage": "HK.29",
+    "Earliest date": "2023-05-31",
+    "Latest date": "2024-01-21",
+    "Description": "Alias of XBB.1.9.2.5.1.1.29, ORF1a:G2509D, North America"
+  },
+  {
+    "Lineage": "HK.30",
+    "Earliest date": "2022-10-10",
+    "Latest date": "2024-04-15",
+    "Description": "Alias of XBB.1.9.2.5.1.1.30, T26609C, China"
+  },
+  {
+    "Lineage": "HK.31",
+    "Earliest date": "2023-01-11",
+    "Latest date": "2024-02-05",
+    "Description": "Alias of XBB.1.9.2.5.1.1.31, ORF1a:G604S"
+  },
+  {
+    "Lineage": "HK.32",
+    "Earliest date": "2023-07-27",
+    "Latest date": "2024-03-08",
+    "Description": "Alias of XBB.1.9.2.5.1.1.32, S:Q14R, ORF1a:S2193F, China, from sars-cov-2-variants/lineage-proposals#601"
+  },
+  {
+    "Lineage": "HK.33",
+    "Earliest date": "2023-08-21",
+    "Latest date": "2024-06-16",
+    "Description": "Alias of XBB.1.9.2.5.1.1.33, S:L455F (G22927T) on C2644T branch, North America, from sars-cov-2-variants/lineage-proposals#537"
+  },
+  {
+    "Lineage": "HK.34",
+    "Earliest date": "2023-08-22",
+    "Latest date": "2023-12-04",
+    "Description": "Alias of XBB.1.9.2.5.1.1.34, S:F186S, ORF1a:V3660M, on C2644T branch, Singapore, from sars-cov-2-variants/lineage-proposals#905"
+  },
+  {
+    "Lineage": "HK.34.1",
+    "Earliest date": "2023-09-18",
+    "Latest date": "2024-01-16",
+    "Description": "Alias of XBB.1.9.2.5.1.1.34.1, S:K356T, Singapore, from sars-cov-2-variants/lineage-proposals#1048"
+  },
+  {
+    "Lineage": "EG.5.1.2",
+    "Earliest date": "2023-04-06",
+    "Latest date": "2024-04-12",
+    "Description": "Alias of XBB.1.9.2.5.1.2, Japan, ORF1b:V1644I, from sars-cov-2-variants/lineage-proposals#301"
+  },
+  {
+    "Lineage": "EG.5.1.3",
+    "Earliest date": "2021-07-16",
+    "Latest date": "2024-04-11",
+    "Description": "Alias of XBB.1.9.2.5.1.3, ORF1a:R542C, C22570T, from sars-cov-2-variants/lineage-proposals#222"
+  },
+  {
+    "Lineage": "JG.1",
+    "Earliest date": "2023-06-28",
+    "Latest date": "2024-01-11",
+    "Description": "Alias of XBB.1.9.2.5.1.3.1, S:T732I, France, from #2218"
+  },
+  {
+    "Lineage": "JG.2",
+    "Earliest date": "2021-12-22",
+    "Latest date": "2024-06-20",
+    "Description": "Alias of XBB.1.9.2.5.1.3.2, S:G75V, Europe, from #2249"
+  },
+  {
+    "Lineage": "JG.3",
+    "Earliest date": "2021-07-16",
+    "Latest date": "2024-07-31",
+    "Description": "Alias of XBB.1.9.2.5.1.3.3, S:L455F (G22927T), S:S704L, Europe, from #2231"
+  },
+  {
+    "Lineage": "JG.3.1",
+    "Earliest date": "2023-06-26",
+    "Latest date": "2024-05-09",
+    "Description": "Alias of XBB.1.9.2.5.1.3.3.1, S:T307I, from sars-cov-2-variants/lineage-proposals#829"
+  },
+  {
+    "Lineage": "JG.3.2",
+    "Earliest date": "2022-12-07",
+    "Latest date": "2024-05-01",
+    "Description": "Alias of XBB.1.9.2.5.1.3.3.2, S:N450D, Canada, from #2376"
+  },
+  {
+    "Lineage": "JG.3.3",
+    "Earliest date": "2023-08-29",
+    "Latest date": "2024-02-06",
+    "Description": "Alias of XBB.1.9.2.5.1.3.3.3, S:A83S, Belgium, from #2363"
+  },
+  {
+    "Lineage": "JG.3.4",
+    "Earliest date": "2023-09-24",
+    "Latest date": "2024-02-29",
+    "Description": "Alias of XBB.1.9.2.5.1.3.3.4, S:478R, USA, from sars-cov-2-variants/lineage-proposals#1081"
+  },
+  {
+    "Lineage": "JG.4",
+    "Earliest date": "2023-05-28",
+    "Latest date": "2023-12-22",
+    "Description": "Alias of XBB.1.9.2.5.1.3.4, C1684T, Europe"
+  },
+  {
+    "Lineage": "EG.5.1.4",
+    "Earliest date": "2023-04-03",
+    "Latest date": "2024-04-10",
+    "Description": "Alias of XBB.1.9.2.5.1.4, ORF1b:K2557R, from #2117"
+  },
+  {
+    "Lineage": "JJ.1",
+    "Earliest date": "2023-06-23",
+    "Latest date": "2024-02-13",
+    "Description": "Alias of XBB.1.9.2.5.1.4.1, S:L455F (G22927T), ORF3a:I47V, China/Japan, from #2208"
+  },
+  {
+    "Lineage": "EG.5.1.5",
+    "Earliest date": "2023-04-23",
+    "Latest date": "2024-01-09",
+    "Description": "Alias of XBB.1.9.2.5.1.5, ORF1a:L3293I, ORF1b:T1274I, ORF1b:L2349V, Portugal"
+  },
+  {
+    "Lineage": "EG.5.1.6",
+    "Earliest date": "2022-10-07",
+    "Latest date": "2024-06-14",
+    "Description": "Alias of XBB.1.9.2.5.1.6, S:F157L, ORF1a:S1857L, USA, from sars-cov-2-variants/lineage-proposals#394"
+  },
+  {
+    "Lineage": "HV.1",
+    "Earliest date": "2022-10-18",
+    "Latest date": "2024-07-25",
+    "Description": "Alias of XBB.1.9.2.5.1.6.1, S:L452R, USA"
+  },
+  {
+    "Lineage": "HV.1.1",
+    "Earliest date": "2023-08-15",
+    "Latest date": "2024-04-26",
+    "Description": "Alias of XBB.1.9.2.5.1.6.1.1, S:K444T, on ORF1a:T4083M branch, USA, from sars-cov-2-variants/lineage-proposals#866"
+  },
+  {
+    "Lineage": "HV.1.2",
+    "Earliest date": "2023-08-13",
+    "Latest date": "2024-02-16",
+    "Description": "Alias of XBB.1.9.2.5.1.6.1.2, S:S514F, on ORF1a:T4083M branch, USA, from sars-cov-2-variants/lineage-proposals#957"
+  },
+  {
+    "Lineage": "HV.1.3",
+    "Earliest date": "2023-08-14",
+    "Latest date": "2024-02-05",
+    "Description": "Alias of XBB.1.9.2.5.1.6.1.3, S:493L, USA, from sars-cov-2-variants/lineage-proposals#924"
+  },
+  {
+    "Lineage": "HV.1.4",
+    "Earliest date": "2023-07-21",
+    "Latest date": "2024-01-25",
+    "Description": "Alias of XBB.1.9.2.5.1.6.1.4, S:A1078S, USA, from sars-cov-2-variants/lineage-proposals#957"
+  },
+  {
+    "Lineage": "HV.1.5",
+    "Earliest date": "2023-08-23",
+    "Latest date": "2024-02-06",
+    "Description": "Alias of XBB.1.9.2.5.1.6.1.5, S:L1265F, USA/Canada, from sars-cov-2-variants/lineage-proposals#957"
+  },
+  {
+    "Lineage": "HV.1.6",
+    "Earliest date": "2023-04-12",
+    "Latest date": "2024-02-10",
+    "Description": "Alias of XBB.1.9.2.5.1.6.1.6, ORF1a:T1794I, ORF1a:P2018S, Canada/USA"
+  },
+  {
+    "Lineage": "HV.1.6.1",
+    "Earliest date": "2023-09-03",
+    "Latest date": "2024-02-09",
+    "Description": "Alias of XBB.1.9.2.5.1.6.1.6.1, S:S704L, Canada, from sars-cov-2-variants/lineage-proposals#957"
+  },
+  {
+    "Lineage": "KL.1",
+    "Earliest date": "2023-10-13",
+    "Latest date": "2024-02-29",
+    "Description": "Alias of XBB.1.9.2.5.1.6.1.6.1.1, S:K444N, Canada, from sars-cov-2-variants/lineage-proposals#1174"
+  },
+  {
+    "Lineage": "KL.1.1",
+    "Earliest date": "2023-10-27",
+    "Latest date": "2024-02-29",
+    "Description": "Alias of XBB.1.9.2.5.1.6.1.6.1.1.1, S:H1101Y, Canada"
+  },
+  {
+    "Lineage": "HV.1.7",
+    "Earliest date": "2023-09-20",
+    "Latest date": "2023-12-13",
+    "Description": "Alias of XBB.1.9.2.5.1.6.1.7, S:S221L, Canada, from sars-cov-2-variants/lineage-proposals#957"
+  },
+  {
+    "Lineage": "HV.1.8",
+    "Earliest date": "2023-08-07",
+    "Latest date": "2024-03-01",
+    "Description": "Alias of XBB.1.9.2.5.1.6.1.8, S:T208M, USA, from #2432"
+  },
+  {
+    "Lineage": "HV.1.9",
+    "Earliest date": "2023-10-02",
+    "Latest date": "2024-04-19",
+    "Description": "Alias of XBB.1.9.2.5.1.6.1.9, S:N211I, S:T1117I, New Zealand, from sars-cov-2-variants/lineage-proposals#957"
+  },
+  {
+    "Lineage": "HV.1.10",
+    "Earliest date": "2023-09-21",
+    "Latest date": "2024-02-06",
+    "Description": "Alias of XBB.1.9.2.5.1.6.1.10, S:R452W, USA, from sars-cov-2-variants/lineage-proposals#1044"
+  },
+  {
+    "Lineage": "HV.1.11",
+    "Earliest date": "2023-10-16",
+    "Latest date": "2024-02-06",
+    "Description": "Alias of XBB.1.9.2.5.1.6.1.11, S:N450D, USA"
+  },
+  {
+    "Lineage": "HV.2",
+    "Earliest date": "2023-09-11",
+    "Latest date": "2024-05-10",
+    "Description": "Alias of XBB.1.9.2.5.1.6.2, S:L455F (G22927T), Canada, from sars-cov-2-variants/lineage-proposals#537"
+  },
+  {
+    "Lineage": "EG.5.1.7",
+    "Earliest date": "2023-07-14",
+    "Latest date": "2024-05-13",
+    "Description": "Alias of XBB.1.9.2.5.1.7, S:K278N"
+  },
+  {
+    "Lineage": "EG.5.1.8",
+    "Earliest date": "2022-12-31",
+    "Latest date": "2024-04-29",
+    "Description": "Alias of XBB.1.9.2.5.1.8, S:L455F (G22927T), China, on C29762T branch, from sars-cov-2-variants/lineage-proposals#537"
+  },
+  {
+    "Lineage": "KB.1",
+    "Earliest date": "2023-07-24",
+    "Latest date": "2024-02-24",
+    "Description": "Alias of XBB.1.9.2.5.1.8.1, S:E654V, China, from #2347"
+  },
+  {
+    "Lineage": "KB.2",
+    "Earliest date": "2023-08-16",
+    "Latest date": "2024-02-01",
+    "Description": "Alias of XBB.1.9.2.5.1.8.2, S:R214H"
+  },
+  {
+    "Lineage": "KB.3",
+    "Earliest date": "2023-08-26",
+    "Latest date": "2024-01-04",
+    "Description": "Alias of XBB.1.9.2.5.1.8.2, S:A83T, from sars-cov-2-variants/lineage-proposals#1052"
+  },
+  {
+    "Lineage": "KB.4",
+    "Earliest date": "2023-07-29",
+    "Latest date": "2024-03-06",
+    "Description": "Alias of XBB.1.9.2.5.1.8.2, S:T95I, from sars-cov-2-variants/lineage-proposals#891"
+  },
+  {
+    "Lineage": "EG.5.1.9",
+    "Earliest date": "2023-07-03",
+    "Latest date": "2023-12-31",
+    "Description": "Alias of XBB.1.9.2.5.1.9, S:L176F (on ORF1a:D982G branch)"
+  },
+  {
+    "Lineage": "EG.5.1.10",
+    "Earliest date": "2023-06-08",
+    "Latest date": "2023-11-27",
+    "Description": "Alias of XBB.1.9.2.5.1.10, ORF1a:I3758V, Portugal/Spain"
+  },
+  {
+    "Lineage": "EG.5.1.11",
+    "Earliest date": "2023-04-12",
+    "Latest date": "2023-12-18",
+    "Description": "Alias of XBB.1.9.2.5.1.11, S:K182Q, Indonesia"
+  },
+  {
+    "Lineage": "JR.1",
+    "Earliest date": "2023-05-06",
+    "Latest date": "2023-05-19",
+    "Description": "Alias of XBB.1.9.2.5.1.11.1, S:478R, ORF3a:Y91C, Indonesia"
+  },
+  {
+    "Lineage": "JR.1.1",
+    "Earliest date": "2023-08-14",
+    "Latest date": "2024-04-04",
+    "Description": "Alias of XBB.1.9.2.5.1.11.1.1, S:L455F (G22927C), from sars-cov-2-variants/lineage-proposals#537"
+  },
+  {
+    "Lineage": "JR.1.1.1",
+    "Earliest date": "2023-09-12",
+    "Latest date": "2024-02-10",
+    "Description": "Alias of XBB.1.9.2.5.1.11.1.1.1, S:K356Q, Thailand, from sars-cov-2-variants/lineage-proposals#1015"
+  },
+  {
+    "Lineage": "EG.5.1.12",
+    "Earliest date": "2023-05-10",
+    "Latest date": "2024-02-22",
+    "Description": "Alias of XBB.1.9.2.5.1.12, T26972C, C28909T"
+  },
+  {
+    "Lineage": "EG.5.1.13",
+    "Earliest date": "2023-03-20",
+    "Latest date": "2024-07-02",
+    "Description": "Alias of XBB.1.9.2.5.1.13, C12439T"
+  },
+  {
+    "Lineage": "EG.5.1.14",
+    "Earliest date": "2023-04-03",
+    "Latest date": "2024-02-20",
+    "Description": "Alias of XBB.1.9.2.5.1.14, C16017T, C19524T"
+  },
+  {
+    "Lineage": "EG.5.1.15",
+    "Earliest date": "2023-04-15",
+    "Latest date": "2024-02-20",
+    "Description": "Alias of XBB.1.9.2.5.1.15, ORF1a:T753I"
+  },
+  {
+    "Lineage": "EG.5.1.16",
+    "Earliest date": "2023-04-16",
+    "Latest date": "2024-04-05",
+    "Description": "Alias of XBB.1.9.2.5.1.16, ORF1b:A2431V, from sars-cov-2-variants/lineage-proposals#899"
+  },
+  {
+    "Lineage": "EG.5.1.17",
+    "Earliest date": "2023-06-28",
+    "Latest date": "2024-01-29",
+    "Description": "Alias of XBB.1.9.2.5.1.17, S:L455F (G22927C), China, from sars-cov-2-variants/lineage-proposals#537"
+  },
+  {
+    "Lineage": "EG.5.1.18",
+    "Earliest date": "2023-05-04",
+    "Latest date": "2024-02-10",
+    "Description": "Alias of XBB.1.9.2.5.1.18, ORF1a:G3002S, ORF3a:S220I"
+  },
+  {
+    "Lineage": "EG.5.1.19",
+    "Earliest date": "2023-06-01",
+    "Latest date": "2024-02-08",
+    "Description": "Alias of XBB.1.9.2.5.1.19, S:L455F (G22927T), ORF1b:K1383R, ORF3a:M260K, from sars-cov-2-variants/lineage-proposals#537"
+  },
+  {
+    "Lineage": "EG.5.2",
+    "Earliest date": "2023-02-09",
+    "Latest date": "2024-01-04",
+    "Description": "Alias of XBB.1.9.2.5.2, N:L161F"
+  },
+  {
+    "Lineage": "EG.5.2.1",
+    "Earliest date": "2022-12-31",
+    "Latest date": "2024-01-21",
+    "Description": "Alias of XBB.1.9.2.5.2.1, S:S704L, USA, from sars-cov-2-variants/lineage-proposals#189"
+  },
+  {
+    "Lineage": "EG.5.2.2",
+    "Earliest date": "2023-03-18",
+    "Latest date": "2023-12-27",
+    "Description": "Alias of XBB.1.9.2.5.2.2, ORF1b:T239I, China"
+  },
+  {
+    "Lineage": "EG.5.2.3",
+    "Earliest date": "2023-05-30",
+    "Latest date": "2023-10-14",
+    "Description": "Alias of XBB.1.9.2.5.2.3, S:S704L, S:N1178D, Austria/USA, from sars-cov-2-variants/lineage-proposals#353"
+  },
+  {
+    "Lineage": "EG.5.2.4",
+    "Earliest date": "2023-05-12",
+    "Latest date": "2023-10-22",
+    "Description": "Alias of XBB.1.9.2.5.2.4, S:K679R, on ORF3a:I118V branch, from sars-cov-2-variants/lineage-proposals#770"
+  },
+  {
+    "Lineage": "EG.6",
+    "Earliest date": "2023-01-30",
+    "Latest date": "2023-11-08",
+    "Description": "Alias of XBB.1.9.2.6, C1684T, Israel"
+  },
+  {
+    "Lineage": "EG.6.1",
+    "Earliest date": "2023-02-14",
+    "Latest date": "2024-08-11",
+    "Description": "Alias of XBB.1.9.2.6.1, S:F456L (T22928C), Israel/Japan/Canada, from #1950"
+  },
+  {
+    "Lineage": "EG.6.1.1",
+    "Earliest date": "2023-07-07",
+    "Latest date": "2024-01-05",
+    "Description": "Alias of XBB.1.9.2.6.1.1, S:484K, S:L242I, from sars-cov-2-variants/lineage-proposals#546"
+  },
+  {
+    "Lineage": "EG.6.1.2",
+    "Earliest date": "2023-06-21",
+    "Latest date": "2024-01-18",
+    "Description": "Alias of XBB.1.9.2.6.1.2, S:V705I, Israel, from sars-cov-2-variants/lineage-proposals#826"
+  },
+  {
+    "Lineage": "EG.7",
+    "Earliest date": "2023-03-18",
+    "Latest date": "2024-01-02",
+    "Description": "Alias of XBB.1.9.2.7, S:R403K, S:L513F, ORF1a:N2531S, Germany/England, from sars-cov-2-variants/lineage-proposals#56"
+  },
+  {
+    "Lineage": "EG.8",
+    "Earliest date": "2022-05-17",
+    "Latest date": "2023-09-19",
+    "Description": "Alias of XBB.1.9.2.8, ORF1a:S2303F, Europe"
+  },
+  {
+    "Lineage": "EG.9",
+    "Earliest date": "2023-05-22",
+    "Latest date": "2023-07-17",
+    "Description": "Alias of XBB.1.9.2.9, S:403K, ORF1a:T1474I, ORF1b:N969S, from sars-cov-2-variants/lineage-proposals#280"
+  },
+  {
+    "Lineage": "EG.9.1",
+    "Earliest date": "2023-04-12",
+    "Latest date": "2023-12-04",
+    "Description": "Alias of XBB.1.9.2.9.1, S:A344T, C13767T, from sars-cov-2-variants/lineage-proposals#57"
+  },
+  {
+    "Lineage": "EG.10",
+    "Earliest date": "2023-03-29",
+    "Latest date": "2024-01-15",
+    "Description": "Alias of XBB.1.9.2.10, S:A344T, S:R403K, Germany/Austria, from sars-cov-2-variants/lineage-proposals#346"
+  },
+  {
+    "Lineage": "EG.10.1",
+    "Earliest date": "2023-05-30",
+    "Latest date": "2024-02-01",
+    "Description": "Alias of XBB.1.9.2.10.1, S:S494P, S:A701V, from sars-cov-2-variants/lineage-proposals#346"
+  },
+  {
+    "Lineage": "EG.10.1.1",
+    "Earliest date": "2023-06-07",
+    "Latest date": "2024-04-29",
+    "Description": "Alias of XBB.1.9.2.10.1.1, ORF1a:V2703L, ORF1a:V3683I, ORF1b:P1570S"
+  },
+  {
+    "Lineage": "EG.11",
+    "Earliest date": "2022-10-18",
+    "Latest date": "2024-06-06",
+    "Description": "Alias of XBB.1.9.2.11, S:E554K, A26319G, Malaysia, from sars-cov-2-variants/lineage-proposals#523"
+  },
+  {
+    "Lineage": "EG.12",
+    "Earliest date": "2023-02-05",
+    "Latest date": "2023-09-14",
+    "Description": "Alias of XBB.1.9.2.12, S:E554K, N:R195T, ORF1a:T4159I, Oman/Austria/Brunei/India"
+  },
+  {
+    "Lineage": "EG.13",
+    "Earliest date": "2022-07-16",
+    "Latest date": "2023-12-05",
+    "Description": "Alias of XBB.1.9.2.13, ORF1a:K798N"
+  },
+  {
+    "Lineage": "EG.14",
+    "Earliest date": "2023-01-08",
+    "Latest date": "2024-04-22",
+    "Description": "Alias of XBB.1.9.2.14, Orf1b:K1383R, from #2274"
+  },
+  {
+    "Lineage": "XBB.1.9.3",
+    "Earliest date": "2022-12-01",
+    "Latest date": "2023-07-27",
+    "Description": "ORF1b:G2005S, ORF1b:G1568C, Europe, from jmcbroome/auto-pango-designation#193"
+  },
+  {
+    "Lineage": "GD.1",
+    "Earliest date": "2023-02-14",
+    "Latest date": "2023-10-23",
+    "Description": "Alias of XBB.1.9.3.1, S:Y453F, Mexico/USA, from #1897"
+  },
+  {
+    "Lineage": "GD.2",
+    "Earliest date": "2022-12-20",
+    "Latest date": "2023-05-17",
+    "Description": "Alias of XBB.1.9.3.2, S:L212S, Philippines"
+  },
+  {
+    "Lineage": "GD.3",
+    "Earliest date": "2022-12-19",
+    "Latest date": "2024-04-05",
+    "Description": "Alias of XBB.1.9.3.3, S:F59L, Russia"
+  },
+  {
+    "Lineage": "XBB.1.9.4",
+    "Earliest date": "2022-11-17",
+    "Latest date": "2023-07-20",
+    "Description": "28603T, Europe"
+  },
+  {
+    "Lineage": "XBB.1.9.5",
+    "Earliest date": "2022-11-24",
+    "Latest date": "2023-10-27",
+    "Description": "ORF1a:D629E, Russia"
+  },
+  {
+    "Lineage": "XBB.1.9.6",
+    "Earliest date": "2023-01-31",
+    "Latest date": "2023-06-28",
+    "Description": "S:403K, S:570T, Indonesia"
+  },
+  {
+    "Lineage": "XBB.1.9.7",
+    "Earliest date": "2023-02-23",
+    "Latest date": "2023-09-08",
+    "Description": "S:486P, S:478R, ORF1a:P1018T, Indonesia"
+  },
+  {
+    "Lineage": "XBB.1.10",
+    "Earliest date": "2022-11-22",
+    "Latest date": "2023-05-04",
+    "Description": "USA/Japan, S:A852V, S:R403K, pre ORF8:8*"
+  },
+  {
+    "Lineage": "XBB.1.11",
+    "Earliest date": "2022-10-20",
+    "Latest date": "2023-06-08",
+    "Description": "Indonesia/Malaysia/Singapore/USA, C13968A and G16377A, from #1490"
+  },
+  {
+    "Lineage": "XBB.1.11.1",
+    "Earliest date": "2022-11-04",
+    "Latest date": "2023-08-08",
+    "Description": "Indonesia/Malaysia/Singapore, S:S486P, from #1490"
+  },
+  {
+    "Lineage": "FP.1",
+    "Earliest date": "2023-01-30",
+    "Latest date": "2023-09-03",
+    "Description": "Alias of XBB.1.11.1.1, A6616G, C21642T, following ORF1a:T2016I, Singapore, from #1847"
+  },
+  {
+    "Lineage": "FP.2",
+    "Earliest date": "2022-12-19",
+    "Latest date": "2023-07-27",
+    "Description": "Alias of XBB.1.11.1.2, S:F186S, ORF1a:V3078I, Indonesia/Malaysia/Singapore, from sars-cov-2-variants/lineage-proposals#31"
+  },
+  {
+    "Lineage": "FP.2.1",
+    "Earliest date": "2023-03-10",
+    "Latest date": "2023-09-14",
+    "Description": "Alias of XBB.1.11.1.2.1, S:478R, ORF1a:I693T, ORF1a:T951A, ORF3a:W149C, Indonesia, from #2012"
+  },
+  {
+    "Lineage": "FP.2.1.1",
+    "Earliest date": "2023-05-31",
+    "Latest date": "2023-10-31",
+    "Description": "Alias of XBB.1.11.1.2.1.1, S:L452Q, USA/Austria, from sars-cov-2-variants/lineage-proposals#329"
+  },
+  {
+    "Lineage": "FP.2.1.2",
+    "Earliest date": "2023-04-13",
+    "Latest date": "2023-07-16",
+    "Description": "Alias of XBB.1.11.1.2.1.2, S:P521S, Indonesia"
+  },
+  {
+    "Lineage": "FP.3",
+    "Earliest date": "2023-02-02",
+    "Latest date": "2023-07-11",
+    "Description": "Alias of XBB.1.11.1.3, S:478R, Indonesia/Malaysia, from #2021"
+  },
+  {
+    "Lineage": "FP.4",
+    "Earliest date": "2023-03-02",
+    "Latest date": "2023-09-29",
+    "Description": "Alias of XBB.1.11.1.4, C3241T, C2536T, Vietnam/South Korea/Japan"
+  },
+  {
+    "Lineage": "XBB.1.12",
+    "Earliest date": "2022-12-15",
+    "Latest date": "2023-06-08",
+    "Description": "Spain/Sweden/Germany, S:Y453F, ORF1a:S216F, ORF1a:A2832V"
+  },
+  {
+    "Lineage": "XBB.1.12.1",
+    "Earliest date": "2023-03-29",
+    "Latest date": "2023-07-12",
+    "Description": "S:Q613H, S:E1202Q, Argentina/Chile/Spain, from sars-cov-2-variants/lineage-proposals#336"
+  },
+  {
+    "Lineage": "XBB.1.13",
+    "Earliest date": "2022-08-01",
+    "Latest date": "2023-05-30",
+    "Description": "S:S490P, from #1487"
+  },
+  {
+    "Lineage": "XBB.1.13.1",
+    "Earliest date": "2021-07-16",
+    "Latest date": "2023-11-06",
+    "Description": "S:Q564E, S:N856K, Czechia"
+  },
+  {
+    "Lineage": "XBB.1.14",
+    "Earliest date": "2022-11-06",
+    "Latest date": "2023-05-15",
+    "Description": "S:G75V, S:E554K"
+  },
+  {
+    "Lineage": "XBB.1.14.1",
+    "Earliest date": "2023-01-09",
+    "Latest date": "2023-05-17",
+    "Description": "S:N148T, N:A211S, Russia"
+  },
+  {
+    "Lineage": "XBB.1.15",
+    "Earliest date": "2022-01-28",
+    "Latest date": "2023-07-20",
+    "Description": "ORF1a:A540V on ORF8:G8* polytomy, Colombia, USA, Guatemala, and Mexico. Automatically inferred by https://github.com/jmcbroome/autolin."
+  },
+  {
+    "Lineage": "XBB.1.15.1",
+    "Earliest date": "2023-01-25",
+    "Latest date": "2023-06-27",
+    "Description": "S:486P, A19464G, C9803T, Brazil/Chile/USA"
+  },
+  {
+    "Lineage": "XBB.1.16",
+    "Earliest date": "2020-11-20",
+    "Latest date": "2024-05-02",
+    "Description": "Defined by S:E180V, S:478R, found in India, USA, Singapore, and Europe, from #1723"
+  },
+  {
+    "Lineage": "XBB.1.16.1",
+    "Earliest date": "2022-10-18",
+    "Latest date": "2024-03-21",
+    "Description": "Defined by S:T547I, from #1772"
+  },
+  {
+    "Lineage": "FU.1",
+    "Earliest date": "2023-02-13",
+    "Latest date": "2024-02-12",
+    "Description": "Alias of XBB.1.16.1.1, T3802C"
+  },
+  {
+    "Lineage": "FU.1.1",
+    "Earliest date": "2023-03-12",
+    "Latest date": "2023-11-25",
+    "Description": "Alias of XBB.1.16.1.1.1, S:K1266R"
+  },
+  {
+    "Lineage": "FU.1.1.1",
+    "Earliest date": "2023-07-03",
+    "Latest date": "2023-12-14",
+    "Description": "Alias of XBB.1.16.1.1.1.1, S:N74S, USA"
+  },
+  {
+    "Lineage": "FU.2",
+    "Earliest date": "2023-02-09",
+    "Latest date": "2024-02-20",
+    "Description": "Alias of XBB.1.16.1.2, C8692T"
+  },
+  {
+    "Lineage": "FU.2.1",
+    "Earliest date": "2023-03-22",
+    "Latest date": "2024-03-26",
+    "Description": "Alias of XBB.1.16.1.2.1, S:E619Q, Vietnam"
+  },
+  {
+    "Lineage": "FU.3",
+    "Earliest date": "2023-03-06",
+    "Latest date": "2023-11-21",
+    "Description": "Alias of XBB.1.16.1.3, C11665T, India-RJ"
+  },
+  {
+    "Lineage": "FU.3.1",
+    "Earliest date": "2023-03-31",
+    "Latest date": "2023-09-12",
+    "Description": "Alias of XBB.1.16.1.3.1, S:G184S"
+  },
+  {
+    "Lineage": "FU.4",
+    "Earliest date": "2023-03-17",
+    "Latest date": "2023-08-07",
+    "Description": "Alias of XBB.1.16.1.4, S:Y453F, T29410C, from #1832"
+  },
+  {
+    "Lineage": "FU.5",
+    "Earliest date": "2023-04-23",
+    "Latest date": "2023-12-10",
+    "Description": "Alias of XBB.1.16.1.5, S:K97E, ORF1a:R542C, Bangladesh, from #2137"
+  },
+  {
+    "Lineage": "XBB.1.16.2",
+    "Earliest date": "2023-02-20",
+    "Latest date": "2024-06-18",
+    "Description": "Defined by ORF3a:V13L, ORF1a:P926H, India, from #1802"
+  },
+  {
+    "Lineage": "GY.1",
+    "Earliest date": "2023-04-16",
+    "Latest date": "2023-11-11",
+    "Description": "Alias of XBB.1.16.2.1, S:L84I, ORF1a:A4068S, China, from #2066"
+  },
+  {
+    "Lineage": "GY.1.1",
+    "Earliest date": "2023-08-19",
+    "Latest date": "2023-12-03",
+    "Description": "Alias of XBB.1.16.2.1.1, S:L455F (G22927T), S:F456L (T22928C), China, from sars-cov-2-variants/lineage-proposals#804"
+  },
+  {
+    "Lineage": "GY.1.1.1",
+    "Earliest date": "2023-06-20",
+    "Latest date": "2024-01-15",
+    "Description": "Alias of XBB.1.16.2.1.1.1, S:A475V, Thailand, from sars-cov-2-variants/lineage-proposals#804"
+  },
+  {
+    "Lineage": "GY.2",
+    "Earliest date": "2023-04-18",
+    "Latest date": "2023-07-23",
+    "Description": "Alias of XBB.1.16.2.2, S:T883I"
+  },
+  {
+    "Lineage": "GY.2.1",
+    "Earliest date": "2023-03-20",
+    "Latest date": "2023-11-13",
+    "Description": "Alias of XBB.1.16.2.2.1, S:S255F, South Korea"
+  },
+  {
+    "Lineage": "GY.3",
+    "Earliest date": "2023-04-11",
+    "Latest date": "2023-09-19",
+    "Description": "Alias of XBB.1.16.2.3, S:M177I, Thailand"
+  },
+  {
+    "Lineage": "GY.4",
+    "Earliest date": "2023-05-13",
+    "Latest date": "2023-08-19",
+    "Description": "Alias of XBB.1.16.2.4, S:N450K, C29095T, Laos, from sars-cov-2-variants/lineage-proposals#345"
+  },
+  {
+    "Lineage": "GY.5",
+    "Earliest date": "2023-01-03",
+    "Latest date": "2023-12-04",
+    "Description": "Alias of XBB.1.16.2.5, G9190C"
+  },
+  {
+    "Lineage": "GY.6",
+    "Earliest date": "2023-04-10",
+    "Latest date": "2023-11-27",
+    "Description": "Alias of XBB.1.16.2.6, ORF1a:V1765I, from sars-cov-2-variants/lineage-proposals#308"
+  },
+  {
+    "Lineage": "GY.7",
+    "Earliest date": "2023-03-22",
+    "Latest date": "2023-12-08",
+    "Description": "Alias of XBB.1.16.2.7, ORF1a:G3617C, G5515T, Thailand/Laos"
+  },
+  {
+    "Lineage": "GY.8",
+    "Earliest date": "2023-05-19",
+    "Latest date": "2023-12-08",
+    "Description": "Alias of XBB.1.16.2.8, S:F456L (T22928C), C25452T, Japan, from #2148"
+  },
+  {
+    "Lineage": "GY.9",
+    "Earliest date": "2023-05-23",
+    "Latest date": "2023-11-22",
+    "Description": "Alias of XBB.1.16.2.9, S:F186S, Europe"
+  },
+  {
+    "Lineage": "XBB.1.16.3",
+    "Earliest date": "2022-10-10",
+    "Latest date": "2023-11-13",
+    "Description": "Defined by A2893C, India"
+  },
+  {
+    "Lineage": "XBB.1.16.4",
+    "Earliest date": "2023-02-20",
+    "Latest date": "2024-02-13",
+    "Description": "Defined by S:T678I, India, from #1903"
+  },
+  {
+    "Lineage": "XBB.1.16.5",
+    "Earliest date": "2023-02-04",
+    "Latest date": "2023-11-07",
+    "Description": "Defined by T9991C,C16332T, India, from #1983"
+  },
+  {
+    "Lineage": "XBB.1.16.6",
+    "Earliest date": "2022-10-18",
+    "Latest date": "2024-03-28",
+    "Description": "S:F456L (T22930A), A12397G, USA/Canada/China/Malaysia"
+  },
+  {
+    "Lineage": "JF.1",
+    "Earliest date": "2023-06-27",
+    "Latest date": "2024-02-28",
+    "Description": "Alias of XBB.1.16.6.1, S:L455F (G22927T), USA, from #2207"
+  },
+  {
+    "Lineage": "JF.1.1",
+    "Earliest date": "2023-02-20",
+    "Latest date": "2024-04-03",
+    "Description": "Alias of XBB.1.16.6.1.1, ORF1a:S2030L"
+  },
+  {
+    "Lineage": "JF.1.1.1",
+    "Earliest date": "2023-09-18",
+    "Latest date": "2023-12-01",
+    "Description": "Alias of XBB.1.16.6.1.1.1, S:A475V, ORF1a:P2005S, Canada, from sars-cov-2-variants/lineage-proposals#643"
+  },
+  {
+    "Lineage": "JF.1.1.2",
+    "Earliest date": "2023-09-20",
+    "Latest date": "2024-02-29",
+    "Description": "Alias of XBB.1.16.6.1.1.2, S:V1264L"
+  },
+  {
+    "Lineage": "JF.2",
+    "Earliest date": "2023-05-28",
+    "Latest date": "2023-12-07",
+    "Description": "Alias of XBB.1.16.6.2, S:Q675H, USA/Wales, from sars-cov-2-variants/lineage-proposals#457"
+  },
+  {
+    "Lineage": "JF.3",
+    "Earliest date": "2023-09-05",
+    "Latest date": "2024-01-16",
+    "Description": "Alias of XBB.1.16.6.3, S:Q14H, S:L455F (G22927T), S:S810L, USA/Australia, from sars-cov-2-variants/lineage-proposals#976"
+  },
+  {
+    "Lineage": "JF.4",
+    "Earliest date": "2021-07-16",
+    "Latest date": "2024-02-06",
+    "Description": "Alias of XBB.1.16.6.4, ORF1a:S212L, ORF8:A15V"
+  },
+  {
+    "Lineage": "XBB.1.16.7",
+    "Earliest date": "2023-03-19",
+    "Latest date": "2023-12-29",
+    "Description": "S:T732I after T12214C, Singapore/Japan/SouthKorea"
+  },
+  {
+    "Lineage": "XBB.1.16.8",
+    "Earliest date": "2023-03-04",
+    "Latest date": "2023-12-07",
+    "Description": "S:T732I after C28531T, India/USA/China/Australia"
+  },
+  {
+    "Lineage": "XBB.1.16.9",
+    "Earliest date": "2023-04-25",
+    "Latest date": "2024-07-30",
+    "Description": "S:F456L (T22930G), ORF1a:S2500F, Canada/Sweden/SouthKorea/USA"
+  },
+  {
+    "Lineage": "XBB.1.16.10",
+    "Earliest date": "2023-03-14",
+    "Latest date": "2023-11-28",
+    "Description": "N:G25D, from #1984"
+  },
+  {
+    "Lineage": "XBB.1.16.11",
+    "Earliest date": "2020-10-23",
+    "Latest date": "2024-04-04",
+    "Description": "S:P521T, India"
+  },
+  {
+    "Lineage": "XBB.1.16.12",
+    "Earliest date": "2023-03-25",
+    "Latest date": "2024-01-01",
+    "Description": "S:Q52H, South Korea"
+  },
+  {
+    "Lineage": "XBB.1.16.13",
+    "Earliest date": "2023-02-06",
+    "Latest date": "2023-12-18",
+    "Description": "ORF1a:G519S, ORF1a:G1101D, India"
+  },
+  {
+    "Lineage": "HF.1",
+    "Earliest date": "2023-05-10",
+    "Latest date": "2024-07-03",
+    "Description": "Alias of XBB.1.16.13.1, S:K304N, South Korea/Japan, from #2083"
+  },
+  {
+    "Lineage": "HF.1.1",
+    "Earliest date": "2023-06-13",
+    "Latest date": "2024-02-15",
+    "Description": "Alias of XBB.1.16.13.1.1, S:H1101Y, on N:A35T branch, South Korea/USA/Canada, from sars-cov-2-variants/lineage-proposals#521"
+  },
+  {
+    "Lineage": "HF.1.2",
+    "Earliest date": "2023-06-11",
+    "Latest date": "2024-01-16",
+    "Description": "Alias of XBB.1.16.13.1.2, S:A688V, on ORF1a:P1158S branch, USA"
+  },
+  {
+    "Lineage": "XBB.1.16.14",
+    "Earliest date": "2023-03-29",
+    "Latest date": "2023-12-27",
+    "Description": "S:L452Q, after A11782G, India/France/Canada, from sars-cov-2-variants/lineage-proposals#329"
+  },
+  {
+    "Lineage": "XBB.1.16.15",
+    "Earliest date": "2022-08-01",
+    "Latest date": "2024-06-03",
+    "Description": "S:K147N, S:P521S, T10756C, T14067C, on C27513T branch, from #2092"
+  },
+  {
+    "Lineage": "JM.1",
+    "Earliest date": "2023-07-18",
+    "Latest date": "2024-01-02",
+    "Description": "Alias of XBB.1.16.15.1, S:Q52H, England/Wales, from sars-cov-2-variants/lineage-proposals#569"
+  },
+  {
+    "Lineage": "JM.2",
+    "Earliest date": "2023-07-05",
+    "Latest date": "2024-01-29",
+    "Description": "Alias of XBB.1.16.15.2, S:R78S, Europe/North America"
+  },
+  {
+    "Lineage": "XBB.1.16.16",
+    "Earliest date": "2023-03-24",
+    "Latest date": "2024-04-17",
+    "Description": "S:Q613H, S:S412N, India-GJ/USA/Pakistan, from sars-cov-2-variants/lineage-proposals#54"
+  },
+  {
+    "Lineage": "XBB.1.16.17",
+    "Earliest date": "2022-11-16",
+    "Latest date": "2024-06-14",
+    "Description": "S:E554K, mainly in NZ, from sars-cov-2-variants/lineage-proposals#354"
+  },
+  {
+    "Lineage": "XBB.1.16.18",
+    "Earliest date": "2023-02-27",
+    "Latest date": "2023-11-20",
+    "Description": "ORF7a:T39I, from sars-cov-2-variants/lineage-proposals#276"
+  },
+  {
+    "Lineage": "XBB.1.16.19",
+    "Earliest date": "2021-07-16",
+    "Latest date": "2024-03-16",
+    "Description": "ORF1b:V839I"
+  },
+  {
+    "Lineage": "XBB.1.16.20",
+    "Earliest date": "2023-02-21",
+    "Latest date": "2023-11-26",
+    "Description": "ORF7b:S31L"
+  },
+  {
+    "Lineage": "XBB.1.16.21",
+    "Earliest date": "2022-10-18",
+    "Latest date": "2023-12-17",
+    "Description": "ORF1a:V4072I"
+  },
+  {
+    "Lineage": "XBB.1.16.22",
+    "Earliest date": "2023-03-10",
+    "Latest date": "2023-10-16",
+    "Description": "ORF3a:E242Q, from #1893"
+  },
+  {
+    "Lineage": "XBB.1.16.23",
+    "Earliest date": "2023-04-06",
+    "Latest date": "2024-02-19",
+    "Description": "S:K304Q, India/USA/Japan/Singapore, from #2187"
+  },
+  {
+    "Lineage": "XBB.1.16.24",
+    "Earliest date": "2023-04-28",
+    "Latest date": "2024-01-09",
+    "Description": "S:K182E, S:V551I, S:E554K, on A25410G branch, India, from #2223"
+  },
+  {
+    "Lineage": "XBB.1.16.25",
+    "Earliest date": "2023-03-02",
+    "Latest date": "2023-10-25",
+    "Description": "ORF1a:K510E, C16611T, A29221G"
+  },
+  {
+    "Lineage": "XBB.1.16.26",
+    "Earliest date": "2023-03-16",
+    "Latest date": "2024-01-06",
+    "Description": "S:L455F (G22927T), S:F456L (T22928C), China, from sars-cov-2-variants/lineage-proposals#685"
+  },
+  {
+    "Lineage": "XBB.1.16.27",
+    "Earliest date": "2023-08-07",
+    "Latest date": "2024-02-13",
+    "Description": "S:F456L (T22928C), S:E554K, ORF1a:A3889T, France, from #2345"
+  },
+  {
+    "Lineage": "XBB.1.16.28",
+    "Earliest date": "2023-07-28",
+    "Latest date": "2024-07-22",
+    "Description": "S:V1230A, S:Q613H, S:Q675K, Russia, from sars-cov-2-variants/lineage-proposals#1000"
+  },
+  {
+    "Lineage": "XBB.1.16.29",
+    "Earliest date": "2023-04-11",
+    "Latest date": "2023-12-14",
+    "Description": "S:T883I, on C7765T branch, TrinidadTobago, from sars-cov-2-variants/lineage-proposals#524"
+  },
+  {
+    "Lineage": "XBB.1.16.30",
+    "Earliest date": "2023-05-09",
+    "Latest date": "2024-03-25",
+    "Description": "S:E554Q, on C7765T branch, USA/Germany, from sars-cov-2-variants/lineage-proposals#554"
+  },
+  {
+    "Lineage": "XBB.1.16.31",
+    "Earliest date": "2023-03-15",
+    "Latest date": "2024-03-15",
+    "Description": "T9004C, on C7765T branch"
+  },
+  {
+    "Lineage": "XBB.1.16.32",
+    "Earliest date": "2023-05-15",
+    "Latest date": "2023-11-15",
+    "Description": "S:S490P, South Africa/USA"
+  },
+  {
+    "Lineage": "KJ.1",
+    "Earliest date": "2023-07-20",
+    "Latest date": "2023-11-25",
+    "Description": "Alias of XBB.1.16.32.1, S:T573I, ORF1a:P1659L, South Africa"
+  },
+  {
+    "Lineage": "XBB.1.17",
+    "Earliest date": "2022-10-30",
+    "Latest date": "2023-03-13",
+    "Description": "Defined by T27995C and ORF1a:L469F, from #1712"
+  },
+  {
+    "Lineage": "XBB.1.17.1",
+    "Earliest date": "2022-01-18",
+    "Latest date": "2023-11-30",
+    "Description": "Defined by S:215H, S:S486P, from #1712"
+  },
+  {
+    "Lineage": "GA.1",
+    "Earliest date": "2023-01-23",
+    "Latest date": "2023-09-01",
+    "Description": "Alias of XBB.1.17.1.1, ORF1a:G728C"
+  },
+  {
+    "Lineage": "GA.2",
+    "Earliest date": "2023-01-23",
+    "Latest date": "2023-11-10",
+    "Description": "Alias of XBB.1.17.1.2, ORF3a:I179F, T6640C, Africa"
+  },
+  {
+    "Lineage": "GA.2.1",
+    "Earliest date": "2023-04-10",
+    "Latest date": "2023-10-10",
+    "Description": "Alias of XBB.1.17.1.2.1, S:E554K"
+  },
+  {
+    "Lineage": "GA.2.1.1",
+    "Earliest date": "2023-07-27",
+    "Latest date": "2024-01-08",
+    "Description": "Alias of XBB.1.17.1.2.1.1, S:N450D, S:K478R"
+  },
+  {
+    "Lineage": "GA.3",
+    "Earliest date": "2023-02-14",
+    "Latest date": "2023-11-15",
+    "Description": "Alias of XBB.1.17.1.3, ORF1b:A186V, Ghana"
+  },
+  {
+    "Lineage": "GA.4",
+    "Earliest date": "2023-03-23",
+    "Latest date": "2023-09-25",
+    "Description": "Alias of XBB.1.17.1.4, S:K356T, ORF1a:N1080D, ORF1a:S2553F, Nigeria, from sars-cov-2-variants/lineage-proposals#265"
+  },
+  {
+    "Lineage": "GA.4.1",
+    "Earliest date": "2023-07-07",
+    "Latest date": "2024-02-21",
+    "Description": "Alias of XBB.1.17.1.4.1, S:K478R, S:S704L, S:E554K, USA/Qatar, from sars-cov-2-variants/lineage-proposals#661"
+  },
+  {
+    "Lineage": "GA.4.1.1",
+    "Earliest date": "2023-08-16",
+    "Latest date": "2023-11-07",
+    "Description": "Alias of XBB.1.17.1.4.1.1, S:Q675H"
+  },
+  {
+    "Lineage": "GA.4.1.2",
+    "Earliest date": "2023-09-10",
+    "Latest date": "2023-12-10",
+    "Description": "Alias of XBB.1.17.1.4.1.2, S:T572I, England"
+  },
+  {
+    "Lineage": "GA.4.1.3",
+    "Earliest date": "2023-08-11",
+    "Latest date": "2024-01-04",
+    "Description": "Alias of XBB.1.17.1.4.1.3, S:185insLAG, S:F186D, N:K370N, ORF1a:V1339I, from sars-cov-2-variants/lineage-proposals#968"
+  },
+  {
+    "Lineage": "GA.4.2",
+    "Earliest date": "2023-08-29",
+    "Latest date": "2023-11-14",
+    "Description": "Alias of XBB.1.17.1.4.2, S:K558N, S:G1124S, England/Italy"
+  },
+  {
+    "Lineage": "GA.4.3",
+    "Earliest date": "2023-08-08",
+    "Latest date": "2023-10-09",
+    "Description": "Alias of XBB.1.17.1.4.3, S:F186L, S:L585F, Greece/Romania, from sars-cov-2-variants/lineage-proposals#908"
+  },
+  {
+    "Lineage": "GA.5",
+    "Earliest date": "2023-02-06",
+    "Latest date": "2024-01-18",
+    "Description": "Alias of XBB.1.17.1.5, T23797C"
+  },
+  {
+    "Lineage": "GA.6",
+    "Earliest date": "2023-02-14",
+    "Latest date": "2023-09-20",
+    "Description": "Alias of XBB.1.17.1.6, ORF1a:I2138V, G8785A, Ghana"
+  },
+  {
+    "Lineage": "GA.6.1",
+    "Earliest date": "2023-03-23",
+    "Latest date": "2023-07-11",
+    "Description": "Alias of XBB.1.17.1.6.1, S:478R, A19767G, C29642T"
+  },
+  {
+    "Lineage": "GA.7",
+    "Earliest date": "2023-02-13",
+    "Latest date": "2023-12-13",
+    "Description": "Alias of XBB.1.17.1.7, ORF1a:T1429I, Cote d'Ivoire"
+  },
+  {
+    "Lineage": "GA.7.1",
+    "Earliest date": "2023-08-21",
+    "Latest date": "2023-12-19",
+    "Description": "Alias of XBB.1.17.1.7.1, S:P521S, S:N148T, S:S494P, S:Q218R, from sars-cov-2-variants/lineage-proposals#755"
+  },
+  {
+    "Lineage": "GA.7.2",
+    "Earliest date": "2023-01-23",
+    "Latest date": "2023-08-03",
+    "Description": "Alias of XBB.1.17.1.7.2, S:H245Y"
+  },
+  {
+    "Lineage": "GA.8",
+    "Earliest date": "2023-02-13",
+    "Latest date": "2023-07-03",
+    "Description": "Alias of XBB.1.17.1.8, C3619T, C27389T, Congo"
+  },
+  {
+    "Lineage": "GA.8.1",
+    "Earliest date": "2023-07-29",
+    "Latest date": "2023-12-11",
+    "Description": "Alias of XBB.1.17.1.8.1, S:K182E, S:S494P, S:E554K, France/Belgium"
+  },
+  {
+    "Lineage": "GA.9",
+    "Earliest date": "2023-02-20",
+    "Latest date": "2023-11-21",
+    "Description": "Alias of XBB.1.17.1.9, ORF3a:K67N,T7534C,C29719A"
+  },
+  {
+    "Lineage": "GA.10",
+    "Earliest date": "2023-02-22",
+    "Latest date": "2023-03-22",
+    "Description": "Alias of XBB.1.17.1.10, ORF1a:V4520I, Mali"
+  },
+  {
+    "Lineage": "GA.10.1",
+    "Earliest date": "2023-09-15",
+    "Latest date": "2024-01-08",
+    "Description": "Alias of XBB.1.17.1.10.1, S:L455F (G22927T), S:F456L (T22928C), S:K478R, ORF1a:A776V, ORF1a:F1214S, ORF1b:K1947R, from sars-cov-2-variants/lineage-proposals#919"
+  },
+  {
+    "Lineage": "XBB.1.17.2",
+    "Earliest date": "2022-11-11",
+    "Latest date": "2023-03-31",
+    "Description": "Defined by ORF1a:A698S, Russia, from #1712"
+  },
+  {
+    "Lineage": "XBB.1.18",
+    "Earliest date": "2022-01-12",
+    "Latest date": "2023-08-08",
+    "Description": "Defined by A8001G, Brazil"
+  },
+  {
+    "Lineage": "XBB.1.18.1",
+    "Earliest date": "2022-10-26",
+    "Latest date": "2023-10-25",
+    "Description": "Defined by S:F486P, Brazil"
+  },
+  {
+    "Lineage": "FE.1",
+    "Earliest date": "2023-01-04",
+    "Latest date": "2023-11-12",
+    "Description": "Alias of XBB.1.18.1.1, S:F456L (T22928C), Brazil/Chile"
+  },
+  {
+    "Lineage": "FE.1.1",
+    "Earliest date": "2023-02-02",
+    "Latest date": "2023-11-27",
+    "Description": "Alias of XBB.1.18.1.1.1, ORF8:S67F, T4579A"
+  },
+  {
+    "Lineage": "FE.1.1.1",
+    "Earliest date": "2023-02-22",
+    "Latest date": "2023-11-24",
+    "Description": "Alias of XBB.1.18.1.1.1.1, ORF1a:T999I, North America"
+  },
+  {
+    "Lineage": "HE.1",
+    "Earliest date": "2023-02-12",
+    "Latest date": "2023-08-29",
+    "Description": "Alias of XBB.1.18.1.1.1.1.1, S:V622I, ORF8:A55V, USA/Puerto Rico, from #2067"
+  },
+  {
+    "Lineage": "HE.2",
+    "Earliest date": "2023-05-24",
+    "Latest date": "2023-11-07",
+    "Description": "Alias of XBB.1.18.1.1.1.1.2, S:H1058Y, USA"
+  },
+  {
+    "Lineage": "FE.1.1.2",
+    "Earliest date": "2023-01-03",
+    "Latest date": "2023-09-04",
+    "Description": "Alias of XBB.1.18.1.1.1.2, S:K1086R, Brazil/USA"
+  },
+  {
+    "Lineage": "FE.1.1.3",
+    "Earliest date": "2023-04-01",
+    "Latest date": "2023-08-30",
+    "Description": "Alias of XBB.1.18.1.1.1.3, A24775G, on G28371T (N:G33V, ORF9b:V30L) branch, China"
+  },
+  {
+    "Lineage": "FE.1.1.4",
+    "Earliest date": "2023-03-13",
+    "Latest date": "2023-11-27",
+    "Description": "Alias of XBB.1.18.1.1.1.4, A4336G, T24073C, Brazil"
+  },
+  {
+    "Lineage": "FE.1.1.5",
+    "Earliest date": "2023-04-09",
+    "Latest date": "2023-12-28",
+    "Description": "Alias of XBB.1.18.1.1.1.5, S:E554K, Brazil, from sars-cov-2-variants/lineage-proposals#556"
+  },
+  {
+    "Lineage": "FE.1.2",
+    "Earliest date": "2022-06-28",
+    "Latest date": "2023-12-29",
+    "Description": "Alias of XBB.1.18.1.1.2, A5488G"
+  },
+  {
+    "Lineage": "XBB.1.19",
+    "Earliest date": "2022-12-23",
+    "Latest date": "2023-10-31",
+    "Description": "Defined by S:486P, A10042G, T21363C, on C541T, pre ORF8:8* branch, Pakistan, from #1680"
+  },
+  {
+    "Lineage": "XBB.1.19.1",
+    "Earliest date": "2023-01-18",
+    "Latest date": "2024-02-07",
+    "Description": "Defined by S:E554K, Pakistan, from #1765"
+  },
+  {
+    "Lineage": "GW.1",
+    "Earliest date": "2023-03-26",
+    "Latest date": "2023-10-05",
+    "Description": "Alias of XBB.1.19.1.1, ORF1a:D264N, N:M322V, China, from sars-cov-2-variants/lineage-proposals#157"
+  },
+  {
+    "Lineage": "GW.1.1",
+    "Earliest date": "2023-04-30",
+    "Latest date": "2023-11-24",
+    "Description": "Alias of XBB.1.19.1.1.1, S:F456L (T22928C), China/Japan/Singapore, from sars-cov-2-variants/lineage-proposals#355"
+  },
+  {
+    "Lineage": "GW.2",
+    "Earliest date": "2023-01-24",
+    "Latest date": "2023-09-01",
+    "Description": "Alias of XBB.1.19.1.2, S:D936G, USA"
+  },
+  {
+    "Lineage": "GW.3",
+    "Earliest date": "2023-02-13",
+    "Latest date": "2023-07-03",
+    "Description": "Alias of XBB.1.19.1.3, ORF1a:S100N, ORF1a:N3537S"
+  },
+  {
+    "Lineage": "GW.4",
+    "Earliest date": "2023-02-27",
+    "Latest date": "2023-09-24",
+    "Description": "Alias of XBB.1.19.1.4, ORF1a:M3280I"
+  },
+  {
+    "Lineage": "GW.5",
+    "Earliest date": "2021-03-01",
+    "Latest date": "2024-01-15",
+    "Description": "Alias of XBB.1.19.1.5, S:L455F (G22927T), S:F456L (T22928C), S:K478I, Pakistan, from #2142"
+  },
+  {
+    "Lineage": "GW.5.1",
+    "Earliest date": "2023-04-06",
+    "Latest date": "2024-01-11",
+    "Description": "Alias of XBB.1.19.1.5.1, ORF3a:W149C, Pakistan"
+  },
+  {
+    "Lineage": "GW.5.1.1",
+    "Earliest date": "2023-07-31",
+    "Latest date": "2024-03-02",
+    "Description": "Alias of XBB.1.19.1.5.1.1, S:A475V, S:F79S, Pakistan, from #2277"
+  },
+  {
+    "Lineage": "KE.1",
+    "Earliest date": "2023-10-01",
+    "Latest date": "2024-03-11",
+    "Description": "Alias of XBB.1.19.1.5.1.1.1, S:F186S, England/Wales"
+  },
+  {
+    "Lineage": "KE.2",
+    "Earliest date": "2023-08-06",
+    "Latest date": "2024-02-06",
+    "Description": "Alias of XBB.1.19.1.5.1.1.2, S:S704L, UK, from sars-cov-2-variants/lineage-proposals#945"
+  },
+  {
+    "Lineage": "KE.3",
+    "Earliest date": "2023-08-23",
+    "Latest date": "2024-02-15",
+    "Description": "Alias of XBB.1.19.1.5.1.1.3, ORF1a:L3641S, ORF1a:T5131I, ORF7a:M1K, UK"
+  },
+  {
+    "Lineage": "GW.5.2",
+    "Earliest date": "2023-05-01",
+    "Latest date": "2023-11-27",
+    "Description": "Alias of XBB.1.19.1.5.2, N:T379I"
+  },
+  {
+    "Lineage": "GW.5.3",
+    "Earliest date": "2023-05-12",
+    "Latest date": "2024-02-02",
+    "Description": "Alias of XBB.1.19.1.5.3, T20310C, C28519T, from sars-cov-2-variants/lineage-proposals#815"
+  },
+  {
+    "Lineage": "GW.5.3.1",
+    "Earliest date": "2023-05-10",
+    "Latest date": "2024-04-17",
+    "Description": "Alias of XBB.1.19.1.5.3.1, S:A475V, S:G184A, from sars-cov-2-variants/lineage-proposals#815"
+  },
+  {
+    "Lineage": "XBB.1.19.2",
+    "Earliest date": "2023-02-13",
+    "Latest date": "2023-07-20",
+    "Description": "Defined by S:P521S, Pakistan, from sars-cov-2-variants/lineage-proposals#233"
+  },
+  {
+    "Lineage": "XBB.1.20",
+    "Earliest date": "2022-11-15",
+    "Latest date": "2023-01-11",
+    "Description": "Defined by ORF3a:A72V, ORF1a:P4312T on C541T, pre ORF8:8* branch, Malaysia"
+  },
+  {
+    "Lineage": "XBB.1.21",
+    "Earliest date": "2022-11-21",
+    "Latest date": "2023-05-23",
+    "Description": "Defined by S:486A, ORF1a:K1247R, Turkey, from #1646"
+  },
+  {
+    "Lineage": "XBB.1.22",
+    "Earliest date": "2022-12-26",
+    "Latest date": "2024-01-14",
+    "Description": "Defined by S:486P, on ORF9b:I5T branch, from #1704"
+  },
+  {
+    "Lineage": "XBB.1.22.1",
+    "Earliest date": "2023-02-06",
+    "Latest date": "2023-10-31",
+    "Description": "Defined by S:Y200C, from #1704"
+  },
+  {
+    "Lineage": "FY.1",
+    "Earliest date": "2023-01-19",
+    "Latest date": "2023-11-17",
+    "Description": "Alias of XBB.1.22.1.1, Defined by ORF1b:D1782N"
+  },
+  {
+    "Lineage": "FY.1.1",
+    "Earliest date": "2023-01-21",
+    "Latest date": "2023-09-22",
+    "Description": "Alias of XBB.1.22.1.1.1, S:A83S, Malaysia/Japan"
+  },
+  {
+    "Lineage": "FY.1.2",
+    "Earliest date": "2023-02-08",
+    "Latest date": "2024-02-24",
+    "Description": "Alias of XBB.1.22.1.1.2, S:T572I, ORF1b:P218L, Europe"
+  },
+  {
+    "Lineage": "FY.1.2.1",
+    "Earliest date": "2023-06-12",
+    "Latest date": "2024-05-02",
+    "Description": "Alias of XBB.1.22.1.1.2.1, S:W64L, from sars-cov-2-variants/lineage-proposals#863"
+  },
+  {
+    "Lineage": "FY.1.2.2",
+    "Earliest date": "2023-04-24",
+    "Latest date": "2024-02-03",
+    "Description": "Alias of XBB.1.22.1.1.2.2, S:V1129I"
+  },
+  {
+    "Lineage": "FY.1.2.3",
+    "Earliest date": "2023-07-03",
+    "Latest date": "2023-11-10",
+    "Description": "Alias of XBB.1.22.1.1.2.3, S:D215H"
+  },
+  {
+    "Lineage": "FY.1.3",
+    "Earliest date": "2023-02-28",
+    "Latest date": "2023-08-01",
+    "Description": "Alias of XBB.1.22.1.1.3, S:E583D, South Korea"
+  },
+  {
+    "Lineage": "FY.1.4",
+    "Earliest date": "2023-04-12",
+    "Latest date": "2023-12-01",
+    "Description": "Alias of XBB.1.22.1.1.4, S:478R, S:D1084G, USA, from sars-cov-2-variants/lineage-proposals#165"
+  },
+  {
+    "Lineage": "FY.1.4.1",
+    "Earliest date": "2023-06-13",
+    "Latest date": "2023-11-24",
+    "Description": "Alias of XBB.1.22.1.1.4.1, S:I569T, S:N185S, USA"
+  },
+  {
+    "Lineage": "FY.2",
+    "Earliest date": "2023-03-16",
+    "Latest date": "2024-01-08",
+    "Description": "Alias of XBB.1.22.1.2, S:I197T, ORF1b:S997P, Indonesia, from #1859"
+  },
+  {
+    "Lineage": "FY.2.1",
+    "Earliest date": "2023-03-26",
+    "Latest date": "2023-11-17",
+    "Description": "Alias of XBB.1.22.1.2.1, S:A684V, from #2080"
+  },
+  {
+    "Lineage": "FY.3",
+    "Earliest date": "2023-02-21",
+    "Latest date": "2024-02-26",
+    "Description": "Alias of XBB.1.22.1.3, ORF1a:E750K, C23191T, China"
+  },
+  {
+    "Lineage": "FY.3.1",
+    "Earliest date": "2023-03-21",
+    "Latest date": "2024-01-08",
+    "Description": "Alias of XBB.1.22.1.3.1, S:I210T, China, from #2009"
+  },
+  {
+    "Lineage": "FY.3.2",
+    "Earliest date": "2022-12-17",
+    "Latest date": "2024-01-28",
+    "Description": "Alias of XBB.1.22.1.3.2, ORF1a:E3764G, China, from #2000"
+  },
+  {
+    "Lineage": "FY.3.3",
+    "Earliest date": "2023-04-01",
+    "Latest date": "2023-12-02",
+    "Description": "Alias of XBB.1.22.1.3.3, ORF3a:V48F, China"
+  },
+  {
+    "Lineage": "FY.4",
+    "Earliest date": "2023-03-27",
+    "Latest date": "2023-07-31",
+    "Description": "Alias of XBB.1.22.1.4, S:Y451H, A8374G, C25517T, Kenya, from #1979"
+  },
+  {
+    "Lineage": "FY.4.1",
+    "Earliest date": "2022-11-15",
+    "Latest date": "2023-11-17",
+    "Description": "Alias of XBB.1.22.1.4.1, S:S494P, Kenya, from #1979"
+  },
+  {
+    "Lineage": "FY.4.1.1",
+    "Earliest date": "2023-05-14",
+    "Latest date": "2023-11-17",
+    "Description": "Alias of XBB.1.22.1.4.1.1, S:S704L, from sars-cov-2-variants/lineage-proposals#302"
+  },
+  {
+    "Lineage": "FY.4.1.2",
+    "Earliest date": "2023-04-11",
+    "Latest date": "2023-12-20",
+    "Description": "Alias of XBB.1.22.1.4.1.2, ORF1a:S2926F, Kenya"
+  },
+  {
+    "Lineage": "FY.4.2",
+    "Earliest date": "2023-04-26",
+    "Latest date": "2023-10-26",
+    "Description": "Alias of XBB.1.22.1.4.2, ORF1a:Y2171F, ORF1b:V2287I, Kenya/USA/Japan, from sars-cov-2-variants/lineage-proposals#487"
+  },
+  {
+    "Lineage": "FY.5",
+    "Earliest date": "2023-03-10",
+    "Latest date": "2023-12-14",
+    "Description": "Alias of XBB.1.22.1.5, S:478R, Indonesia, from #1965"
+  },
+  {
+    "Lineage": "FY.5.1",
+    "Earliest date": "2023-07-30",
+    "Latest date": "2024-03-14",
+    "Description": "Alias of XBB.1.22.1.5.1, S:T572I, from sars-cov-2-variants/lineage-proposals#929"
+  },
+  {
+    "Lineage": "FY.5.1.1",
+    "Earliest date": "2023-08-25",
+    "Latest date": "2024-04-15",
+    "Description": "Alias of XBB.1.22.1.5.1.1, S:M153I, S:F186S, S:S247N, from sars-cov-2-variants/lineage-proposals#790"
+  },
+  {
+    "Lineage": "FY.5.2",
+    "Earliest date": "2023-03-25",
+    "Latest date": "2024-02-08",
+    "Description": "Alias of XBB.1.22.1.5.2, S:L176F, Indonesia, on A6019G branch, from sars-cov-2-variants/lineage-proposals#267"
+  },
+  {
+    "Lineage": "FY.5.3",
+    "Earliest date": "2023-05-23",
+    "Latest date": "2023-10-26",
+    "Description": "Alias of XBB.1.22.1.5.3, S:A222V, Singapore/Japan, on A6019G branch"
+  },
+  {
+    "Lineage": "FY.5.4",
+    "Earliest date": "2023-05-20",
+    "Latest date": "2024-05-13",
+    "Description": "Alias of XBB.1.22.1.5.4, S:T572I, ORF1a:D3009N, ORF1a:Y4077C on A6019G branch, from sars-cov-2-variants/lineage-proposals#929"
+  },
+  {
+    "Lineage": "FY.5.5",
+    "Earliest date": "2023-05-18",
+    "Latest date": "2024-03-26",
+    "Description": "Alias of XBB.1.22.1.5.5, ORF1a:M2796I"
+  },
+  {
+    "Lineage": "FY.5.5.1",
+    "Earliest date": "2023-06-19",
+    "Latest date": "2024-01-16",
+    "Description": "Alias of XBB.1.22.1.5.5.1, S:T572I, from sars-cov-2-variants/lineage-proposals#929"
+  },
+  {
+    "Lineage": "FY.6",
+    "Earliest date": "2022-03-02",
+    "Latest date": "2023-12-15",
+    "Description": "Alias of XBB.1.22.1.6, ORF1a:A591V"
+  },
+  {
+    "Lineage": "FY.6.1",
+    "Earliest date": "2023-05-09",
+    "Latest date": "2023-12-19",
+    "Description": "Alias of XBB.1.22.1.6.1, S:S939F, Japan"
+  },
+  {
+    "Lineage": "FY.6.2",
+    "Earliest date": "2023-07-05",
+    "Latest date": "2023-10-26",
+    "Description": "Alias of XBB.1.22.1.6.2, ORF1a:A3143V, ins_S:216:SLQGN, Japan, from sars-cov-2-variants/lineage-proposals#637"
+  },
+  {
+    "Lineage": "FY.7",
+    "Earliest date": "2023-05-25",
+    "Latest date": "2023-07-26",
+    "Description": "Alias of XBB.1.22.1.7, S:G769A, S:D1168E, from sars-cov-2-variants/lineage-proposals#257"
+  },
+  {
+    "Lineage": "FY.8",
+    "Earliest date": "2023-05-06",
+    "Latest date": "2024-03-29",
+    "Description": "Alias of XBB.1.22.1.8, S:T572I, from sars-cov-2-variants/lineage-proposals#635"
+  },
+  {
+    "Lineage": "FY.8.1",
+    "Earliest date": "2023-08-16",
+    "Latest date": "2024-01-03",
+    "Description": "Alias of XBB.1.22.1.8.1, S:478R, T4579A, from sars-cov-2-variants/lineage-proposals#1002"
+  },
+  {
+    "Lineage": "FY.8.1.1",
+    "Earliest date": "2023-09-09",
+    "Latest date": "2023-11-09",
+    "Description": "Alias of XBB.1.22.1.8.1.1, S:P521Q, ORF1b:V1149L, from sars-cov-2-variants/lineage-proposals#1002"
+  },
+  {
+    "Lineage": "FY.9",
+    "Earliest date": "2023-02-20",
+    "Latest date": "2023-10-28",
+    "Description": "Alias of XBB.1.22.1.9, S:Q675K, ORF1a:D220E, ORF1a:C667Y, Indonesia from #2053"
+  },
+  {
+    "Lineage": "XBB.1.22.2",
+    "Earliest date": "2023-02-02",
+    "Latest date": "2023-09-11",
+    "Description": "Defined by ORF1a:L3829F, C15237T"
+  },
+  {
+    "Lineage": "HU.1",
+    "Earliest date": "2023-02-27",
+    "Latest date": "2023-09-07",
+    "Description": "Alias of XBB.1.22.2.1, S:K529N, France, from #2136"
+  },
+  {
+    "Lineage": "HU.1.1",
+    "Earliest date": "2023-04-24",
+    "Latest date": "2023-10-19",
+    "Description": "Alias of XBB.1.22.2.1.1, S:E471Q, S:Y28H, France/USA, from #2136"
+  },
+  {
+    "Lineage": "HU.2",
+    "Earliest date": "2023-03-28",
+    "Latest date": "2023-10-04",
+    "Description": "Alias of XBB.1.22.2.2, S:T76I, ORF1a:R24H, ORF1b:A1428V, Australia/New Zealand, from sars-cov-2-variants/lineage-proposals#364"
+  },
+  {
+    "Lineage": "XBB.1.22.3",
+    "Earliest date": "2023-04-24",
+    "Latest date": "2023-12-13",
+    "Description": "Defined by ORF1a:P3504L, ORF1b:H1838N, Japan"
+  },
+  {
+    "Lineage": "XBB.1.23",
+    "Earliest date": "2022-11-28",
+    "Latest date": "2023-01-12",
+    "Description": "Defined by E:S68F, on ORF9b:I5T branch, South East Asia"
+  },
+  {
+    "Lineage": "XBB.1.24",
+    "Earliest date": "2023-01-31",
+    "Latest date": "2023-07-12",
+    "Description": "Defined by S:F486P, on T13704C branch, South East Asia, from #1654"
+  },
+  {
+    "Lineage": "XBB.1.24.1",
+    "Earliest date": "2023-02-06",
+    "Latest date": "2023-12-22",
+    "Description": "S:L518Q, Singapore"
+  },
+  {
+    "Lineage": "XBB.1.24.2",
+    "Earliest date": "2023-01-30",
+    "Latest date": "2023-06-05",
+    "Description": "S:R158S, after ORF1a:K261N, N:A35T, Singapore/Malaysia"
+  },
+  {
+    "Lineage": "XBB.1.24.3",
+    "Earliest date": "2023-02-02",
+    "Latest date": "2023-09-12",
+    "Description": "S:S256L, after ORF1a:K261N, Malaysia/Japan"
+  },
+  {
+    "Lineage": "XBB.1.25",
+    "Earliest date": "2022-11-12",
+    "Latest date": "2023-05-01",
+    "Description": "Defined by C673T, G487T, on ORF9b:I5T branch"
+  },
+  {
+    "Lineage": "XBB.1.26",
+    "Earliest date": "2022-12-14",
+    "Latest date": "2023-03-14",
+    "Description": "Defined by T10663C, on ORF9b:I5T branch, Canada"
+  },
+  {
+    "Lineage": "XBB.1.27",
+    "Earliest date": "2022-10-31",
+    "Latest date": "2023-04-20",
+    "Description": "Defined by S:478R, S:A890V, Mexico/USA/India, from #1654"
+  },
+  {
+    "Lineage": "XBB.1.28",
+    "Earliest date": "2022-11-14",
+    "Latest date": "2024-02-07",
+    "Description": "Defined by S:403K, Europe, from #1757"
+  },
+  {
+    "Lineage": "XBB.1.28.1",
+    "Earliest date": "2022-11-09",
+    "Latest date": "2023-12-18",
+    "Description": "Defined by S:356T, Indonesia, global"
+  },
+  {
+    "Lineage": "FW.1",
+    "Earliest date": "2023-02-10",
+    "Latest date": "2024-01-25",
+    "Description": "Alias of XBB.1.28.1.1, S:A701V, Indonesia, Europe"
+  },
+  {
+    "Lineage": "FW.1.1",
+    "Earliest date": "2023-06-02",
+    "Latest date": "2023-12-17",
+    "Description": "Alias of XBB.1.28.1.1.1, S:N148T, UK"
+  },
+  {
+    "Lineage": "FW.1.1.1",
+    "Earliest date": "2023-09-03",
+    "Latest date": "2024-02-20",
+    "Description": "Alias of XBB.1.28.1.1.1.1, S:A684T, ORF1a:S2285F, ORF1a:K3353R, UK, from sars-cov-2-variants/lineage-proposals#1242"
+  },
+  {
+    "Lineage": "FW.2",
+    "Earliest date": "2023-01-24",
+    "Latest date": "2023-12-07",
+    "Description": "Alias of XBB.1.28.1.2, ORF1a:G2258C, France"
+  },
+  {
+    "Lineage": "FW.3",
+    "Earliest date": "2023-03-15",
+    "Latest date": "2023-08-09",
+    "Description": "Alias of XBB.1.28.1.3, ORF1a:D2627N"
+  },
+  {
+    "Lineage": "XBB.1.29",
+    "Earliest date": "2022-10-22",
+    "Latest date": "2023-02-17",
+    "Description": "Defined by ORF1a:L3829F, S:A292S, Europe"
+  },
+  {
+    "Lineage": "XBB.1.30",
+    "Earliest date": "2022-10-14",
+    "Latest date": "2023-06-06",
+    "Description": "Defined by ORF1b:K2557R, South East Asia"
+  },
+  {
+    "Lineage": "XBB.1.31",
+    "Earliest date": "2023-02-24",
+    "Latest date": "2023-09-14",
+    "Description": "Defined by S:453F and S:478R, Indonesia/Singapore, from #1837"
+  },
+  {
+    "Lineage": "XBB.1.31.1",
+    "Earliest date": "2023-03-31",
+    "Latest date": "2023-05-24",
+    "Description": "S:E554K, Indonesia, from sars-cov-2-variants/lineage-proposals#141"
+  },
+  {
+    "Lineage": "XBB.1.31.2",
+    "Earliest date": "2023-03-02",
+    "Latest date": "2023-08-26",
+    "Description": "ORF1a:A1049V, Indonesia"
+  },
+  {
+    "Lineage": "XBB.1.32",
+    "Earliest date": "2022-11-09",
+    "Latest date": "2023-05-19",
+    "Description": "Defined by ORF1a:E148D, Philippines, from #1827"
+  },
+  {
+    "Lineage": "XBB.1.32.1",
+    "Earliest date": "2023-02-23",
+    "Latest date": "2023-05-25",
+    "Description": "S:Y453F, ORF1a:L642F, ORF1b:L2497I, Philippines/Thailand, from #1908"
+  },
+  {
+    "Lineage": "XBB.1.33",
+    "Earliest date": "2023-02-21",
+    "Latest date": "2024-06-28",
+    "Description": "Defined by S:A376Trev, on ORF1b:L1061I, A27965G, pre ORF8:8* branch, found mainly in Italy, from #1879"
+  },
+  {
+    "Lineage": "XBB.1.34",
+    "Earliest date": "2022-01-17",
+    "Latest date": "2024-01-03",
+    "Description": "S:486P, S:681R, N:A50V, Uganda/Sudan, from #1621"
+  },
+  {
+    "Lineage": "XBB.1.34.1",
+    "Earliest date": "2023-03-08",
+    "Latest date": "2023-12-10",
+    "Description": "S:E554K, ORF1b:P970L"
+  },
+  {
+    "Lineage": "XBB.1.34.2",
+    "Earliest date": "2023-03-20",
+    "Latest date": "2023-06-22",
+    "Description": "S:K182I, ORF8:C90F, ORF1a:G989C"
+  },
+  {
+    "Lineage": "HB.1",
+    "Earliest date": "2023-04-25",
+    "Latest date": "2023-12-08",
+    "Description": "Alias of XBB.1.34.2.1, S:F456L (T22928C), USA/China/Canada, from sars-cov-2-variants/lineage-proposals#217"
+  },
+  {
+    "Lineage": "XBB.1.35",
+    "Earliest date": "2022-10-10",
+    "Latest date": "2023-04-21",
+    "Description": "ORF1a:V89A, Indonesia"
+  },
+  {
+    "Lineage": "XBB.1.36",
+    "Earliest date": "2022-11-11",
+    "Latest date": "2023-06-10",
+    "Description": "Defined by S:S490P, found mainly in Malaysia, Indonesia and Singapore, from #1781"
+  },
+  {
+    "Lineage": "XBB.1.37",
+    "Earliest date": "2022-10-11",
+    "Latest date": "2023-08-11",
+    "Description": "Defined by A5371G, Indonesia/Russia, from #1929"
+  },
+  {
+    "Lineage": "XBB.1.37.1",
+    "Earliest date": "2023-01-25",
+    "Latest date": "2023-12-11",
+    "Description": "Defined by S:486P, A1846G, G7459T, T27285C, Russia/South Korea, from #1929"
+  },
+  {
+    "Lineage": "XBB.1.38",
+    "Earliest date": "2022-10-04",
+    "Latest date": "2023-06-10",
+    "Description": "Defined by S:T732I, Russia"
+  },
+  {
+    "Lineage": "XBB.1.38.1",
+    "Earliest date": "2022-12-02",
+    "Latest date": "2023-04-16",
+    "Description": "S:T883I, Russia"
+  },
+  {
+    "Lineage": "XBB.1.39",
+    "Earliest date": "2022-09-22",
+    "Latest date": "2023-05-14",
+    "Description": "ORF1a:V2866M, Singapore/Malaysia"
+  },
+  {
+    "Lineage": "XBB.1.40",
+    "Earliest date": "2023-01-31",
+    "Latest date": "2023-05-04",
+    "Description": "S:Y453F, ORF1a:G519S, ORF1a:L2609F, ORF3a:P104S, Malaysia"
+  },
+  {
+    "Lineage": "XBB.1.41",
+    "Earliest date": "2023-04-24",
+    "Latest date": "2023-11-02",
+    "Description": "S:L335S, S:R403K, S:486P, possibly common in Central/West Africa, from #1997"
+  },
+  {
+    "Lineage": "XBB.1.41.1",
+    "Earliest date": "2022-10-18",
+    "Latest date": "2024-01-29",
+    "Description": "S:478R, Africa, from sars-cov-2-variants/lineage-proposals#150"
+  },
+  {
+    "Lineage": "JC.1",
+    "Earliest date": "2023-05-26",
+    "Latest date": "2024-03-20",
+    "Description": "Alias of XBB.1.41.1.1, S:K77R, Japan/Hawaii"
+  },
+  {
+    "Lineage": "JC.2",
+    "Earliest date": "2023-07-16",
+    "Latest date": "2024-01-22",
+    "Description": "Alias of XBB.1.41.1.2, S:D339R, ORF1a:V1056L, Greece, from sars-cov-2-variants/lineage-proposals#961"
+  },
+  {
+    "Lineage": "JC.3",
+    "Earliest date": "2023-08-12",
+    "Latest date": "2023-12-09",
+    "Description": "Alias of XBB.1.41.1.3, S:N703I, South Africa"
+  },
+  {
+    "Lineage": "JC.4",
+    "Earliest date": "2023-07-27",
+    "Latest date": "2024-02-17",
+    "Description": "Alias of XBB.1.41.1.4, S:N148S"
+  },
+  {
+    "Lineage": "JC.5",
+    "Earliest date": "2022-07-27",
+    "Latest date": "2024-02-12",
+    "Description": "Alias of XBB.1.41.1.5, ORF1a:P1220L, N:H300Y, from sars-cov-2-variants/lineage-proposals#629"
+  },
+  {
+    "Lineage": "JC.5.1",
+    "Earliest date": "2023-08-02",
+    "Latest date": "2024-04-04",
+    "Description": "Alias of XBB.1.41.1.5.1, S:Q173K, USA"
+  },
+  {
+    "Lineage": "JC.6",
+    "Earliest date": "2023-07-24",
+    "Latest date": "2023-12-18",
+    "Description": "Alias of XBB.1.41.1.6, S:I1227V, South Africa"
+  },
+  {
+    "Lineage": "XBB.1.41.2",
+    "Earliest date": "2023-05-26",
+    "Latest date": "2024-02-02",
+    "Description": "S:S494P, USA, from sars-cov-2-variants/lineage-proposals#389"
+  },
+  {
+    "Lineage": "XBB.1.41.3",
+    "Earliest date": "2023-03-27",
+    "Latest date": "2023-11-06",
+    "Description": "C17850T, C25276T, C29416G, Africa"
+  },
+  {
+    "Lineage": "JW.1",
+    "Earliest date": "2023-04-23",
+    "Latest date": "2023-12-07",
+    "Description": "Alias of XBB.1.41.3.1, S:K478R, ORF1a:L397F, South Africa/DRC"
+  },
+  {
+    "Lineage": "JW.1.1",
+    "Earliest date": "2023-08-12",
+    "Latest date": "2023-11-29",
+    "Description": "Alias of XBB.1.41.3.1.1, S:Q14K, South Africa"
+  },
+  {
+    "Lineage": "XBB.1.42",
+    "Earliest date": "2022-12-11",
+    "Latest date": "2024-01-18",
+    "Description": "S:486P, S:Q613H, on ORF1a:T4175I branch with XBB.1.9, Indonesia/Malaysia/China, from #1954"
+  },
+  {
+    "Lineage": "XBB.1.42.1",
+    "Earliest date": "2023-04-21",
+    "Latest date": "2024-05-13",
+    "Description": "S:478R, from sars-cov-2-variants/lineage-proposals#198"
+  },
+  {
+    "Lineage": "XBB.1.42.2",
+    "Earliest date": "2023-03-12",
+    "Latest date": "2024-07-05",
+    "Description": "C6040T, G9049A"
+  },
+  {
+    "Lineage": "HL.1",
+    "Earliest date": "2023-05-22",
+    "Latest date": "2023-08-27",
+    "Description": "Alias of XBB.1.42.2.1, S:E583D, from sars-cov-2-variants/lineage-proposals#352"
+  },
+  {
+    "Lineage": "HL.2",
+    "Earliest date": "2023-04-29",
+    "Latest date": "2023-11-18",
+    "Description": "Alias of XBB.1.42.2.2, S:S929N, China"
+  },
+  {
+    "Lineage": "XBB.1.43",
+    "Earliest date": "2022-06-12",
+    "Latest date": "2023-04-20",
+    "Description": "G11071A, Indonesia, from #2015"
+  },
+  {
+    "Lineage": "XBB.1.43.1",
+    "Earliest date": "2023-01-03",
+    "Latest date": "2023-09-13",
+    "Description": "S:486P, ORF1a:A2621V, A20713C, from #2015"
+  },
+  {
+    "Lineage": "XBB.1.44",
+    "Earliest date": "2022-08-16",
+    "Latest date": "2023-09-01",
+    "Description": "S:T747I, Russia"
+  },
+  {
+    "Lineage": "XBB.1.44.1",
+    "Earliest date": "2023-02-02",
+    "Latest date": "2023-07-26",
+    "Description": "S:486P, ORF3a:S195F, Russia/China, from #2043"
+  },
+  {
+    "Lineage": "XBB.1.45",
+    "Earliest date": "2022-11-03",
+    "Latest date": "2023-01-28",
+    "Description": "T21000C, USA/Singapore/Malaysia"
+  },
+  {
+    "Lineage": "XBB.1.45.1",
+    "Earliest date": "2022-11-25",
+    "Latest date": "2023-08-28",
+    "Description": "S:486P, A3139G, A19137G, C28291T, USA/Portugal, from #1937"
+  },
+  {
+    "Lineage": "XBB.1.46",
+    "Earliest date": "2022-09-21",
+    "Latest date": "2023-06-26",
+    "Description": "ORF1a:C1114F, Singapore/Malaysia"
+  },
+  {
+    "Lineage": "XBB.1.47",
+    "Earliest date": "2022-11-16",
+    "Latest date": "2023-01-27",
+    "Description": "ORF1a:T1761I, ORF1a:C2180Y, ORF1a:I2854V, Philippines/Singapore/Japan"
+  },
+  {
+    "Lineage": "XBB.1.47.1",
+    "Earliest date": "2023-02-15",
+    "Latest date": "2023-05-29",
+    "Description": "S:486P, S:A260V, S:V1122G, Japan/USA/Australia/Germany"
+  },
+  {
+    "Lineage": "XBB.1.48",
+    "Earliest date": "2023-01-08",
+    "Latest date": "2023-05-04",
+    "Description": "S:L455F (G22927T), S:F456L (T22928C), C2509T, on C541T, pre ORF8:8* branch, Pakistan, from #1681"
+  },
+  {
+    "Lineage": "XBB.1.49",
+    "Earliest date": "2023-03-22",
+    "Latest date": "2023-05-17",
+    "Description": "S:346S, S:486P, on ORF1b:L1061I, A27965G, pre ORF8:8* branch with XBB.1.33, Somalia, from sars-cov-2-variants/lineage-proposals#208"
+  },
+  {
+    "Lineage": "XBB.2",
+    "Earliest date": "2022-01-08",
+    "Latest date": "2023-11-13",
+    "Description": "Defined by S:D253G, from #1173"
+  },
+  {
+    "Lineage": "XBB.2.1",
+    "Earliest date": "2022-09-26",
+    "Latest date": "2023-03-23",
+    "Description": "Defined by S:N764R (C23853G), two step mutation on top of C23854A (S:N764K defining of all Omicrons)"
+  },
+  {
+    "Lineage": "XBB.2.2",
+    "Earliest date": "2022-10-18",
+    "Latest date": "2023-05-09",
+    "Description": "Defined by S:Q613H"
+  },
+  {
+    "Lineage": "XBB.2.3",
+    "Earliest date": "2021-07-16",
+    "Latest date": "2024-02-21",
+    "Description": "Defined by S:P521S and S:S486P, India/Indonesia/Singapore/USA, from #1603 and #1535"
+  },
+  {
+    "Lineage": "XBB.2.3.1",
+    "Earliest date": "2023-01-29",
+    "Latest date": "2023-09-08",
+    "Description": "S:D80Y, England/Sweden/India, from #1775"
+  },
+  {
+    "Lineage": "XBB.2.3.2",
+    "Earliest date": "2023-01-04",
+    "Latest date": "2024-05-06",
+    "Description": "S:G184V, ORF1a:R2159W, India, from #1776"
+  },
+  {
+    "Lineage": "HH.1",
+    "Earliest date": "2022-05-06",
+    "Latest date": "2023-12-14",
+    "Description": "Alias of XBB.2.3.2.1, ORF1a:T2977I, T20697C"
+  },
+  {
+    "Lineage": "HH.1.1",
+    "Earliest date": "2023-03-14",
+    "Latest date": "2023-11-29",
+    "Description": "Alias of XBB.2.3.2.1.1, S:G181A, from sars-cov-2-variants/lineage-proposals#183"
+  },
+  {
+    "Lineage": "HH.2",
+    "Earliest date": "2023-03-08",
+    "Latest date": "2024-02-28",
+    "Description": "Alias of XBB.2.3.2.2, ORF1a:D48Y"
+  },
+  {
+    "Lineage": "HH.2.1",
+    "Earliest date": "2023-07-13",
+    "Latest date": "2023-11-23",
+    "Description": "Alias of XBB.2.3.2.2.1, S:K478R, England/France, from sars-cov-2-variants/lineage-proposals#236"
+  },
+  {
+    "Lineage": "HH.3",
+    "Earliest date": "2023-03-19",
+    "Latest date": "2023-10-25",
+    "Description": "Alias of XBB.2.3.2.3, S:D1260Y, Japan"
+  },
+  {
+    "Lineage": "HH.4",
+    "Earliest date": "2023-03-02",
+    "Latest date": "2023-10-08",
+    "Description": "Alias of XBB.2.3.2.4, S:A845S, India"
+  },
+  {
+    "Lineage": "HH.5",
+    "Earliest date": "2023-05-11",
+    "Latest date": "2023-12-25",
+    "Description": "Alias of XBB.2.3.2.5, S:K147N, India, from sars-cov-2-variants/lineage-proposals#438"
+  },
+  {
+    "Lineage": "HH.6",
+    "Earliest date": "2023-06-30",
+    "Latest date": "2023-11-28",
+    "Description": "Alias of XBB.2.3.2.6, S:K478R, ORF1a:D935E, India, from sars-cov-2-variants/lineage-proposals#236"
+  },
+  {
+    "Lineage": "HH.7",
+    "Earliest date": "2023-01-04",
+    "Latest date": "2024-06-27",
+    "Description": "Alias of XBB.2.3.2.7, ORF1a:T1788M, India from #1962"
+  },
+  {
+    "Lineage": "HH.8",
+    "Earliest date": "2023-04-14",
+    "Latest date": "2023-11-24",
+    "Description": "Alias of XBB.2.3.2.8, S:Q607R"
+  },
+  {
+    "Lineage": "HH.8.1",
+    "Earliest date": "2023-07-13",
+    "Latest date": "2023-12-26",
+    "Description": "Alias of XBB.2.3.2.8.1, S:K478R, from sars-cov-2-variants/lineage-proposals#236"
+  },
+  {
+    "Lineage": "XBB.2.3.3",
+    "Earliest date": "2023-01-04",
+    "Latest date": "2024-02-07",
+    "Description": "S:182N, India/USA, from #1810"
+  },
+  {
+    "Lineage": "GJ.1",
+    "Earliest date": "2023-02-22",
+    "Latest date": "2023-12-02",
+    "Description": "Alias of XBB.2.3.3.1, found mainly in China and USA, from #2005"
+  },
+  {
+    "Lineage": "GJ.1.1",
+    "Earliest date": "2023-03-28",
+    "Latest date": "2023-12-15",
+    "Description": "Alias of XBB.2.3.3.1.1, S:A222V, N:R319H, ORF1a:V1915I, from sars-cov-2-variants/lineage-proposals#109"
+  },
+  {
+    "Lineage": "GJ.1.2",
+    "Earliest date": "2023-02-16",
+    "Latest date": "2024-03-23",
+    "Description": "Alias of XBB.2.3.3.1.2, ORF1b:V1110I, from #2059"
+  },
+  {
+    "Lineage": "GJ.1.2.1",
+    "Earliest date": "2023-07-05",
+    "Latest date": "2024-01-22",
+    "Description": "Alias of XBB.2.3.3.1.2.1, S:N450D, Singapore/Thailand/South Korea/USA/Spain, from sars-cov-2-variants/lineage-proposals#446"
+  },
+  {
+    "Lineage": "JE.1",
+    "Earliest date": "2023-06-16",
+    "Latest date": "2024-03-01",
+    "Description": "Alias of XBB.2.3.3.1.2.1.1, S:478R, Singapore/SouthKorea/USA, from sars-cov-2-variants/lineage-proposals#597"
+  },
+  {
+    "Lineage": "JE.1.1",
+    "Earliest date": "2023-08-20",
+    "Latest date": "2024-01-28",
+    "Description": "Alias of XBB.2.3.3.1.2.1.1.1, S:Q52R, from sars-cov-2-variants/lineage-proposals#827"
+  },
+  {
+    "Lineage": "JE.1.1.1",
+    "Earliest date": "2023-08-10",
+    "Latest date": "2024-03-08",
+    "Description": "Alias of XBB.2.3.3.1.2.1.1.1.1, S:V1122A, from #2390"
+  },
+  {
+    "Lineage": "KH.1",
+    "Earliest date": "2023-10-13",
+    "Latest date": "2024-03-19",
+    "Description": "Alias of XBB.2.3.3.1.2.1.1.1.1.1, S:E554K, on N:L13F, ORF1a:R135S (reversion) branch, from #2390"
+  },
+  {
+    "Lineage": "GJ.1.2.2",
+    "Earliest date": "2023-06-03",
+    "Latest date": "2024-02-19",
+    "Description": "Alias of XBB.2.3.3.1.2.2, S:478R, Europe/USA/Australia"
+  },
+  {
+    "Lineage": "GJ.1.2.3",
+    "Earliest date": "2023-06-07",
+    "Latest date": "2023-10-17",
+    "Description": "Alias of XBB.2.3.3.1.2.3, S:T76I, Japan, on ORF1b:S997P branch"
+  },
+  {
+    "Lineage": "GJ.1.2.4",
+    "Earliest date": "2023-06-06",
+    "Latest date": "2023-12-29",
+    "Description": "Alias of XBB.2.3.3.1.2.4, S:S255F, on ORF1a:H919Y branch, Japan/USA/South Korea"
+  },
+  {
+    "Lineage": "GJ.1.2.5",
+    "Earliest date": "2023-05-02",
+    "Latest date": "2024-05-15",
+    "Description": "Alias of XBB.2.3.3.1.2.5, S:I834V, Singapore/South Korea/USA，on ORF1b:S997P branch, from sars-cov-2-variants/lineage-proposals#628"
+  },
+  {
+    "Lineage": "GJ.1.2.6",
+    "Earliest date": "2023-05-26",
+    "Latest date": "2024-01-08",
+    "Description": "Alias of XBB.2.3.3.1.2.6, S:478R, on ORF1b:S997P branch, from sars-cov-2-variants/lineage-proposals#726"
+  },
+  {
+    "Lineage": "GJ.1.2.7",
+    "Earliest date": "2023-06-26",
+    "Latest date": "2024-01-09",
+    "Description": "Alias of XBB.2.3.3.1.2.7, S:478R, T6511C, on ORF1a:H919Y branch, from sars-cov-2-variants/lineage-proposals#726"
+  },
+  {
+    "Lineage": "GJ.1.2.8",
+    "Earliest date": "2023-06-19",
+    "Latest date": "2024-01-15",
+    "Description": "Alias of XBB.2.3.3.1.2.8, S:T747I, USA"
+  },
+  {
+    "Lineage": "GJ.2",
+    "Earliest date": "2023-03-20",
+    "Latest date": "2023-11-27",
+    "Description": "Alias of XBB.2.3.3.2, S:I1114S, Europe"
+  },
+  {
+    "Lineage": "GJ.3",
+    "Earliest date": "2023-03-08",
+    "Latest date": "2023-12-26",
+    "Description": "Alias of XBB.2.3.3.3, ORF1a:P971S, ORF1b:V2371L"
+  },
+  {
+    "Lineage": "GJ.4",
+    "Earliest date": "2023-02-15",
+    "Latest date": "2024-03-27",
+    "Description": "Alias of XBB.2.3.3.4, S:M153I, from #1902"
+  },
+  {
+    "Lineage": "GJ.5",
+    "Earliest date": "2023-04-20",
+    "Latest date": "2024-02-15",
+    "Description": "Alias of XBB.2.3.3.5, S:478R, A11794G, C13138T, from sars-cov-2-variants/lineage-proposals#429"
+  },
+  {
+    "Lineage": "GJ.5.1",
+    "Earliest date": "2022-10-18",
+    "Latest date": "2024-01-03",
+    "Description": "Alias of XBB.2.3.3.5.1, S:S255F, ORF1a:A540V, ORF1a:A3963V, from sars-cov-2-variants/lineage-proposals#429"
+  },
+  {
+    "Lineage": "GJ.6",
+    "Earliest date": "2023-07-31",
+    "Latest date": "2023-12-26",
+    "Description": "Alias of XBB.2.3.3.6, S:F456L (T22930A), M:G6S, India, from sars-cov-2-variants/lineage-proposals#675"
+  },
+  {
+    "Lineage": "GJ.7",
+    "Earliest date": "2023-04-20",
+    "Latest date": "2023-09-11",
+    "Description": "Alias of XBB.2.3.3.7, S:E183K, Australia/NewZealand, from sars-cov-2-variants/lineage-proposals#439"
+  },
+  {
+    "Lineage": "XBB.2.3.4",
+    "Earliest date": "2023-01-08",
+    "Latest date": "2023-12-06",
+    "Description": "S:478Q, India, from #1822"
+  },
+  {
+    "Lineage": "GZ.1",
+    "Earliest date": "2023-03-14",
+    "Latest date": "2023-12-11",
+    "Description": "Alias of XBB.2.3.4.1, S:F186L, India-GJ"
+  },
+  {
+    "Lineage": "XBB.2.3.5",
+    "Earliest date": "2023-01-06",
+    "Latest date": "2024-01-02",
+    "Description": "S:K478N, found mainly in USA and India, from #1846"
+  },
+  {
+    "Lineage": "XBB.2.3.6",
+    "Earliest date": "2023-02-10",
+    "Latest date": "2023-09-26",
+    "Description": "N:T166I, mainly Singapore"
+  },
+  {
+    "Lineage": "GM.1",
+    "Earliest date": "2023-02-24",
+    "Latest date": "2023-09-06",
+    "Description": "Alias of XBB.2.3.6.1, S:P621S, Singapore"
+  },
+  {
+    "Lineage": "GM.2",
+    "Earliest date": "2023-03-18",
+    "Latest date": "2023-09-05",
+    "Description": "Alias of XBB.2.3.6.2, S:G181R, Singapore"
+  },
+  {
+    "Lineage": "GM.3",
+    "Earliest date": "2023-03-10",
+    "Latest date": "2023-10-04",
+    "Description": "Alias of XBB.2.3.6.3, ORF1a:R4017K, Singapore"
+  },
+  {
+    "Lineage": "GM.3.1",
+    "Earliest date": "2023-05-15",
+    "Latest date": "2023-10-31",
+    "Description": "Alias of XBB.2.3.6.3.1, S:N388K, Japan, from sars-cov-2-variants/lineage-proposals#450"
+  },
+  {
+    "Lineage": "XBB.2.3.7",
+    "Earliest date": "2022-12-31",
+    "Latest date": "2023-10-15",
+    "Description": "ORF1a:T4087I"
+  },
+  {
+    "Lineage": "XBB.2.3.8",
+    "Earliest date": "2023-03-17",
+    "Latest date": "2024-05-16",
+    "Description": "C2013T, T16389C, S:478R, Singapore/SouthKorea, from #1866"
+  },
+  {
+    "Lineage": "HG.1",
+    "Earliest date": "2023-04-16",
+    "Latest date": "2023-10-12",
+    "Description": "Alias of XBB.2.3.8.1, S:S98F, South Korea"
+  },
+  {
+    "Lineage": "HG.1.1",
+    "Earliest date": "2023-06-15",
+    "Latest date": "2023-11-27",
+    "Description": "Alias of XBB.2.3.8.1.1, S:A1190S, South Korea"
+  },
+  {
+    "Lineage": "HG.2",
+    "Earliest date": "2023-05-21",
+    "Latest date": "2023-12-05",
+    "Description": "Alias of XBB.2.3.8.2, S:T259I, South Korea/USA, from sars-cov-2-variants/lineage-proposals#652"
+  },
+  {
+    "Lineage": "HG.3",
+    "Earliest date": "2023-05-29",
+    "Latest date": "2023-10-02",
+    "Description": "Alias of XBB.2.3.8.3, S:S255F, South Korea"
+  },
+  {
+    "Lineage": "XBB.2.3.9",
+    "Earliest date": "2023-02-12",
+    "Latest date": "2023-09-12",
+    "Description": "S:S98F, C18744T, C19200T, India"
+  },
+  {
+    "Lineage": "XBB.2.3.10",
+    "Earliest date": "2023-02-02",
+    "Latest date": "2023-10-03",
+    "Description": "T5947C, India"
+  },
+  {
+    "Lineage": "GE.1",
+    "Earliest date": "2023-03-29",
+    "Latest date": "2024-04-05",
+    "Description": "Alias of XBB.2.3.10.1, S:K478R, from #1866"
+  },
+  {
+    "Lineage": "GE.1.1",
+    "Earliest date": "2023-06-11",
+    "Latest date": "2024-01-16",
+    "Description": "Alias of XBB.2.3.10.1.1, S:E554K, Bangladesh/Singapore, from sars-cov-2-variants/lineage-proposals#367"
+  },
+  {
+    "Lineage": "GE.1.2",
+    "Earliest date": "2023-05-12",
+    "Latest date": "2024-04-26",
+    "Description": "Alias of XBB.2.3.10.1.2, S:N148T, Kenya, from sars-cov-2-variants/lineage-proposals#200"
+  },
+  {
+    "Lineage": "GE.1.2.1",
+    "Earliest date": "2023-09-28",
+    "Latest date": "2024-04-19",
+    "Description": "Alias of XBB.2.3.10.1.2.1, S:478T, S:A376S, ORF7a-ORF8 possibly completely deleted, from sars-cov-2-variants/lineage-proposals#1103"
+  },
+  {
+    "Lineage": "KT.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of XBB.2.3.10.1.2.1.1, S:K77R, US/UK"
+  },
+  {
+    "Lineage": "KT.1.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of XBB.2.3.10.1.2.1.1.1, C683T, G15957A, USA"
+  },
+  {
+    "Lineage": "KT.1.2",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of XBB.2.3.10.1.2.1.1.2, ORF1b:N2328S, C583T"
+  },
+  {
+    "Lineage": "GE.1.2.2",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Alias of XBB.2.3.10.1.2.2, S:S408N, ORF1b:A517V, ORF1b:D1899E, ORF7a-ORF8 possibly completed deleted, Kenya, from sars-cov-2-variants/lineage-proposals#1340"
+  },
+  {
+    "Lineage": "GE.1.3",
+    "Earliest date": "2023-04-02",
+    "Latest date": "2024-01-07",
+    "Description": "Alias of XBB.2.3.10.1.3, S:T732I, from sars-cov-2-variants/lineage-proposals#102"
+  },
+  {
+    "Lineage": "GE.1.4",
+    "Earliest date": "2022-10-18",
+    "Latest date": "2024-01-08",
+    "Description": "Alias of XBB.2.3.10.1.4, ORF1a:P3359S"
+  },
+  {
+    "Lineage": "GE.1.5",
+    "Earliest date": "2023-05-17",
+    "Latest date": "2024-01-16",
+    "Description": "Alias of XBB.2.3.10.1.5, G6352A, C11653T, T16242A"
+  },
+  {
+    "Lineage": "GE.1.6",
+    "Earliest date": "2023-06-21",
+    "Latest date": "2024-05-27",
+    "Description": "Alias of XBB.2.3.10.1.6, S:L118I"
+  },
+  {
+    "Lineage": "XBB.2.3.11",
+    "Earliest date": "2023-01-04",
+    "Latest date": "2024-03-09",
+    "Description": "S:K478R, India, from #1866"
+  },
+  {
+    "Lineage": "GS.1",
+    "Earliest date": "2023-03-30",
+    "Latest date": "2024-01-12",
+    "Description": "Alias of XBB.2.3.11.1, S:213D, C4582T, C25075T, Australia, from #2023"
+  },
+  {
+    "Lineage": "GS.2",
+    "Earliest date": "2023-04-24",
+    "Latest date": "2023-11-02",
+    "Description": "Alias of XBB.2.3.11.2, S:T470N, Singapore/Brunei, from sars-cov-2-variants/lineage-proposals#93"
+  },
+  {
+    "Lineage": "GS.3",
+    "Earliest date": "2023-05-18",
+    "Latest date": "2024-01-09",
+    "Description": "Alias of XBB.2.3.11.3, S:R190S, USA/UK, from sars-cov-2-variants/lineage-proposals#669"
+  },
+  {
+    "Lineage": "GS.4",
+    "Earliest date": "2023-01-08",
+    "Latest date": "2024-03-04",
+    "Description": "Alias of XBB.2.3.11.4, M:A104V, ORF1a:A181T, France, from sars-cov-2-variants/lineage-proposals#668"
+  },
+  {
+    "Lineage": "GS.4.1",
+    "Earliest date": "2021-07-16",
+    "Latest date": "2024-06-10",
+    "Description": "Alias of XBB.2.3.11.4.1, S:N185D, ORF3a:G172C, France, from sars-cov-2-variants/lineage-proposals#668"
+  },
+  {
+    "Lineage": "GS.4.1.1",
+    "Earliest date": "2023-08-14",
+    "Latest date": "2024-01-02",
+    "Description": "Alias of XBB.2.3.11.4.1.1, S:P561S, France"
+  },
+  {
+    "Lineage": "GS.5",
+    "Earliest date": "2023-05-20",
+    "Latest date": "2023-12-15",
+    "Description": "Alias of XBB.2.3.11.5, M:A104V, S:Q218H, from sars-cov-2-variants/lineage-proposals#768"
+  },
+  {
+    "Lineage": "GS.6",
+    "Earliest date": "2023-07-04",
+    "Latest date": "2023-11-27",
+    "Description": "Alias of XBB.2.3.11.6, S:A845S, Wales"
+  },
+  {
+    "Lineage": "GS.7",
+    "Earliest date": "2023-05-22",
+    "Latest date": "2023-12-06",
+    "Description": "Alias of XBB.2.3.11.7, ORF1a:L204I, C14925T"
+  },
+  {
+    "Lineage": "GS.7.1",
+    "Earliest date": "2023-08-03",
+    "Latest date": "2023-12-17",
+    "Description": "Alias of XBB.2.3.11.7.1, S:E180Q, Tunisia"
+  },
+  {
+    "Lineage": "GS.8",
+    "Earliest date": "2023-04-20",
+    "Latest date": "2023-10-20",
+    "Description": "Alias of XBB.2.3.11.8, ORF3a:I179V, Vietnam"
+  },
+  {
+    "Lineage": "XBB.2.3.12",
+    "Earliest date": "2023-02-25",
+    "Latest date": "2023-12-10",
+    "Description": "S:S494P, from #2029"
+  },
+  {
+    "Lineage": "JU.1",
+    "Earliest date": "2023-08-18",
+    "Latest date": "2024-03-20",
+    "Description": "Alias of XBB.2.3.12.1, S:N148T, S:Q218R, S:N450D, Georgia/Russia"
+  },
+  {
+    "Lineage": "XBB.2.3.13",
+    "Earliest date": "2021-07-16",
+    "Latest date": "2023-11-02",
+    "Description": "ORF1a:T1822I, Spain"
+  },
+  {
+    "Lineage": "JA.1",
+    "Earliest date": "2023-03-03",
+    "Latest date": "2023-12-13",
+    "Description": "Alias of XBB.2.3.13.1, S:F456L (T22928C), Spain/England/France, from sars-cov-2-variants/lineage-proposals#240"
+  },
+  {
+    "Lineage": "XBB.2.3.14",
+    "Earliest date": "2023-01-19",
+    "Latest date": "2023-09-26",
+    "Description": "ORF1a:Q998H"
+  },
+  {
+    "Lineage": "XBB.2.3.15",
+    "Earliest date": "2023-04-18",
+    "Latest date": "2024-01-08",
+    "Description": "ORF1a:I4308V, from sars-cov-2-variants/lineage-proposals#722"
+  },
+  {
+    "Lineage": "JS.1",
+    "Earliest date": "2023-06-02",
+    "Latest date": "2024-04-30",
+    "Description": "Alias of XBB.2.3.15.1, S:S256T"
+  },
+  {
+    "Lineage": "JS.2",
+    "Earliest date": "2023-02-16",
+    "Latest date": "2023-11-07",
+    "Description": "Alias of XBB.2.3.15.2, S:T323I, from sars-cov-2-variants/lineage-proposals#722"
+  },
+  {
+    "Lineage": "XBB.2.3.16",
+    "Earliest date": "2023-07-25",
+    "Latest date": "2023-12-04",
+    "Description": "S:K478N, USA"
+  },
+  {
+    "Lineage": "XBB.2.3.17",
+    "Earliest date": "2023-06-10",
+    "Latest date": "2023-12-06",
+    "Description": "S:N450D, USA"
+  },
+  {
+    "Lineage": "XBB.2.3.18",
+    "Earliest date": "2023-08-03",
+    "Latest date": "2023-12-27",
+    "Description": "S:F456L (T22930A), S:N450D, S:1231A, India, from sars-cov-2-variants/lineage-proposals#738"
+  },
+  {
+    "Lineage": "XBB.2.3.19",
+    "Earliest date": "2023-03-06",
+    "Latest date": "2023-12-09",
+    "Description": "S:G184V, ORF1a:P1786L, India"
+  },
+  {
+    "Lineage": "JY.1",
+    "Earliest date": "2023-08-03",
+    "Latest date": "2024-01-20",
+    "Description": "Alias of XBB.2.3.19.1, S:E654K, S:K478T (rev), India, from sars-cov-2-variants/lineage-proposals#731"
+  },
+  {
+    "Lineage": "JY.1.1",
+    "Earliest date": "2023-08-09",
+    "Latest date": "2024-01-15",
+    "Description": "Alias of XBB.2.3.19.1.1, S:T1117K"
+  },
+  {
+    "Lineage": "XBB.2.3.20",
+    "Earliest date": "2023-02-26",
+    "Latest date": "2023-11-04",
+    "Description": "N:A267S, S:210del, Bangladesh, from sars-cov-2-variants/lineage-proposals#328"
+  },
+  {
+    "Lineage": "XBB.2.3.21",
+    "Earliest date": "2023-05-10",
+    "Latest date": "2023-12-25",
+    "Description": "S:T883I, ORF1a:D3042N, 670T reversion, Japan, from sars-cov-2-variants/lineage-proposals#281"
+  },
+  {
+    "Lineage": "XBB.2.3.22",
+    "Earliest date": "2023-05-16",
+    "Latest date": "2023-11-30",
+    "Description": "S:S937T, ORF8:K94T, Romania/Bulgaria"
+  },
+  {
+    "Lineage": "XBB.2.4",
+    "Earliest date": "2022-10-18",
+    "Latest date": "2023-12-26",
+    "Description": "Defined by S:S486P, Spain/Denmark/Germany, from #1603 and #1518"
+  },
+  {
+    "Lineage": "XBB.2.5",
+    "Earliest date": "2022-10-06",
+    "Latest date": "2023-04-29",
+    "Description": "S:Q613H, from jmcbroome/auto-pango-designation#193"
+  },
+  {
+    "Lineage": "XBB.2.6",
+    "Earliest date": "2022-02-14",
+    "Latest date": "2023-07-23",
+    "Description": "Mostly Peru, C5144T, T5731A"
+  },
+  {
+    "Lineage": "XBB.2.6.1",
+    "Earliest date": "2022-12-10",
+    "Latest date": "2023-06-23",
+    "Description": "S:P521S, Peru, from #1869"
+  },
+  {
+    "Lineage": "GH.1",
+    "Earliest date": "2022-12-01",
+    "Latest date": "2023-07-31",
+    "Description": "Alias of XBB.2.6.1.1, ORF9b:P51Q, T6895C, T9148C, A15192C, Peru, from #1869"
+  },
+  {
+    "Lineage": "XBB.2.6.2",
+    "Earliest date": "2022-11-01",
+    "Latest date": "2023-04-03",
+    "Description": "S:T19L, Peru"
+  },
+  {
+    "Lineage": "XBB.2.6.3",
+    "Earliest date": "2023-01-12",
+    "Latest date": "2023-05-11",
+    "Description": "S:T883I, C25587T, Peru"
+  },
+  {
+    "Lineage": "XBB.2.7",
+    "Earliest date": "2022-09-28",
+    "Latest date": "2023-01-31",
+    "Description": "ORF1a:R3662H, parent of lineage proposed in #1725"
+  },
+  {
+    "Lineage": "XBB.2.7.1",
+    "Earliest date": "2023-01-05",
+    "Latest date": "2023-04-27",
+    "Description": "S:Y453F, S:K478Q, Singapore, from #1725"
+  },
+  {
+    "Lineage": "XBB.2.8",
+    "Earliest date": "2022-09-22",
+    "Latest date": "2023-03-11",
+    "Description": "C6968T, Brunei"
+  },
+  {
+    "Lineage": "XBB.2.9",
+    "Earliest date": "2022-12-28",
+    "Latest date": "2023-09-06",
+    "Description": "Defined by ORF1a:V2027I and S:F486P, found mainly in Russia, from #1877"
+  },
+  {
+    "Lineage": "XBB.2.10",
+    "Earliest date": "2022-11-02",
+    "Latest date": "2023-04-18",
+    "Description": "S:Q52H, Latvia/Poland"
+  },
+  {
+    "Lineage": "XBB.2.11",
+    "Earliest date": "2022-01-03",
+    "Latest date": "2023-04-04",
+    "Description": "C18129T"
+  },
+  {
+    "Lineage": "XBB.2.11.1",
+    "Earliest date": "2022-07-27",
+    "Latest date": "2023-04-19",
+    "Description": "C4084T, C9559T, T16521C, USA"
+  },
+  {
+    "Lineage": "XBB.2.12",
+    "Earliest date": "2022-10-01",
+    "Latest date": "2023-06-12",
+    "Description": "S:Q613H (G23401C), C4090T, T24194C, India"
+  },
+  {
+    "Lineage": "XBB.3",
+    "Earliest date": "2022-08-22",
+    "Latest date": "2023-04-14",
+    "Description": "ORF1b:I1988V, on ORF1a:D82G branch"
+  },
+  {
+    "Lineage": "XBB.3.1",
+    "Earliest date": "2022-09-20",
+    "Latest date": "2023-02-04",
+    "Description": "S:Q677R, after T1993C, India-TN/Singapore, from #1241"
+  },
+  {
+    "Lineage": "XBB.3.2",
+    "Earliest date": "2022-09-10",
+    "Latest date": "2023-05-02",
+    "Description": "S:M177T"
+  },
+  {
+    "Lineage": "XBB.3.3",
+    "Earliest date": "2022-10-04",
+    "Latest date": "2023-01-20",
+    "Description": "S:V1122L, after T1993C, USA"
+  },
+  {
+    "Lineage": "XBB.3.4",
+    "Earliest date": "2022-09-22",
+    "Latest date": "2023-07-17",
+    "Description": "S:E990D"
+  },
+  {
+    "Lineage": "XBB.3.5",
+    "Earliest date": "2022-11-23",
+    "Latest date": "2023-03-20",
+    "Description": "ORF1a:T4083M, Mozambique, from #1778"
+  },
+  {
+    "Lineage": "XBB.4",
+    "Earliest date": "2022-09-07",
+    "Latest date": "2023-04-05",
+    "Description": "S:K444R, on ORF1a:D82G branch, from #1239"
+  },
+  {
+    "Lineage": "XBB.4.1",
+    "Earliest date": "2022-10-13",
+    "Latest date": "2022-11-16",
+    "Description": "England/Austria, S:L5F, S:T470N"
+  },
+  {
+    "Lineage": "XBB.5",
+    "Earliest date": "2022-09-09",
+    "Latest date": "2022-12-24",
+    "Description": "S:A653V, after G5518A, on ORF1a:D82G branch, India-TN, Singapore, Australia"
+  },
+  {
+    "Lineage": "XBB.6",
+    "Earliest date": "2022-09-12",
+    "Latest date": "2023-04-25",
+    "Description": "C14178T, on ORF1a:D82G branch, USA/India/England"
+  },
+  {
+    "Lineage": "XBB.6.1",
+    "Earliest date": "2022-10-22",
+    "Latest date": "2023-05-30",
+    "Description": "S:F486P, USA, from #1459"
+  },
+  {
+    "Lineage": "XBB.7",
+    "Earliest date": "2022-10-01",
+    "Latest date": "2023-03-20",
+    "Description": "S:Q613H, after G5518A, on ORF1a:D82G branch, Malaysia"
+  },
+  {
+    "Lineage": "XBB.8",
+    "Earliest date": "2022-08-24",
+    "Latest date": "2023-05-02",
+    "Description": "T14574C, on ORF1a:D82G branch, India/Malaysia/Brunei"
+  },
+  {
+    "Lineage": "XBB.8.1",
+    "Earliest date": "2022-12-19",
+    "Latest date": "2023-06-06",
+    "Description": "S:486P, ORF1a:K634N, ORF1a:K3353R, Malaysia"
+  },
+  {
+    "Lineage": "XBB.8.2",
+    "Earliest date": "2023-02-27",
+    "Latest date": "2023-11-20",
+    "Description": "S:486P, ORF1a:A2529V, Reunion/Mayotte/Mauritius, from #1995"
+  },
+  {
+    "Lineage": "XBB.9",
+    "Earliest date": "2022-08-27",
+    "Latest date": "2023-03-05",
+    "Description": "N:T49I, on ORF1a:D82G branch, Philippines"
+  },
+  {
+    "Lineage": "XBC",
+    "Earliest date": "2022-08-22",
+    "Latest date": "2023-03-06",
+    "Description": "Recombinant lineage of BA.2 and B.1.617.2(21I), predominantly in Philippines, from #1100"
+  },
+  {
+    "Lineage": "XBC.1",
+    "Earliest date": "2022-01-11",
+    "Latest date": "2024-01-02",
+    "Description": "Mostly Philippines, South Korea, USA, Singapore, defined by S:L452M, from #1130"
+  },
+  {
+    "Lineage": "XBC.1.1",
+    "Earliest date": "2022-10-25",
+    "Latest date": "2023-06-25",
+    "Description": "Mostly Australia, ORF1a:I3619T, ORF8:V114L"
+  },
+  {
+    "Lineage": "XBC.1.1.1",
+    "Earliest date": "2022-11-06",
+    "Latest date": "2023-01-06",
+    "Description": "Australia, S:G476S"
+  },
+  {
+    "Lineage": "XBC.1.1.2",
+    "Earliest date": "2022-12-29",
+    "Latest date": "2023-09-07",
+    "Description": "ORF7b:L32F, Australia"
+  },
+  {
+    "Lineage": "XBC.1.2",
+    "Earliest date": "2022-09-20",
+    "Latest date": "2023-02-13",
+    "Description": "Philippines/Netherlands/Denmark, T11269C"
+  },
+  {
+    "Lineage": "XBC.1.2.1",
+    "Earliest date": "2022-11-09",
+    "Latest date": "2023-06-19",
+    "Description": "Denmark, ORF1b:T132I"
+  },
+  {
+    "Lineage": "XBC.1.3",
+    "Earliest date": "2022-09-05",
+    "Latest date": "2023-06-26",
+    "Description": "Philippines/Australia, C25614T"
+  },
+  {
+    "Lineage": "XBC.1.3.1",
+    "Earliest date": "2022-11-13",
+    "Latest date": "2024-03-26",
+    "Description": "ORF1a:Q455K, ORF1a:T4174I, ORF1a:V2061A, ORF1b:S759N, Australia/New Zealand, from sars-cov-2-variants/lineage-proposals#542"
+  },
+  {
+    "Lineage": "KD.1",
+    "Earliest date": "2023-06-21",
+    "Latest date": "2024-02-17",
+    "Description": "Alias of XBC.1.3.1.1, S:R346S, Australia, from sars-cov-2-variants/lineage-proposals#673"
+  },
+  {
+    "Lineage": "KD.2",
+    "Earliest date": "2023-04-12",
+    "Latest date": "2024-01-24",
+    "Description": "Alias of XBC.1.3.1.2, ORF1a:M3661L, ORF1a:M3934I, Australia/New Zealand"
+  },
+  {
+    "Lineage": "KD.3",
+    "Earliest date": "2023-04-08",
+    "Latest date": "2024-01-11",
+    "Description": "Alias of XBC.1.3.1.3, C10519T, C19524T, New Zealand"
+  },
+  {
+    "Lineage": "KD.4",
+    "Earliest date": "2023-03-07",
+    "Latest date": "2024-01-15",
+    "Description": "Alias of XBC.1.3.1.4, ORF1a:K394R, ORF1a:L730F, ORF1a:T965I, Australia/Japan"
+  },
+  {
+    "Lineage": "XBC.1.4",
+    "Earliest date": "2022-09-13",
+    "Latest date": "2023-08-18",
+    "Description": "Australia, S:G184S, from #1622"
+  },
+  {
+    "Lineage": "XBC.1.5",
+    "Earliest date": "2022-09-07",
+    "Latest date": "2023-10-10",
+    "Description": "Philippines/South Korea/Japan, ORF1a:T708I after A10042C, from #1671"
+  },
+  {
+    "Lineage": "XBC.1.6",
+    "Earliest date": "2023-01-17",
+    "Latest date": "2024-01-10",
+    "Description": "S:346S, S:M452R, found in Australia, from #1755"
+  },
+  {
+    "Lineage": "XBC.1.6.1",
+    "Earliest date": "2023-02-13",
+    "Latest date": "2024-03-21",
+    "Description": "ORF8:P36L, Australia"
+  },
+  {
+    "Lineage": "GT.1",
+    "Earliest date": "2023-03-12",
+    "Latest date": "2023-09-03",
+    "Description": "Alias of XBC.1.6.1.1, S:I105V, C28333T, Australia"
+  },
+  {
+    "Lineage": "XBC.1.6.2",
+    "Earliest date": "2023-02-20",
+    "Latest date": "2023-11-25",
+    "Description": "ORF1a:D827N, Australia"
+  },
+  {
+    "Lineage": "XBC.1.6.3",
+    "Earliest date": "2023-03-03",
+    "Latest date": "2023-12-05",
+    "Description": "N:A173V, Australia"
+  },
+  {
+    "Lineage": "HW.1",
+    "Earliest date": "2023-03-28",
+    "Latest date": "2024-01-06",
+    "Description": "Alias of XBC.1.6.3.1, ORF1a:T1597I, ORF1a:A2123V, Australia, from sars-cov-2-variants/lineage-proposals#71"
+  },
+  {
+    "Lineage": "HW.1.1",
+    "Earliest date": "2023-06-10",
+    "Latest date": "2024-07-08",
+    "Description": "Alias of XBC.1.6.3.1.1, S:N460H, T16242A, C22120T, USA/Ireland, from sars-cov-2-variants/lineage-proposals#452"
+  },
+  {
+    "Lineage": "HW.1.2",
+    "Earliest date": "2023-03-28",
+    "Latest date": "2024-01-13",
+    "Description": "Alias of XBC.1.6.3.1.2, G15957A, Australia"
+  },
+  {
+    "Lineage": "HW.1.3",
+    "Earliest date": "2023-04-12",
+    "Latest date": "2023-08-29",
+    "Description": "Alias of XBC.1.6.3.1.3, N:T391I, Australia"
+  },
+  {
+    "Lineage": "XBC.1.6.4",
+    "Earliest date": "2023-03-16",
+    "Latest date": "2023-10-13",
+    "Description": "ORF1a:V1117I, T20286C, Australia"
+  },
+  {
+    "Lineage": "XBC.1.6.5",
+    "Earliest date": "2023-04-04",
+    "Latest date": "2023-12-23",
+    "Description": "ORF7a:Q90*, C1594T, C15601T, Australia, from sars-cov-2-variants/lineage-proposals#479"
+  },
+  {
+    "Lineage": "XBC.1.6.6",
+    "Earliest date": "2023-02-18",
+    "Latest date": "2023-11-20",
+    "Description": "T8707C, C26735T, Australia"
+  },
+  {
+    "Lineage": "JT.1",
+    "Earliest date": "2023-05-12",
+    "Latest date": "2024-02-11",
+    "Description": "Alias of XBC.1.6.6.1, S:V445A, from sars-cov-2-variants/lineage-proposals#203"
+  },
+  {
+    "Lineage": "XBC.1.7",
+    "Earliest date": "2023-02-09",
+    "Latest date": "2023-05-15",
+    "Description": "S:478R, S:444T, Philippines/Australia/Hong Kong, from sars-cov-2-variants/lineage-proposals#110"
+  },
+  {
+    "Lineage": "XBC.1.7.1",
+    "Earliest date": "2023-03-29",
+    "Latest date": "2023-05-26",
+    "Description": "S:N185S, Philiippines"
+  },
+  {
+    "Lineage": "XBC.1.7.2",
+    "Earliest date": "2023-04-19",
+    "Latest date": "2023-07-07",
+    "Description": "S:T299I, Australia"
+  },
+  {
+    "Lineage": "XBC.2",
+    "Earliest date": "2022-08-24",
+    "Latest date": "2023-01-26",
+    "Description": "Mostly Philippines, defined by S:K97R"
+  },
+  {
+    "Lineage": "XBC.2.1",
+    "Earliest date": "2022-11-29",
+    "Latest date": "2023-04-30",
+    "Description": "S:K444T, Australia, from #1538"
+  },
+  {
+    "Lineage": "XBD",
+    "Earliest date": "2022-08-25",
+    "Latest date": "2023-02-07",
+    "Description": "Recombinant lineage of BA.2.75.2 and BF.5, India and world, from #1137"
+  },
+  {
+    "Lineage": "XBE",
+    "Earliest date": "2022-08-08",
+    "Latest date": "2023-02-28",
+    "Description": "Recombinant lineage of BA.5.2 and BE.4.1, predominantly in USA and England, from #1246"
+  },
+  {
+    "Lineage": "XBF",
+    "Earliest date": "2022-04-17",
+    "Latest date": "2023-10-02",
+    "Description": "Recombinant lineage of BA.5.2* and CJ.1, Australia, from #1259"
+  },
+  {
+    "Lineage": "XBF.1",
+    "Earliest date": "2022-12-16",
+    "Latest date": "2023-03-14",
+    "Description": "Australia/England, S:S939F"
+  },
+  {
+    "Lineage": "XBF.1.1",
+    "Earliest date": "2023-01-24",
+    "Latest date": "2023-04-16",
+    "Description": "England, S:P621S, from #1651"
+  },
+  {
+    "Lineage": "XBF.2",
+    "Earliest date": "2022-11-08",
+    "Latest date": "2023-10-12",
+    "Description": "Australia, ORF8:V62A"
+  },
+  {
+    "Lineage": "XBF.3",
+    "Earliest date": "2022-10-28",
+    "Latest date": "2024-06-05",
+    "Description": "Australia, ORF1a:V274I"
+  },
+  {
+    "Lineage": "XBF.4",
+    "Earliest date": "2022-12-01",
+    "Latest date": "2023-05-19",
+    "Description": "Europe, ORF1a:H417Y, from jmcbroome/auto-pango-designation#193"
+  },
+  {
+    "Lineage": "XBF.5",
+    "Earliest date": "2022-11-05",
+    "Latest date": "2023-07-12",
+    "Description": "Australia, C2455T"
+  },
+  {
+    "Lineage": "XBF.6",
+    "Earliest date": "2022-11-16",
+    "Latest date": "2023-04-25",
+    "Description": "Australia, ORF1a:V3986A"
+  },
+  {
+    "Lineage": "XBF.7",
+    "Earliest date": "2022-11-11",
+    "Latest date": "2023-07-03",
+    "Description": "Global, N:T379I (not on ORF1a:K120N branch)"
+  },
+  {
+    "Lineage": "XBF.7.1",
+    "Earliest date": "2022-12-05",
+    "Latest date": "2023-05-02",
+    "Description": "S:T323I"
+  },
+  {
+    "Lineage": "XBF.8",
+    "Earliest date": "2022-10-27",
+    "Latest date": "2023-04-09",
+    "Description": "Australia, T9931C, C12970T"
+  },
+  {
+    "Lineage": "XBF.8.1",
+    "Earliest date": "2023-01-10",
+    "Latest date": "2023-03-15",
+    "Description": "Australia, S:P621S, from #1651"
+  },
+  {
+    "Lineage": "XBF.9",
+    "Earliest date": "2022-11-28",
+    "Latest date": "2023-11-30",
+    "Description": "Europe, ORF1b:S1003G"
+  },
+  {
+    "Lineage": "XBF.10",
+    "Earliest date": "2022-12-10",
+    "Latest date": "2023-05-26",
+    "Description": "Australia, S:M153I"
+  },
+  {
+    "Lineage": "XBG",
+    "Earliest date": "2022-07-05",
+    "Latest date": "2023-03-20",
+    "Description": "Recombinant lineage of BA.2.76 and BA.5.2, predominantly in UK, from #896"
+  },
+  {
+    "Lineage": "XBH",
+    "Earliest date": "2022-07-27",
+    "Latest date": "2022-12-22",
+    "Description": "Recombinant lineage of BA.2.3.17 and BA.2.75.2, predominantly in Brunei, from #1229"
+  },
+  {
+    "Lineage": "XBJ",
+    "Earliest date": "2022-09-02",
+    "Latest date": "2023-06-28",
+    "Description": "Recombinant lineage of BA.2.3.20 and BA.5.2, possibly Philippines, from #1268"
+  },
+  {
+    "Lineage": "XBJ.1",
+    "Earliest date": "2022-09-17",
+    "Latest date": "2023-02-03",
+    "Description": "A16011G, from #1591"
+  },
+  {
+    "Lineage": "XBJ.1.1",
+    "Earliest date": "2022-11-21",
+    "Latest date": "2023-04-10",
+    "Description": "S:G485D, N:R195K, from #1591"
+  },
+  {
+    "Lineage": "XBJ.2",
+    "Earliest date": "2022-10-03",
+    "Latest date": "2023-03-06",
+    "Description": "C22006T, Europe"
+  },
+  {
+    "Lineage": "XBJ.3",
+    "Earliest date": "2022-11-01",
+    "Latest date": "2023-03-06",
+    "Description": "ORF1a:K2928N, Europe"
+  },
+  {
+    "Lineage": "XBJ.4",
+    "Earliest date": "2022-12-10",
+    "Latest date": "2023-03-26",
+    "Description": "S:G485D, Japan/Thailand"
+  },
+  {
+    "Lineage": "XBK",
+    "Earliest date": "2022-01-11",
+    "Latest date": "2024-03-09",
+    "Description": "Recombinant lineage of BA.5.2 and CJ.1, Denmark/Europe, from #1418"
+  },
+  {
+    "Lineage": "XBK.1",
+    "Earliest date": "2022-07-27",
+    "Latest date": "2023-06-05",
+    "Description": "S:P1162S, from #1551 and jmcbroome/auto-pango-designation#193"
+  },
+  {
+    "Lineage": "XBL",
+    "Earliest date": "2022-11-24",
+    "Latest date": "2023-10-30",
+    "Description": "Recombinant lineage of XBB.1.5.57-BA.2.75* (short segment from ~1k-~5k)-XBB.1.5.57, Malaysia, from #1532"
+  },
+  {
+    "Lineage": "XBL.1",
+    "Earliest date": "2023-01-20",
+    "Latest date": "2023-08-07",
+    "Description": "S:V635I, T2461C"
+  },
+  {
+    "Lineage": "XBL.2",
+    "Earliest date": "2022-12-14",
+    "Latest date": "2023-07-13",
+    "Description": "A1393G"
+  },
+  {
+    "Lineage": "XBL.3",
+    "Earliest date": "2023-01-20",
+    "Latest date": "2023-11-18",
+    "Description": "C11824T, G14400T"
+  },
+  {
+    "Lineage": "XBL.3.1",
+    "Earliest date": "2023-03-01",
+    "Latest date": "2023-08-30",
+    "Description": "S:I726V, C10252T, G29702A, Singapore/South Korea/Thailand, from sars-cov-2-variants/lineage-proposals#44"
+  },
+  {
+    "Lineage": "XBM",
+    "Earliest date": "2022-07-25",
+    "Latest date": "2023-03-30",
+    "Description": "Recombinant lineage of BA.2.76 and BF.3, India/USA/Canada, from #1441"
+  },
+  {
+    "Lineage": "XBN",
+    "Earliest date": "2022-09-29",
+    "Latest date": "2023-02-16",
+    "Description": "Recombinant lineage of BA.2.75 and XBB.3, mainly found in USA, from #1296"
+  },
+  {
+    "Lineage": "XBP",
+    "Earliest date": "2022-11-01",
+    "Latest date": "2023-04-27",
+    "Description": "Recombinant lineage of BA.2.75* and BQ.1*, predominantly in England and Canada, from #1393"
+  },
+  {
+    "Lineage": "XBQ",
+    "Earliest date": "2022-10-27",
+    "Latest date": "2023-04-11",
+    "Description": "Recombinant lineage of BA.5.2 and CJ.1, defined by ORF1b:M454I, England and Canada, from #1440 and autolin"
+  },
+  {
+    "Lineage": "XBR",
+    "Earliest date": "2022-11-23",
+    "Latest date": "2023-05-14",
+    "Description": "Recombinant lineage of BA.2.75* and BQ.1 (with S:R346T), England, Canada, USA, from #1637"
+  },
+  {
+    "Lineage": "XBS",
+    "Earliest date": "2022-11-08",
+    "Latest date": "2023-03-23",
+    "Description": "Recombinant lineage of BA.2.75* and BQ.1 (with S:R346T), England, from #1567"
+  },
+  {
+    "Lineage": "XBT",
+    "Earliest date": "2022-11-29",
+    "Latest date": "2023-04-17",
+    "Description": "Recombinant lineage of BA.5.2.34, BA.2.75, BA.5.2.34, Germany, from #1576"
+  },
+  {
+    "Lineage": "XBU",
+    "Earliest date": "2022-10-31",
+    "Latest date": "2023-07-11",
+    "Description": "Recombinant lineage of BA.2.75.3, BQ.1, BA.2.75.3, from #1425"
+  },
+  {
+    "Lineage": "XBV",
+    "Earliest date": "2022-11-14",
+    "Latest date": "2023-05-16",
+    "Description": "Recombinant lineage of CR.1, XBB.1, from #1460"
+  },
+  {
+    "Lineage": "XBW",
+    "Earliest date": "2022-01-03",
+    "Latest date": "2023-06-16",
+    "Description": "Recombinant lineage of XBB.1.5, BQ.1.14, from #1505"
+  },
+  {
+    "Lineage": "XBY",
+    "Earliest date": "2023-01-16",
+    "Latest date": "2023-03-17",
+    "Description": "Recombinant lineage of BR.2.1, XBF, from #1669"
+  },
+  {
+    "Lineage": "XBZ",
+    "Earliest date": "2022-11-18",
+    "Latest date": "2023-04-17",
+    "Description": "Recombinant lineage of BA.5.2* and EF.1.3, predominantly in Denmark, Germany and Austria, from #1666"
+  },
+  {
+    "Lineage": "XCA",
+    "Earliest date": "2022-12-22",
+    "Latest date": "2023-04-04",
+    "Description": "Recombinant lineage of BA.2.75* and BQ.1*, predominantly in UK, from #1752"
+  },
+  {
+    "Lineage": "XCB",
+    "Earliest date": "2022-12-28",
+    "Latest date": "2023-05-05",
+    "Description": "Recombinant lineage of BF.31.1 and BQ.1.10*, predominantly in Chile, from #1668"
+  },
+  {
+    "Lineage": "XCC",
+    "Earliest date": "2023-02-12",
+    "Latest date": "2023-06-23",
+    "Description": "Recombinant lineage of CH.1.1.1 and XBB.1.9.1, predominantly Pakistan, Australia, from #1876"
+  },
+  {
+    "Lineage": "XCD",
+    "Earliest date": "2023-01-26",
+    "Latest date": "2023-07-28",
+    "Description": "Recombinant lineage of XBB.1* and BQ.1.1.25*, with S:R214H, S:478I, Indonesia, from #2042"
+  },
+  {
+    "Lineage": "XCE",
+    "Earliest date": "2023-02-10",
+    "Latest date": "2023-08-28",
+    "Description": "Recombinant lineage of BQ.1* and FY.1 (XBB.1.22.1.1), Indonesia, South Korea, France, from sars-cov-2-variants/lineage-proposals#123"
+  },
+  {
+    "Lineage": "XCF",
+    "Earliest date": "2023-03-20",
+    "Latest date": "2023-11-15",
+    "Description": "Recombinant lineage of XBB* and FE.1 (XBB.1.18.1.1), possibly South America, from sars-cov-2-variants/lineage-proposals#2"
+  },
+  {
+    "Lineage": "XCF.1",
+    "Earliest date": "2023-04-15",
+    "Latest date": "2023-07-07",
+    "Description": "S:F157L, USA, from sars-cov-2-variants/lineage-proposals#274"
+  },
+  {
+    "Lineage": "XCF.2",
+    "Earliest date": "2023-04-26",
+    "Latest date": "2023-07-10",
+    "Description": "S:S929I, Canada"
+  },
+  {
+    "Lineage": "XCF.3",
+    "Earliest date": "2023-06-30",
+    "Latest date": "2023-11-06",
+    "Description": "S:R78M"
+  },
+  {
+    "Lineage": "XCG",
+    "Earliest date": "2022-10-19",
+    "Latest date": "2023-03-21",
+    "Description": "Recombinant lineage of BA.5.2* and XBB.1, Mexico"
+  },
+  {
+    "Lineage": "XCH",
+    "Earliest date": "2023-06-09",
+    "Latest date": "2024-05-26",
+    "Description": "Recombinant lineage of GK.1.3 and XBB.1.9 (or XBB.1.16), GK.1.3 Spike with ORF9b:I5T from donor, from #2173"
+  },
+  {
+    "Lineage": "XCH.1",
+    "Earliest date": "2022-10-18",
+    "Latest date": "2024-06-09",
+    "Description": "S:T573I, from #2173"
+  },
+  {
+    "Lineage": "XCJ",
+    "Earliest date": "2023-04-17",
+    "Latest date": "2023-10-16",
+    "Description": "Recombinant lineage of GM.2 with a little FP.1 (XBB.1.11.1.1) sandwich inserted in ORF1ab, from sars-cov-2-variants/lineage-proposals#609"
+  },
+  {
+    "Lineage": "XCK",
+    "Earliest date": "2023-07-20",
+    "Latest date": "2023-12-20",
+    "Description": "Recombinant lineage of FL.1.5.1 (5' up to and including S:701) and BQ.1.2.2, from #2215"
+  },
+  {
+    "Lineage": "XCL",
+    "Earliest date": "2023-06-30",
+    "Latest date": "2024-01-25",
+    "Description": "Recombinant lineage of XBB (possibly XBB.1.5.68 or FY.4) from 5' up to 12468-15754, GK.2.1 onwards, Europe, from #2227"
+  },
+  {
+    "Lineage": "XCM",
+    "Earliest date": "2023-07-20",
+    "Latest date": "2023-12-22",
+    "Description": "Recombinant lineage of XBB.2.3 and DV.7.1 (breakpoint between 22017-22031), Spain/Italy, from sars-cov-2-variants/lineage-proposals#674"
+  },
+  {
+    "Lineage": "XCN",
+    "Earliest date": "2023-08-01",
+    "Latest date": "2023-10-06",
+    "Description": "Recombinant lineage of FR.1.1 and EG.5.1.1 (breakpoint between 22630-22663), China (Anhui/Shanghai), from sars-cov-2-variants/lineage-proposals#842"
+  },
+  {
+    "Lineage": "XCP",
+    "Earliest date": "2023-08-21",
+    "Latest date": "2024-02-06",
+    "Description": "Recombinant lineage of EG.5.1.10 and JD.1.1 (breakpoint between 14190-14633), France/Denmark/England, from sars-cov-2-variants/lineage-proposals#772"
+  },
+  {
+    "Lineage": "XCQ",
+    "Earliest date": "2023-06-09",
+    "Latest date": "2023-10-05",
+    "Description": "Recombinant lineage of XBB.2.3 and XBB.1.5 (breakpoint between 23123-27431), Guatemala, from #2289"
+  },
+  {
+    "Lineage": "XCR",
+    "Earliest date": "2023-08-23",
+    "Latest date": "2024-01-20",
+    "Description": "Recombinant lineage of GK.1.1.1 and FU.1.1.1 (breakpoint between 23674-24372), USA, from #2323"
+  },
+  {
+    "Lineage": "XCS",
+    "Earliest date": "2023-07-31",
+    "Latest date": "2023-11-17",
+    "Description": "Recombinant lineage of GK.1.9 and XBB.1.16.25 (breakpoint between 223674-25044), USA, from #2311"
+  },
+  {
+    "Lineage": "XCT",
+    "Earliest date": "2023-08-13",
+    "Latest date": "2024-02-01",
+    "Description": "Recombinant lineage of JG.4, DV.7.1, JG.4 (breakpoints at 18430-19885 and 25960-27506), Europe, from sars-cov-2-variants/lineage-proposals#811"
+  },
+  {
+    "Lineage": "XCT.1",
+    "Earliest date": "2023-09-20",
+    "Latest date": "2024-01-22",
+    "Description": "S:S704L, from #2358"
+  },
+  {
+    "Lineage": "XCU",
+    "Earliest date": "2023-09-04",
+    "Latest date": "2024-02-08",
+    "Description": "Recombinant lineage of XBC.1.7.1 and FL.23.2.1 (breakpoint 22329-22577), Philippines, from sars-cov-2-variants/lineage-proposals#935"
+  },
+  {
+    "Lineage": "XCV",
+    "Earliest date": "2023-07-07",
+    "Latest date": "2024-01-14",
+    "Description": "Recombinant lineage of XBB.1.16.19, EG.5.1.3, XBB.1.16.19 (breakpoints 9694-11749 and 22996-27064), USA/Canada, from #2210"
+  },
+  {
+    "Lineage": "XCW",
+    "Earliest date": "2023-07-06",
+    "Latest date": "2023-12-09",
+    "Description": "Recombinant lineage of XBB.2.3.20, XBB.1.16.15 (breakpoint 22996-27430), India/USA from #2260"
+  },
+  {
+    "Lineage": "XCY",
+    "Earliest date": "2023-09-11",
+    "Latest date": "2024-01-14",
+    "Description": "Recombinant lineage of EG.5.1.3, GK.4 (or GK.3.1) (breakpoint 21719-22569), France, from sars-cov-2-variants/lineage-proposals#887"
+  },
+  {
+    "Lineage": "XCZ",
+    "Earliest date": "2023-08-24",
+    "Latest date": "2024-01-24",
+    "Description": "Recombinant lineage of EG.5.1.1, GK.1.1 (breakpoint 18492-21718), France/Italy/England, from sars-cov-2-variants/lineage-proposals#839"
+  },
+  {
+    "Lineage": "XDA",
+    "Earliest date": "2023-08-19",
+    "Latest date": "2024-03-07",
+    "Description": "Recombinant lineage of XBB.1.16, HN.5 (breakpoint 22102-22927), from sars-cov-2-variants/lineage-proposals#862"
+  },
+  {
+    "Lineage": "XDA.1",
+    "Earliest date": "2023-09-21",
+    "Latest date": "2024-02-09",
+    "Description": "S:L176F, from sars-cov-2-variants/lineage-proposals#1031"
+  },
+  {
+    "Lineage": "XDB",
+    "Earliest date": "2023-03-20",
+    "Latest date": "2023-12-07",
+    "Description": "Recombinant lineage of XBB.1.16.19, non-XBB.1.16/EG.5/XBB.2.3 XBB (breakpoint ~28000, depending on donor), Indonesia, from sars-cov-2-variants/lineage-proposals#969"
+  },
+  {
+    "Lineage": "XDC",
+    "Earliest date": "2023-08-31",
+    "Latest date": "2024-03-11",
+    "Description": "Recombinant lineage of HK.3, XBB.1.16 (breakpoint 22996-27506), China/Singapore, from sars-cov-2-variants/lineage-proposals#902"
+  },
+  {
+    "Lineage": "XDD",
+    "Earliest date": "2023-01-02",
+    "Latest date": "2024-07-22",
+    "Description": "Recombinant lineage of EG.5.1.1, JN.1, EG.5.1.1 (breakpoints at 6541-7842 and 25416-26270), USA/France/Spain, from sars-cov-2-variants/lineage-proposals#1024"
+  },
+  {
+    "Lineage": "XDD.1",
+    "Earliest date": "2023-11-29",
+    "Latest date": "2024-05-16",
+    "Description": "S:S704L, from sars-cov-2-variants/lineage-proposals#1203"
+  },
+  {
+    "Lineage": "XDD.1.1",
+    "Earliest date": "2023-11-21",
+    "Latest date": "2024-07-22",
+    "Description": "S:I584V, from sars-cov-2-variants/lineage-proposals#1203"
+  },
+  {
+    "Lineage": "XDD.1.1.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "S:R346T, from sars-cov-2-variants/lineage-proposals#1450"
+  },
+  {
+    "Lineage": "XDD.2",
+    "Earliest date": "2023-11-20",
+    "Latest date": "2024-02-21",
+    "Description": "S:T307I, from sars-cov-2-variants/lineage-proposals#1176"
+  },
+  {
+    "Lineage": "XDD.3",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "S:T572I, S:F456L (T22928C), G12268A, T17574G, France/Europe"
+  },
+  {
+    "Lineage": "XDE",
+    "Earliest date": "2023-09-14",
+    "Latest date": "2024-01-13",
+    "Description": "Recombinant lineage of GW.5.1 and FL.13.4 (breakpoint at 24034-24046), Pakistan, from #2352"
+  },
+  {
+    "Lineage": "XDF",
+    "Earliest date": "2023-09-14",
+    "Latest date": "2023-12-27",
+    "Description": "Recombinant lineage of XBB* (with C335T) and EG.5.1.3 (breakpoint around 2335-9692), from sars-cov-2-variants/lineage-proposals#1088"
+  },
+  {
+    "Lineage": "XDG",
+    "Earliest date": "2023-08-21",
+    "Latest date": "2023-10-30",
+    "Description": "Recombinant lineage of FL.37 and EG.5.2.4 (breakpoint at 6729-9693), from #2348"
+  },
+  {
+    "Lineage": "XDH",
+    "Earliest date": "2023-04-26",
+    "Latest date": "2023-11-30",
+    "Description": "Recombinant lineage of BN.1.2.8 and XBB.1.9.1 (or XBB.1.22) (breakpoint between 22630-22663), Lithuania/Belarus, from sars-cov-2-variants/lineage-proposals#128"
+  },
+  {
+    "Lineage": "XDJ",
+    "Earliest date": "2023-10-02",
+    "Latest date": "2024-01-10",
+    "Description": "Recombinant lineage of XBB.1.16.6 and HK.3.1 (breakpoint between 14857 and 16877), France, from sars-cov-2-variants/lineage-proposals#997"
+  },
+  {
+    "Lineage": "XDK",
+    "Earliest date": "2023-01-03",
+    "Latest date": "2024-08-12",
+    "Description": "Recombinant lineage of XBB.1.16.11 (likely) and JN.1.1.1 (breakpoint between 5315 and 6182), France, from #2415"
+  },
+  {
+    "Lineage": "XDK.1",
+    "Earliest date": "2023-12-22",
+    "Latest date": "2024-08-09",
+    "Description": "S:R346T, S:G213E, G11596A, from sars-cov-2-variants/lineage-proposals#1407"
+  },
+  {
+    "Lineage": "XDK.1.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "S:K182R, S:E213G reversion, India, from sars-cov-2-variants/lineage-proposals#1490"
+  },
+  {
+    "Lineage": "XDK.1.2",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "S:F456L (T22928C), from sars-cov-2-variants/lineage-proposals#1407"
+  },
+  {
+    "Lineage": "XDK.2",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "S:K679R, T4996A, C11173T, A23598G, C27297T, from sars-cov-2-variants/lineage-proposals#1385"
+  },
+  {
+    "Lineage": "XDK.3",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "S:F456L (T22928C), ORF1a:F3397L, from sars-cov-2-variants/lineage-proposals#1511"
+  },
+  {
+    "Lineage": "XDK.4",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "C25626T"
+  },
+  {
+    "Lineage": "XDK.4.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "S:F456L, France/Luxembourg, from sars-cov-2-variants/lineage-proposals#1467"
+  },
+  {
+    "Lineage": "XDK.5",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "S:F456L, C22388T, Spain from #2611"
+  },
+  {
+    "Lineage": "XDK.6",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "S:F456L, S:R237K, S:Q1201K, England, from sars-cov-2-variants/lineage-proposals#1572"
+  },
+  {
+    "Lineage": "XDL",
+    "Earliest date": "2023-08-12",
+    "Latest date": "2024-04-09",
+    "Description": "Recombinant lineage of EG.5.1.1 and non-EG.5 (breakpoint between 25573-29624) with S:I1114T, most with S:L455F(G22927T), China, from #2351"
+  },
+  {
+    "Lineage": "XDM",
+    "Earliest date": "2023-11-08",
+    "Latest date": "2024-01-24",
+    "Description": "Recombinant lineage of XDA, GW.5, XDA (breakpoints between 22107-22926 and 24047-25838), from sars-cov-2-variants/lineage-proposals#1163"
+  },
+  {
+    "Lineage": "XDN",
+    "Earliest date": "2023-11-26",
+    "Latest date": "2024-03-23",
+    "Description": "Recombinant lineage of JN.1.1 and JD.1 (breakpoint between 24379 and 24989), from #2448"
+  },
+  {
+    "Lineage": "XDP",
+    "Earliest date": "2023-11-07",
+    "Latest date": "2024-08-04",
+    "Description": "Recombinant lineage of JN.1.4+T18453C and FL.15 (breakpoint between 26834 and 27809), from #2451"
+  },
+  {
+    "Lineage": "XDP.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "S:E1092D, after ORF1a:L397P, ORF1a:H388Y, from sars-cov-2-variants/lineage-proposals#1358"
+  },
+  {
+    "Lineage": "XDP.2",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "S:E309Q, Brazil/Canada, from sars-cov-2-variants/lineage-proposals#1432"
+  },
+  {
+    "Lineage": "XDP.3",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "S:S255F, USA"
+  },
+  {
+    "Lineage": "XDQ",
+    "Earliest date": "2023-11-14",
+    "Latest date": "2024-07-01",
+    "Description": "Recombinant lineage of BA.2.86.1 and FL.15.1.1 (breakpoint between 23605 and 24377), most with T22846C, Vietnam/Japan/South Korea, from #2481"
+  },
+  {
+    "Lineage": "XDQ.1",
+    "Earliest date": "2023-12-16",
+    "Latest date": "2024-07-30",
+    "Description": "S:A475V, Japan/South Korea, from #2497"
+  },
+  {
+    "Lineage": "XDQ.1.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "S:S60P, C1594T, Japan, from sars-cov-2-variants/lineage-proposals#1523"
+  },
+  {
+    "Lineage": "XDQ.2",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "S:N487D, Vietnam, from sars-cov-2-variants/lineage-proposals#1408"
+  },
+  {
+    "Lineage": "XDQ.3",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "S:681H, Indonesia, from sars-cov-2-variants/lineage-proposals#1508"
+  },
+  {
+    "Lineage": "XDR",
+    "Earliest date": "2023-11-16",
+    "Latest date": "2024-08-17",
+    "Description": "Recombinant lineage of JD.1.1.1 and JN.1.1 (breakpoint between 11043 and 11726), Brazil, from #2477"
+  },
+  {
+    "Lineage": "XDR.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "S:F59S, G6077T, A14031G, C26801T, Brazil/Peru, from sars-cov-2-variants/lineage-proposals#1542"
+  },
+  {
+    "Lineage": "XDR.1.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "S:F456L, ORF1a:A2142V, ORF1b:A2480D, ORF8:E92K"
+  },
+  {
+    "Lineage": "XDR.1.2",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "ORF1a:L3754F, ORF1b:L1890F"
+  },
+  {
+    "Lineage": "XDS",
+    "Earliest date": "2023-12-05",
+    "Latest date": "2024-06-27",
+    "Description": "Recombinant lineage of EG.5.1.3, JN.3.2.1, EG.5.1.3 (breakpoints at 8294-8392 and 26834-27506), from sars-cov-2-variants/lineage-proposals#1267"
+  },
+  {
+    "Lineage": "XDT",
+    "Earliest date": "2023-11-13",
+    "Latest date": "2024-02-20",
+    "Description": "Recombinant lineage of BA.2.86.4, GK.1 (breakpoint between 23673-24378), Ireland/UK, from #2485"
+  },
+  {
+    "Lineage": "XDU",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Recombinant lineage of BA.2.86.1, XBB.1.16  (breakpoint between 11957-12729), Japan, from #2502"
+  },
+  {
+    "Lineage": "XDV",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Recombinant lineage of XDE, JN.1, XDE, JN.1 (breakpoints between 19327-21608, 27916-28296, 28959-29534), USA/China, from #2402"
+  },
+  {
+    "Lineage": "XDV.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "S:F456L (T22930A), on C11572T branch, Hong Kong"
+  },
+  {
+    "Lineage": "XDV.1.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "S:S60P, T4579A, T9208G, China"
+  },
+  {
+    "Lineage": "XDV.1.2",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "S:R346T, N:I292T, ORF1a:L3116F, China"
+  },
+  {
+    "Lineage": "XDV.1.2.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "S:K462R, ORF1a:L3829F"
+  },
+  {
+    "Lineage": "XDV.1.3",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "S:T572I"
+  },
+  {
+    "Lineage": "XDV.1.4",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "S:I1114T"
+  },
+  {
+    "Lineage": "XDV.1.5",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "S:G184S, S:K478I, China"
+  },
+  {
+    "Lineage": "XDV.1.6",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "S:K478T, S:A263T, ORF1a:V1783I, ORF1a:E1209D"
+  },
+  {
+    "Lineage": "XDV.1.7",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "ORF1a:D2980N, C8950T, China"
+  },
+  {
+    "Lineage": "XDV.1.8",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "T2551C, T9892G"
+  },
+  {
+    "Lineage": "XDV.1.9",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "ORF1a:T2197I"
+  },
+  {
+    "Lineage": "XDV.1.10",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "ORF1a:T4175I, S:G181V, China-Hubei"
+  },
+  {
+    "Lineage": "XDV.1.11",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "T4057C"
+  },
+  {
+    "Lineage": "XDW",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Recombinant lineage of JN.2 (T1030C branch), XDA (breakpoint between 23424-23603), Japan, from sars-cov-2-variants/lineage-proposals#1471"
+  },
+  {
+    "Lineage": "XDY",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Recombinant lineage of LB.1.2.1 and KP.3.2 (breakpoint between 22131-22599), Sweden/Spain, from sars-cov-2-variants/lineage-proposals#1559"
+  },
+  {
+    "Lineage": "XDZ",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Recombinant lineage of JG.3 and JN.1.1.10 (breakpoint between 11043-12788), Europe/North America, from sars-cov-2-variants/lineage-proposals#1356"
+  },
+  {
+    "Lineage": "XEA",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Recombinant lineage of JN.1.63.1 and EG.5 (breakpoint between 27057-27915), East Asia"
+  },
+  {
+    "Lineage": "XEB",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Recombinant lineage of FL.15, JN.1.4+T18453C, FL.15 (breakpoints at 774-896 and 26834-27809), USA, from sars-cov-2-variants/lineage-proposals#1290"
+  },
+  {
+    "Lineage": "XEC",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Recombinant lineage of KS.1.1 (JN.1.13.1.1.1) and KP.3.3 (breakpoint 21738-22599), Europe (Germany), from #2717"
+  },
+  {
+    "Lineage": "XEC.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "S:K182R, ORF1a:L4182F, France/Ireland/Canada"
+  },
+  {
+    "Lineage": "XED",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Recombinant lineage of JN.1.4 and LF.1.1.1 (breakpoint 19210-21652), from #2691"
+  },
+  {
+    "Lineage": "XEE",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Recombinant lineage of KP.2.3.7 and JN.1* (breakpoint 24873-25592), from #2721"
+  },
+  {
+    "Lineage": "XEF",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Recombinant lineage of LB.1.4 and KP.3 (breakpoint 22600-23038), from sars-cov-2-variants/lineage-proposals#1855"
+  },
+  {
+    "Lineage": "XEG",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Recombinant lineage of JN.3.2.1, GJ.1.2, JN.3.2.1, GJ.1.2 (breakpoints: 2940-3430, 11043-12788, 28210-28957), from sars-cov-2-variants/lineage-proposals#1428"
+  },
+  {
+    "Lineage": "A.2.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Lineage with sequences predominantly from Panama"
+  },
+  {
+    "Lineage": "*A.2.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Lineage with sequences predominantly from Panama"
+  },
+  {
+    "Lineage": "A.8",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Indian lineage merged with A.9"
+  },
+  {
+    "Lineage": "*A.8",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Indian lineage merged with A.9"
+  },
+  {
+    "Lineage": "A.10",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Spanish lineage reassigned to A.5"
+  },
+  {
+    "Lineage": "*A.10",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Spanish lineage reassigned to A.5"
+  },
+  {
+    "Lineage": "A.13",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Cote d'Ivoire lineage"
+  },
+  {
+    "Lineage": "*A.13",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Cote d'Ivoire lineage"
+  },
+  {
+    "Lineage": "A.14",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Cote d'Ivoire lineage"
+  },
+  {
+    "Lineage": "*A.14",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Cote d'Ivoire lineage"
+  },
+  {
+    "Lineage": "A.20",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: UAE lineage"
+  },
+  {
+    "Lineage": "*A.20",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: UAE lineage"
+  },
+  {
+    "Lineage": "B.1.1.2",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: UK and Australia"
+  },
+  {
+    "Lineage": "*B.1.1.2",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: UK and Australia"
+  },
+  {
+    "Lineage": "B.1.1.6",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: USA (TX)"
+  },
+  {
+    "Lineage": "*B.1.1.6",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: USA (TX)"
+  },
+  {
+    "Lineage": "B.1.1.20",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: UK lineage"
+  },
+  {
+    "Lineage": "*B.1.1.20",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: UK lineage"
+  },
+  {
+    "Lineage": "B.1.1.32",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Indian lineage"
+  },
+  {
+    "Lineage": "*B.1.1.32",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Indian lineage"
+  },
+  {
+    "Lineage": "B.1.1.35",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: UK lineage"
+  },
+  {
+    "Lineage": "*B.1.1.35",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: UK lineage"
+  },
+  {
+    "Lineage": "B.1.1.36",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: USA"
+  },
+  {
+    "Lineage": "*B.1.1.36",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: USA"
+  },
+  {
+    "Lineage": "B.1.1.60",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Northern Ireland lineage"
+  },
+  {
+    "Lineage": "*B.1.1.60",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Northern Ireland lineage"
+  },
+  {
+    "Lineage": "B.1.1.64",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: UK lineage"
+  },
+  {
+    "Lineage": "*B.1.1.64",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: UK lineage"
+  },
+  {
+    "Lineage": "B.1.1.65",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: USA lineage"
+  },
+  {
+    "Lineage": "*B.1.1.65",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: USA lineage"
+  },
+  {
+    "Lineage": "B.1.1.66",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: South African lineage"
+  },
+  {
+    "Lineage": "*B.1.1.66",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: South African lineage"
+  },
+  {
+    "Lineage": "B.1.1.73",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Reassigned lineage"
+  },
+  {
+    "Lineage": "*B.1.1.73",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Reassigned lineage"
+  },
+  {
+    "Lineage": "B.1.1.76",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: USA lineage"
+  },
+  {
+    "Lineage": "*B.1.1.76",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: USA lineage"
+  },
+  {
+    "Lineage": "B.1.1.78",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Russian lineage"
+  },
+  {
+    "Lineage": "*B.1.1.78",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Russian lineage"
+  },
+  {
+    "Lineage": "B.1.1.79",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Russian lineage"
+  },
+  {
+    "Lineage": "*B.1.1.79",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Russian lineage"
+  },
+  {
+    "Lineage": "B.1.1.80",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Bangladesh lineage"
+  },
+  {
+    "Lineage": "*B.1.1.80",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Bangladesh lineage"
+  },
+  {
+    "Lineage": "B.1.1.81",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Northern Ireland lineage"
+  },
+  {
+    "Lineage": "*B.1.1.81",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Northern Ireland lineage"
+  },
+  {
+    "Lineage": "B.1.1.85",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: USA lineage"
+  },
+  {
+    "Lineage": "*B.1.1.85",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: USA lineage"
+  },
+  {
+    "Lineage": "B.1.1.94",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Brazil lineage"
+  },
+  {
+    "Lineage": "*B.1.1.94",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Brazil lineage"
+  },
+  {
+    "Lineage": "B.1.1.96",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Saudi Arabia/ Russia lineage"
+  },
+  {
+    "Lineage": "*B.1.1.96",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Saudi Arabia/ Russia lineage"
+  },
+  {
+    "Lineage": "B.1.1.102",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Latvian lineage"
+  },
+  {
+    "Lineage": "*B.1.1.102",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Latvian lineage"
+  },
+  {
+    "Lineage": "B.1.1.103",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Bangladesh lineage"
+  },
+  {
+    "Lineage": "*B.1.1.103",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Bangladesh lineage"
+  },
+  {
+    "Lineage": "B.1.1.104",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Netherlands/ Europe lineage"
+  },
+  {
+    "Lineage": "*B.1.1.104",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Netherlands/ Europe lineage"
+  },
+  {
+    "Lineage": "B.1.1.105",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Turkish lineage"
+  },
+  {
+    "Lineage": "*B.1.1.105",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Turkish lineage"
+  },
+  {
+    "Lineage": "B.1.1.106",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: UK lineage"
+  },
+  {
+    "Lineage": "*B.1.1.106",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: UK lineage"
+  },
+  {
+    "Lineage": "B.1.1.108",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: UK lineage"
+  },
+  {
+    "Lineage": "*B.1.1.108",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: UK lineage"
+  },
+  {
+    "Lineage": "B.1.1.124",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: UK/ Switzerland lineage"
+  },
+  {
+    "Lineage": "*B.1.1.124",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: UK/ Switzerland lineage"
+  },
+  {
+    "Lineage": "B.1.1.126",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: USA lineage"
+  },
+  {
+    "Lineage": "*B.1.1.126",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: USA lineage"
+  },
+  {
+    "Lineage": "B.1.1.131",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: UK lineage"
+  },
+  {
+    "Lineage": "*B.1.1.131",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: UK lineage"
+  },
+  {
+    "Lineage": "B.1.1.140",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Russian lineage"
+  },
+  {
+    "Lineage": "*B.1.1.140",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Russian lineage"
+  },
+  {
+    "Lineage": "B.1.1.143",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Brazilian lineage, merged into lineage B.1.1.28"
+  },
+  {
+    "Lineage": "*B.1.1.143",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Brazilian lineage, merged into lineage B.1.1.28"
+  },
+  {
+    "Lineage": "B.1.1.146",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: UK lineage"
+  },
+  {
+    "Lineage": "*B.1.1.146",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: UK lineage"
+  },
+  {
+    "Lineage": "B.1.1.150",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: UK lineage"
+  },
+  {
+    "Lineage": "*B.1.1.150",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: UK lineage"
+  },
+  {
+    "Lineage": "B.1.1.151",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: UK lineage"
+  },
+  {
+    "Lineage": "*B.1.1.151",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: UK lineage"
+  },
+  {
+    "Lineage": "B.1.1.156",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: South African lineage"
+  },
+  {
+    "Lineage": "*B.1.1.156",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: South African lineage"
+  },
+  {
+    "Lineage": "B.1.1.167",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Denmark/ E European lineage"
+  },
+  {
+    "Lineage": "*B.1.1.167",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Denmark/ E European lineage"
+  },
+  {
+    "Lineage": "B.1.1.173",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: UK lineage"
+  },
+  {
+    "Lineage": "*B.1.1.173",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: UK lineage"
+  },
+  {
+    "Lineage": "B.1.1.179",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Indian (split from B.1.1.32)"
+  },
+  {
+    "Lineage": "*B.1.1.179",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Indian (split from B.1.1.32)"
+  },
+  {
+    "Lineage": "B.1.1.183",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: South Korea"
+  },
+  {
+    "Lineage": "*B.1.1.183",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: South Korea"
+  },
+  {
+    "Lineage": "B.1.1.195",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: UK lineage"
+  },
+  {
+    "Lineage": "*B.1.1.195",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: UK lineage"
+  },
+  {
+    "Lineage": "B.1.1.199",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: UK (split from B.1.1.64)"
+  },
+  {
+    "Lineage": "*B.1.1.199",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: UK (split from B.1.1.64)"
+  },
+  {
+    "Lineage": "B.1.1.206",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: South Africa (mostly from B.1.1.54)"
+  },
+  {
+    "Lineage": "*B.1.1.206",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: South Africa (mostly from B.1.1.54)"
+  },
+  {
+    "Lineage": "B.1.1.211",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: French, swiss, UK, Belgian"
+  },
+  {
+    "Lineage": "*B.1.1.211",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: French, swiss, UK, Belgian"
+  },
+  {
+    "Lineage": "B.1.1.212",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Indian (split from B.1.1.32)"
+  },
+  {
+    "Lineage": "*B.1.1.212",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Indian (split from B.1.1.32)"
+  },
+  {
+    "Lineage": "B.1.1.215",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: England with a spanish base"
+  },
+  {
+    "Lineage": "*B.1.1.215",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: England with a spanish base"
+  },
+  {
+    "Lineage": "B.1.1.223",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: USA, NZ, England, one Russia"
+  },
+  {
+    "Lineage": "*B.1.1.223",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: USA, NZ, England, one Russia"
+  },
+  {
+    "Lineage": "B.1.1.233",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: USA (WA)"
+  },
+  {
+    "Lineage": "*B.1.1.233",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: USA (WA)"
+  },
+  {
+    "Lineage": "B.1.1.235",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: merged with B.1.1.115"
+  },
+  {
+    "Lineage": "*B.1.1.235",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: merged with B.1.1.115"
+  },
+  {
+    "Lineage": "B.1.1.238",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: UK and New Zealand (split from B.1.1.7)"
+  },
+  {
+    "Lineage": "*B.1.1.238",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: UK and New Zealand (split from B.1.1.7)"
+  },
+  {
+    "Lineage": "B.1.1.245",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Northern Ireland lineage, previously B.1.1.60 (split)"
+  },
+  {
+    "Lineage": "*B.1.1.245",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Northern Ireland lineage, previously B.1.1.60 (split)"
+  },
+  {
+    "Lineage": "B.1.1.246",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Russia"
+  },
+  {
+    "Lineage": "*B.1.1.246",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Russia"
+  },
+  {
+    "Lineage": "B.1.1.247",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Northern Europe (UK, NL, Switzerland) and Northern Africa (Egypt and Morocco), Gambia (some B.1.1.55)"
+  },
+  {
+    "Lineage": "*B.1.1.247",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Northern Europe (UK, NL, Switzerland) and Northern Africa (Egypt and Morocco), Gambia (some B.1.1.55)"
+  },
+  {
+    "Lineage": "B.1.1.248",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Brazilian lineage reassigned B.1.1.28"
+  },
+  {
+    "Lineage": "*B.1.1.248",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Brazilian lineage reassigned B.1.1.28"
+  },
+  {
+    "Lineage": "B.1.1.250",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: UK lineage"
+  },
+  {
+    "Lineage": "*B.1.1.250",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: UK lineage"
+  },
+  {
+    "Lineage": "B.1.1.252",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: South Africa (formerly B.1.1.66)"
+  },
+  {
+    "Lineage": "*B.1.1.252",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: South Africa (formerly B.1.1.66)"
+  },
+  {
+    "Lineage": "B.1.1.259",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: UK (split from B.1.1.64)"
+  },
+  {
+    "Lineage": "*B.1.1.259",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: UK (split from B.1.1.64)"
+  },
+  {
+    "Lineage": "B.1.1.260",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: UK (split from B.1.1.64)"
+  },
+  {
+    "Lineage": "*B.1.1.260",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: UK (split from B.1.1.64)"
+  },
+  {
+    "Lineage": "B.1.1.264",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Wales lineage, previously part of B.1.1.30"
+  },
+  {
+    "Lineage": "*B.1.1.264",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Wales lineage, previously part of B.1.1.30"
+  },
+  {
+    "Lineage": "B.1.1.276",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Previously part of B.1.1.55, USA lineage"
+  },
+  {
+    "Lineage": "*B.1.1.276",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Previously part of B.1.1.55, USA lineage"
+  },
+  {
+    "Lineage": "B.1.1.278",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: UK lineage"
+  },
+  {
+    "Lineage": "*B.1.1.278",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: UK lineage"
+  },
+  {
+    "Lineage": "B.1.1.281",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Indian lineage, previously part of B.1.1.32"
+  },
+  {
+    "Lineage": "*B.1.1.281",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Indian lineage, previously part of B.1.1.32"
+  },
+  {
+    "Lineage": "B.1.1.287",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: USA lineage"
+  },
+  {
+    "Lineage": "*B.1.1.287",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: USA lineage"
+  },
+  {
+    "Lineage": "B.1.1.292",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: UK lineage"
+  },
+  {
+    "Lineage": "*B.1.1.292",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: UK lineage"
+  },
+  {
+    "Lineage": "B.1.1.293",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Gambian lineage"
+  },
+  {
+    "Lineage": "*B.1.1.293",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Gambian lineage"
+  },
+  {
+    "Lineage": "B.1.1.295",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: UK/Australia lineage"
+  },
+  {
+    "Lineage": "*B.1.1.295",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: UK/Australia lineage"
+  },
+  {
+    "Lineage": "B.1.1.313",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: English lineage"
+  },
+  {
+    "Lineage": "*B.1.1.313",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: English lineage"
+  },
+  {
+    "Lineage": "B.1.1.314",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Brazilian lineage, previously part of B.1.1.33"
+  },
+  {
+    "Lineage": "*B.1.1.314",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Brazilian lineage, previously part of B.1.1.33"
+  },
+  {
+    "Lineage": "B.1.1.439",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Wales lineage, reassigned to B.1.1.29"
+  },
+  {
+    "Lineage": "*B.1.1.439",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Wales lineage, reassigned to B.1.1.29"
+  },
+  {
+    "Lineage": "B.1.1.527",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Lineage in multiple countries, reassigned to C.38, from #150"
+  },
+  {
+    "Lineage": "*B.1.1.527",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Lineage in multiple countries, reassigned to C.38, from #150"
+  },
+  {
+    "Lineage": "BA.1.11",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Does not have a reliable defining mutation"
+  },
+  {
+    "Lineage": "*BA.1.11",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Does not have a reliable defining mutation"
+  },
+  {
+    "Lineage": "BA.2.3.3",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Does not have a reliable defining mutation, from #524"
+  },
+  {
+    "Lineage": "*BA.2.3.3",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Does not have a reliable defining mutation, from #524"
+  },
+  {
+    "Lineage": "BA.2.36.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Redesignated as BA.2.82"
+  },
+  {
+    "Lineage": "*BA.2.36.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Redesignated as BA.2.82"
+  },
+  {
+    "Lineage": "BA.2.84",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Redesignated as BA.2.31.1"
+  },
+  {
+    "Lineage": "*BA.2.84",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Redesignated as BA.2.31.1"
+  },
+  {
+    "Lineage": "BA.5.1.13",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Defined solely by Artic v3 artefacts, from #1029"
+  },
+  {
+    "Lineage": "*BA.5.1.13",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Defined solely by Artic v3 artefacts, from #1029"
+  },
+  {
+    "Lineage": "BF.7.25",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Invisible to pangolin as positions C29708T is part of masked regions 1-255 and 29674-29903. Alias of B.1.1.529.5.2.1.7.25, C29708T"
+  },
+  {
+    "Lineage": "*BF.7.25",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Invisible to pangolin as positions C29708T is part of masked regions 1-255 and 29674-29903. Alias of B.1.1.529.5.2.1.7.25, C29708T"
+  },
+  {
+    "Lineage": "BA.5.2.15",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Redesignated as CF.1, being a child of BA.5.2.27, B.1.1.529.5.2.15, found in USA and Mexico, from #1054"
+  },
+  {
+    "Lineage": "*BA.5.2.15",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Redesignated as CF.1, being a child of BA.5.2.27, B.1.1.529.5.2.15, found in USA and Mexico, from #1054"
+  },
+  {
+    "Lineage": "BA.5.2.17",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Redesignated as BV.1, being a child of BA.5.2.20"
+  },
+  {
+    "Lineage": "*BA.5.2.17",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Redesignated as BV.1, being a child of BA.5.2.20"
+  },
+  {
+    "Lineage": "BQ.1.1.33",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Alias of B.1.1.529.5.3.1.1.1.1.1.1.33, USA lineage, child of BQ.1.1.3"
+  },
+  {
+    "Lineage": "*BQ.1.1.33",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Alias of B.1.1.529.5.3.1.1.1.1.1.1.33, USA lineage, child of BQ.1.1.3"
+  },
+  {
+    "Lineage": "BA.5.4",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: England, Denmark, Spain and Scotland. Sublineage of BA.5.2.1 (with G11837T (ORF1a:V3858L) (nsp6:V289L)), from #618"
+  },
+  {
+    "Lineage": "*BA.5.4",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: England, Denmark, Spain and Scotland. Sublineage of BA.5.2.1 (with G11837T (ORF1a:V3858L) (nsp6:V289L)), from #618"
+  },
+  {
+    "Lineage": "B.1.3.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: South Korean lineage"
+  },
+  {
+    "Lineage": "*B.1.3.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: South Korean lineage"
+  },
+  {
+    "Lineage": "B.1.3.2",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Argentinian lineage"
+  },
+  {
+    "Lineage": "*B.1.3.2",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Argentinian lineage"
+  },
+  {
+    "Lineage": "B.1.3.3",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Israel lineage"
+  },
+  {
+    "Lineage": "*B.1.3.3",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Israel lineage"
+  },
+  {
+    "Lineage": "B.1.3.4",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Israel/ UK lineage"
+  },
+  {
+    "Lineage": "*B.1.3.4",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Israel/ UK lineage"
+  },
+  {
+    "Lineage": "B.1.5",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Reassigned to B.1 and additional sublineages as this lineage has lost monophyletic status and split into multiple parts of the B.1 tree. Previously had a Spanish base, European lineage/ lots of Spanish sequences towards the basal end of the subtree and exports around the globe."
+  },
+  {
+    "Lineage": "*B.1.5",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Reassigned to B.1 and additional sublineages as this lineage has lost monophyletic status and split into multiple parts of the B.1 tree. Previously had a Spanish base, European lineage/ lots of Spanish sequences towards the basal end of the subtree and exports around the globe."
+  },
+  {
+    "Lineage": "B.1.5.2",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Reassigned B.1.190, Netherlands lineage"
+  },
+  {
+    "Lineage": "*B.1.5.2",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Reassigned B.1.190, Netherlands lineage"
+  },
+  {
+    "Lineage": "B.1.5.5",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Reassigned B.1.225"
+  },
+  {
+    "Lineage": "*B.1.5.5",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Reassigned B.1.225"
+  },
+  {
+    "Lineage": "B.1.5.6",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: UK lineage reassigned B.1.223"
+  },
+  {
+    "Lineage": "*B.1.5.6",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: UK lineage reassigned B.1.223"
+  },
+  {
+    "Lineage": "B.1.5.11",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Reassigned B.1.189, USA/ Mexico lineage"
+  },
+  {
+    "Lineage": "*B.1.5.11",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Reassigned B.1.189, USA/ Mexico lineage"
+  },
+  {
+    "Lineage": "B.1.5.12",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Reassigned to B.1.416, Senegal/ Gambia lineage"
+  },
+  {
+    "Lineage": "*B.1.5.12",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Reassigned to B.1.416, Senegal/ Gambia lineage"
+  },
+  {
+    "Lineage": "B.1.5.13",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Reassigned B.1.180, Romanian lineage"
+  },
+  {
+    "Lineage": "*B.1.5.13",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Reassigned B.1.180, Romanian lineage"
+  },
+  {
+    "Lineage": "B.1.5.15",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Reassigned B.1.185, USA lineage"
+  },
+  {
+    "Lineage": "*B.1.5.15",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Reassigned B.1.185, USA lineage"
+  },
+  {
+    "Lineage": "B.1.5.17",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Reassigned B.1.181, USA lineage"
+  },
+  {
+    "Lineage": "*B.1.5.17",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Reassigned B.1.181, USA lineage"
+  },
+  {
+    "Lineage": "B.1.5.16",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: South African lineage, reassigned to B.1.237"
+  },
+  {
+    "Lineage": "*B.1.5.16",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: South African lineage, reassigned to B.1.237"
+  },
+  {
+    "Lineage": "B.1.5.18",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Reassigned B.1.256"
+  },
+  {
+    "Lineage": "*B.1.5.18",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Reassigned B.1.256"
+  },
+  {
+    "Lineage": "B.1.5.19",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: South African lineage reassigned to B.1.381"
+  },
+  {
+    "Lineage": "*B.1.5.19",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: South African lineage reassigned to B.1.381"
+  },
+  {
+    "Lineage": "B.1.5.21",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Reassigned B.1.418, Scottish lineage"
+  },
+  {
+    "Lineage": "*B.1.5.21",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Reassigned B.1.418, Scottish lineage"
+  },
+  {
+    "Lineage": "B.1.5.25",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Reassigned B.1.229"
+  },
+  {
+    "Lineage": "*B.1.5.25",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Reassigned B.1.229"
+  },
+  {
+    "Lineage": "B.1.5.26",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Reassigned B.1.232"
+  },
+  {
+    "Lineage": "*B.1.5.26",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Reassigned B.1.232"
+  },
+  {
+    "Lineage": "B.1.5.27",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: USA lineage (CA), reassigned to B.1.243"
+  },
+  {
+    "Lineage": "*B.1.5.27",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: USA lineage (CA), reassigned to B.1.243"
+  },
+  {
+    "Lineage": "B.1.5.28",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Reassigned B.1.231"
+  },
+  {
+    "Lineage": "*B.1.5.28",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Reassigned B.1.231"
+  },
+  {
+    "Lineage": "B.1.5.29",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: USA lineage (WI/ IL) reassigned to B.1.415"
+  },
+  {
+    "Lineage": "*B.1.5.29",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: USA lineage (WI/ IL) reassigned to B.1.415"
+  },
+  {
+    "Lineage": "B.1.5.30",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: UK lineage"
+  },
+  {
+    "Lineage": "*B.1.5.30",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: UK lineage"
+  },
+  {
+    "Lineage": "B.1.5.31",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: South African lineage, reassigned B.1.417"
+  },
+  {
+    "Lineage": "*B.1.5.31",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: South African lineage, reassigned B.1.417"
+  },
+  {
+    "Lineage": "B.1.5.32",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Colombian lineage, reassigned B.1.420"
+  },
+  {
+    "Lineage": "*B.1.5.32",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Colombian lineage, reassigned B.1.420"
+  },
+  {
+    "Lineage": "B.1.5.33",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Split up in current tree, reassigned to B.1. UK lineage"
+  },
+  {
+    "Lineage": "*B.1.5.33",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Split up in current tree, reassigned to B.1. UK lineage"
+  },
+  {
+    "Lineage": "B.1.5.34",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Reassigned to B.1.222, reassigned Scottish lineage"
+  },
+  {
+    "Lineage": "*B.1.5.34",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Reassigned to B.1.222, reassigned Scottish lineage"
+  },
+  {
+    "Lineage": "B.1.5.35",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Indian lineage reassigned B.1, lacks any structure in current tree"
+  },
+  {
+    "Lineage": "*B.1.5.35",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Indian lineage reassigned B.1, lacks any structure in current tree"
+  },
+  {
+    "Lineage": "B.1.5.36",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Indian lineage reassigned to B.1.136"
+  },
+  {
+    "Lineage": "*B.1.5.36",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Indian lineage reassigned to B.1.136"
+  },
+  {
+    "Lineage": "B.1.8.2",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Reassigned in the current tree. USA lineage (CA)"
+  },
+  {
+    "Lineage": "*B.1.8.2",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Reassigned in the current tree. USA lineage (CA)"
+  },
+  {
+    "Lineage": "B.1.9.6",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: North Macedonia, Switzerland"
+  },
+  {
+    "Lineage": "*B.1.9.6",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: North Macedonia, Switzerland"
+  },
+  {
+    "Lineage": "B.1.11",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: UK lineage, reassigned B.1- broken up in current tree"
+  },
+  {
+    "Lineage": "*B.1.11",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: UK lineage, reassigned B.1- broken up in current tree"
+  },
+  {
+    "Lineage": "B.1.19",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: USA lineage (WI), reassigned B.1- broken up in current tree"
+  },
+  {
+    "Lineage": "*B.1.19",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: USA lineage (WI), reassigned B.1- broken up in current tree"
+  },
+  {
+    "Lineage": "B.1.21",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Split up Washington (USA), reassigned mostly to B.1.371"
+  },
+  {
+    "Lineage": "*B.1.21",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Split up Washington (USA), reassigned mostly to B.1.371"
+  },
+  {
+    "Lineage": "B.1.25",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Australian lineage"
+  },
+  {
+    "Lineage": "*B.1.25",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Australian lineage"
+  },
+  {
+    "Lineage": "B.1.26",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: USA/Gambia lineage"
+  },
+  {
+    "Lineage": "*B.1.26",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: USA/Gambia lineage"
+  },
+  {
+    "Lineage": "B.1.34",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: English lineage, reassigned B.1"
+  },
+  {
+    "Lineage": "*B.1.34",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: English lineage, reassigned B.1"
+  },
+  {
+    "Lineage": "B.1.36.3",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Danish lineage"
+  },
+  {
+    "Lineage": "*B.1.36.3",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Danish lineage"
+  },
+  {
+    "Lineage": "B.1.36.4",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Netherlands lineage"
+  },
+  {
+    "Lineage": "*B.1.36.4",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Netherlands lineage"
+  },
+  {
+    "Lineage": "B.1.36.5",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Saudi Arabia lineage, reassigned to parent lineage B.1.36"
+  },
+  {
+    "Lineage": "*B.1.36.5",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Saudi Arabia lineage, reassigned to parent lineage B.1.36"
+  },
+  {
+    "Lineage": "B.1.36.6",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Norway lineage"
+  },
+  {
+    "Lineage": "*B.1.36.6",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Norway lineage"
+  },
+  {
+    "Lineage": "B.1.36.11",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Netherlands lineage"
+  },
+  {
+    "Lineage": "*B.1.36.11",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Netherlands lineage"
+  },
+  {
+    "Lineage": "B.1.36.13",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Irish lineage"
+  },
+  {
+    "Lineage": "*B.1.36.13",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Irish lineage"
+  },
+  {
+    "Lineage": "B.1.36.14",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Danish lineage"
+  },
+  {
+    "Lineage": "*B.1.36.14",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Danish lineage"
+  },
+  {
+    "Lineage": "B.1.36.15",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Saudi Arabia lineage"
+  },
+  {
+    "Lineage": "*B.1.36.15",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Saudi Arabia lineage"
+  },
+  {
+    "Lineage": "B.1.74",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Spanish lineage"
+  },
+  {
+    "Lineage": "*B.1.74",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Spanish lineage"
+  },
+  {
+    "Lineage": "B.1.75",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Reassigned in the current tree. English lineage"
+  },
+  {
+    "Lineage": "*B.1.75",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Reassigned in the current tree. English lineage"
+  },
+  {
+    "Lineage": "B.1.79",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: UK lineage, some now reassigned to B.1.5"
+  },
+  {
+    "Lineage": "*B.1.79",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: UK lineage, some now reassigned to B.1.5"
+  },
+  {
+    "Lineage": "B.1.80",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Reassigned in the current tree. Indian lineage"
+  },
+  {
+    "Lineage": "*B.1.80",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Reassigned in the current tree. Indian lineage"
+  },
+  {
+    "Lineage": "B.1.82",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Reassigned in the current tree. UK lineage"
+  },
+  {
+    "Lineage": "*B.1.82",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Reassigned in the current tree. UK lineage"
+  },
+  {
+    "Lineage": "B.1.88",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Scottish lineage"
+  },
+  {
+    "Lineage": "*B.1.88",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Scottish lineage"
+  },
+  {
+    "Lineage": "B.1.89",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Reassigned in the current tree. UK lineage"
+  },
+  {
+    "Lineage": "*B.1.89",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Reassigned in the current tree. UK lineage"
+  },
+  {
+    "Lineage": "B.1.90",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Reassigned in the current tree. Scottish lineage"
+  },
+  {
+    "Lineage": "*B.1.90",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Reassigned in the current tree. Scottish lineage"
+  },
+  {
+    "Lineage": "B.1.95",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Indian lineage"
+  },
+  {
+    "Lineage": "*B.1.95",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Indian lineage"
+  },
+  {
+    "Lineage": "B.1.98",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: UK lineage"
+  },
+  {
+    "Lineage": "*B.1.98",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: UK lineage"
+  },
+  {
+    "Lineage": "B.1.102",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Reassigned in the current tree. Iceland lineage"
+  },
+  {
+    "Lineage": "*B.1.102",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Reassigned in the current tree. Iceland lineage"
+  },
+  {
+    "Lineage": "B.1.107",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Reassigned in the current tree. Danish lineage, with USA and UK sequences"
+  },
+  {
+    "Lineage": "*B.1.107",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Reassigned in the current tree. Danish lineage, with USA and UK sequences"
+  },
+  {
+    "Lineage": "B.1.109",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Luxembourg lineage"
+  },
+  {
+    "Lineage": "*B.1.109",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Luxembourg lineage"
+  },
+  {
+    "Lineage": "B.1.114",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Reassigned in the current tree. Canadian lineage"
+  },
+  {
+    "Lineage": "*B.1.114",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Reassigned in the current tree. Canadian lineage"
+  },
+  {
+    "Lineage": "B.1.133",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Reassigned in the current tree. USA lineage (WA)"
+  },
+  {
+    "Lineage": "*B.1.133",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Reassigned in the current tree. USA lineage (WA)"
+  },
+  {
+    "Lineage": "B.1.135",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Reassigned in the current tree. Small Portuguese lineage"
+  },
+  {
+    "Lineage": "*B.1.135",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Reassigned in the current tree. Small Portuguese lineage"
+  },
+  {
+    "Lineage": "B.1.136",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Reassigned in the current tree. Indian lineage, split up and reassigned to B.1"
+  },
+  {
+    "Lineage": "*B.1.136",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Reassigned in the current tree. Indian lineage, split up and reassigned to B.1"
+  },
+  {
+    "Lineage": "B.1.138",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Reassigned in the current tree. Small Australian lineage"
+  },
+  {
+    "Lineage": "*B.1.138",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Reassigned in the current tree. Small Australian lineage"
+  },
+  {
+    "Lineage": "B.1.141",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Reassigned in the current tree. Scottish lineage, first wave of N439K"
+  },
+  {
+    "Lineage": "*B.1.141",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Reassigned in the current tree. Scottish lineage, first wave of N439K"
+  },
+  {
+    "Lineage": "B.1.144",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: South African lineage"
+  },
+  {
+    "Lineage": "*B.1.144",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: South African lineage"
+  },
+  {
+    "Lineage": "B.1.150",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Reassigned lineage"
+  },
+  {
+    "Lineage": "*B.1.150",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Reassigned lineage"
+  },
+  {
+    "Lineage": "B.1.152",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: English lineage"
+  },
+  {
+    "Lineage": "*B.1.152",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: English lineage"
+  },
+  {
+    "Lineage": "B.1.154",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Reassigned in the current tree. USA lineage"
+  },
+  {
+    "Lineage": "*B.1.154",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Reassigned in the current tree. USA lineage"
+  },
+  {
+    "Lineage": "B.1.156",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Reassigned in the current tree. Scottish lineage"
+  },
+  {
+    "Lineage": "*B.1.156",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Reassigned in the current tree. Scottish lineage"
+  },
+  {
+    "Lineage": "B.1.160.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Reassigned B.1.523 English lineage"
+  },
+  {
+    "Lineage": "*B.1.160.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Reassigned B.1.523 English lineage"
+  },
+  {
+    "Lineage": "B.1.160.2",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Reassigned B.1.523 English lineage"
+  },
+  {
+    "Lineage": "*B.1.160.2",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Reassigned B.1.523 English lineage"
+  },
+  {
+    "Lineage": "B.1.160.3",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Indonesian lineage (now B.1.470)"
+  },
+  {
+    "Lineage": "*B.1.160.3",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Indonesian lineage (now B.1.470)"
+  },
+  {
+    "Lineage": "B.1.160.4",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: English lineage (now B.1.471)"
+  },
+  {
+    "Lineage": "*B.1.160.4",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: English lineage (now B.1.471)"
+  },
+  {
+    "Lineage": "B.1.160.5",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Danish lineage"
+  },
+  {
+    "Lineage": "*B.1.160.5",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Danish lineage"
+  },
+  {
+    "Lineage": "B.1.160.6",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Danish lineage, reassigned B.1.160 lack of resolution in current tree"
+  },
+  {
+    "Lineage": "*B.1.160.6",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Danish lineage, reassigned B.1.160 lack of resolution in current tree"
+  },
+  {
+    "Lineage": "B.1.177.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Denmark"
+  },
+  {
+    "Lineage": "*B.1.177.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Denmark"
+  },
+  {
+    "Lineage": "B.1.177.13",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: now part of B.1.177.17"
+  },
+  {
+    "Lineage": "*B.1.177.13",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: now part of B.1.177.17"
+  },
+  {
+    "Lineage": "B.1.177.22",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: UK lineage"
+  },
+  {
+    "Lineage": "*B.1.177.22",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: UK lineage"
+  },
+  {
+    "Lineage": "B.1.177.79",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Latvian lineage. Did not have a defining mutation within the coding region. Therefore merged into B.1.177.60"
+  },
+  {
+    "Lineage": "*B.1.177.79",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Latvian lineage. Did not have a defining mutation within the coding region. Therefore merged into B.1.177.60"
+  },
+  {
+    "Lineage": "B.1.183",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Reassigned in the current tree. Canadian lineage"
+  },
+  {
+    "Lineage": "*B.1.183",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Reassigned in the current tree. Canadian lineage"
+  },
+  {
+    "Lineage": "B.1.185",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Reassigned in the current tree. USA lineage (previously B.1.5.15)"
+  },
+  {
+    "Lineage": "*B.1.185",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Reassigned in the current tree. USA lineage (previously B.1.5.15)"
+  },
+  {
+    "Lineage": "B.1.186",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Saudi-arabian/ Indian lineage (now B.1.260)"
+  },
+  {
+    "Lineage": "*B.1.186",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Saudi-arabian/ Indian lineage (now B.1.260)"
+  },
+  {
+    "Lineage": "B.1.191",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Reassigned in the current tree. Previously B.1.5.21, Scottish lineage"
+  },
+  {
+    "Lineage": "*B.1.191",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Reassigned in the current tree. Previously B.1.5.21, Scottish lineage"
+  },
+  {
+    "Lineage": "B.1.193",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Reassigned in the current tree. USA lineage"
+  },
+  {
+    "Lineage": "*B.1.193",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Reassigned in the current tree. USA lineage"
+  },
+  {
+    "Lineage": "B.1.196",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: USA lineage"
+  },
+  {
+    "Lineage": "*B.1.196",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: USA lineage"
+  },
+  {
+    "Lineage": "B.1.197",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Australian/ New Zealand lineage"
+  },
+  {
+    "Lineage": "*B.1.197",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Australian/ New Zealand lineage"
+  },
+  {
+    "Lineage": "B.1.200",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Reassigned in the current tree. Previously part of B.1.98, reassigned UK lineage"
+  },
+  {
+    "Lineage": "*B.1.200",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Reassigned in the current tree. Previously part of B.1.98, reassigned UK lineage"
+  },
+  {
+    "Lineage": "B.1.202",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Reassigned in the current tree. USA lineage"
+  },
+  {
+    "Lineage": "*B.1.202",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Reassigned in the current tree. USA lineage"
+  },
+  {
+    "Lineage": "B.1.204",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Reassigned in the current tree. USA lineage"
+  },
+  {
+    "Lineage": "*B.1.204",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Reassigned in the current tree. USA lineage"
+  },
+  {
+    "Lineage": "B.1.207",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: USA lineage (TX)"
+  },
+  {
+    "Lineage": "*B.1.207",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: USA lineage (TX)"
+  },
+  {
+    "Lineage": "B.1.209",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Small Scottish lineage"
+  },
+  {
+    "Lineage": "*B.1.209",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Small Scottish lineage"
+  },
+  {
+    "Lineage": "B.1.216",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: USA lineage"
+  },
+  {
+    "Lineage": "*B.1.216",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: USA lineage"
+  },
+  {
+    "Lineage": "B.1.217",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Reassigned in the current tree. Indian lineage Reassigned from B.1.80, split this assignment"
+  },
+  {
+    "Lineage": "*B.1.217",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Reassigned in the current tree. Indian lineage Reassigned from B.1.80, split this assignment"
+  },
+  {
+    "Lineage": "B.1.226",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Reassigned in the current tree. Equatorial Guinea lineage"
+  },
+  {
+    "Lineage": "*B.1.226",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Reassigned in the current tree. Equatorial Guinea lineage"
+  },
+  {
+    "Lineage": "B.1.228",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Reassigned in the current tree. USA lineage, reassigned from B.1.5.27 split"
+  },
+  {
+    "Lineage": "*B.1.228",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Reassigned in the current tree. USA lineage, reassigned from B.1.5.27 split"
+  },
+  {
+    "Lineage": "B.1.230",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Reassigned in the current tree. USA lineage, reassigned from B.1.5.27 split"
+  },
+  {
+    "Lineage": "*B.1.230",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Reassigned in the current tree. USA lineage, reassigned from B.1.5.27 split"
+  },
+  {
+    "Lineage": "B.1.244",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Reassigned in the current tree. Saudi Arabian lineage that previously was part of B.1.160"
+  },
+  {
+    "Lineage": "*B.1.244",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Reassigned in the current tree. Saudi Arabian lineage that previously was part of B.1.160"
+  },
+  {
+    "Lineage": "B.1.246",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Reassigned in the current tree. Saudi Arabian lineage, previously some assigned B.1.160"
+  },
+  {
+    "Lineage": "*B.1.246",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Reassigned in the current tree. Saudi Arabian lineage, previously some assigned B.1.160"
+  },
+  {
+    "Lineage": "B.1.253",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Reassigned in the current tree. UK lineage"
+  },
+  {
+    "Lineage": "*B.1.253",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Reassigned in the current tree. UK lineage"
+  },
+  {
+    "Lineage": "B.1.255",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: North American lineage, with other global diversity (Now all over tree)"
+  },
+  {
+    "Lineage": "*B.1.255",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: North American lineage, with other global diversity (Now all over tree)"
+  },
+  {
+    "Lineage": "B.1.257",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Reassigned in the current tree. UK lineage"
+  },
+  {
+    "Lineage": "*B.1.257",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Reassigned in the current tree. UK lineage"
+  },
+  {
+    "Lineage": "B.1.258.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: French lineage"
+  },
+  {
+    "Lineage": "*B.1.258.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: French lineage"
+  },
+  {
+    "Lineage": "B.1.258.8",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Danish lineage"
+  },
+  {
+    "Lineage": "*B.1.258.8",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Danish lineage"
+  },
+  {
+    "Lineage": "B.1.258.13",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Reassigned in the current tree. Danish lineage"
+  },
+  {
+    "Lineage": "*B.1.258.13",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Reassigned in the current tree. Danish lineage"
+  },
+  {
+    "Lineage": "B.1.259",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Saudi Arabia/ India lineage (now in B.1.260)"
+  },
+  {
+    "Lineage": "*B.1.259",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Saudi Arabia/ India lineage (now in B.1.260)"
+  },
+  {
+    "Lineage": "B.1.261",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Saudi Arabian lineage (now in B.1.260)"
+  },
+  {
+    "Lineage": "*B.1.261",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Saudi Arabian lineage (now in B.1.260)"
+  },
+  {
+    "Lineage": "B.1.262",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Reassigned in the current tree. Danish lineage"
+  },
+  {
+    "Lineage": "*B.1.262",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Reassigned in the current tree. Danish lineage"
+  },
+  {
+    "Lineage": "B.1.266",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Reassigned in the current tree. Austrian lineage"
+  },
+  {
+    "Lineage": "*B.1.266",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Reassigned in the current tree. Austrian lineage"
+  },
+  {
+    "Lineage": "B.1.269",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Reassigned in the current tree. Slovenian lineage"
+  },
+  {
+    "Lineage": "*B.1.269",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Reassigned in the current tree. Slovenian lineage"
+  },
+  {
+    "Lineage": "B.1.271",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Reassigned in the current tree. USA lineage"
+  },
+  {
+    "Lineage": "*B.1.271",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Reassigned in the current tree. USA lineage"
+  },
+  {
+    "Lineage": "B.1.272",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Reassigned in the current tree. France/ Australian lineage"
+  },
+  {
+    "Lineage": "*B.1.272",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Reassigned in the current tree. France/ Australian lineage"
+  },
+  {
+    "Lineage": "B.1.275",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: France lineage"
+  },
+  {
+    "Lineage": "*B.1.275",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: France lineage"
+  },
+  {
+    "Lineage": "B.1.278",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Reassigned in the current tree. UK/ Australia lineage, previously part of B.1.13"
+  },
+  {
+    "Lineage": "*B.1.278",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Reassigned in the current tree. UK/ Australia lineage, previously part of B.1.13"
+  },
+  {
+    "Lineage": "B.1.283",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: USA lineage"
+  },
+  {
+    "Lineage": "*B.1.283",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: USA lineage"
+  },
+  {
+    "Lineage": "B.1.286",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Reassigned in the current tree. USA lineage"
+  },
+  {
+    "Lineage": "*B.1.286",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Reassigned in the current tree. USA lineage"
+  },
+  {
+    "Lineage": "B.1.288",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Reassigned in the current tree. Denmark lineage"
+  },
+  {
+    "Lineage": "*B.1.288",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Reassigned in the current tree. Denmark lineage"
+  },
+  {
+    "Lineage": "B.1.290",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Reassigned in the current tree. USA lineage"
+  },
+  {
+    "Lineage": "*B.1.290",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Reassigned in the current tree. USA lineage"
+  },
+  {
+    "Lineage": "B.1.295",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Reassigned in the current tree. Australian lineage"
+  },
+  {
+    "Lineage": "*B.1.295",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Reassigned in the current tree. Australian lineage"
+  },
+  {
+    "Lineage": "B.1.296",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Reassigned in the current tree. USA/ Australian lineage"
+  },
+  {
+    "Lineage": "*B.1.296",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Reassigned in the current tree. USA/ Australian lineage"
+  },
+  {
+    "Lineage": "B.1.297",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Reassigned in the current tree. USA lineage"
+  },
+  {
+    "Lineage": "*B.1.297",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Reassigned in the current tree. USA lineage"
+  },
+  {
+    "Lineage": "B.1.297.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Reassigned in the current tree. Canadian lineage"
+  },
+  {
+    "Lineage": "*B.1.297.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Reassigned in the current tree. Canadian lineage"
+  },
+  {
+    "Lineage": "B.1.299",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Reassigned in the current tree. USA lineage"
+  },
+  {
+    "Lineage": "*B.1.299",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Reassigned in the current tree. USA lineage"
+  },
+  {
+    "Lineage": "B.1.300",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Reassigned in the current tree. USA lineage"
+  },
+  {
+    "Lineage": "*B.1.300",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Reassigned in the current tree. USA lineage"
+  },
+  {
+    "Lineage": "B.1.303",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Reassigned in the current tree. USA lineage"
+  },
+  {
+    "Lineage": "*B.1.303",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Reassigned in the current tree. USA lineage"
+  },
+  {
+    "Lineage": "B.1.307",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Reassigned in the current tree. USA lineage"
+  },
+  {
+    "Lineage": "*B.1.307",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Reassigned in the current tree. USA lineage"
+  },
+  {
+    "Lineage": "B.1.312",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: USA lineage"
+  },
+  {
+    "Lineage": "*B.1.312",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: USA lineage"
+  },
+  {
+    "Lineage": "B.1.317",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Reassigned in the current tree. USA lineage"
+  },
+  {
+    "Lineage": "*B.1.317",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Reassigned in the current tree. USA lineage"
+  },
+  {
+    "Lineage": "B.1.322",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: USA lineage, reassigned B.1"
+  },
+  {
+    "Lineage": "*B.1.322",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: USA lineage, reassigned B.1"
+  },
+  {
+    "Lineage": "B.1.327",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Reassigned in the current tree. Danish lineage"
+  },
+  {
+    "Lineage": "*B.1.327",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Reassigned in the current tree. Danish lineage"
+  },
+  {
+    "Lineage": "B.1.331",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: USA lineage"
+  },
+  {
+    "Lineage": "*B.1.331",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: USA lineage"
+  },
+  {
+    "Lineage": "B.1.333.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: USA lineage (WA) (all B.1.169)"
+  },
+  {
+    "Lineage": "*B.1.333.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: USA lineage (WA) (all B.1.169)"
+  },
+  {
+    "Lineage": "B.1.339",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Reassigned in the current tree. Irish lineage"
+  },
+  {
+    "Lineage": "*B.1.339",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Reassigned in the current tree. Irish lineage"
+  },
+  {
+    "Lineage": "B.1.345",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Reassigned in the current tree. Canadian lineage"
+  },
+  {
+    "Lineage": "*B.1.345",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Reassigned in the current tree. Canadian lineage"
+  },
+  {
+    "Lineage": "B.1.347",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Reassigned in the current tree. Canadian lineage, previously part of B.1.114 lineage"
+  },
+  {
+    "Lineage": "*B.1.347",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Reassigned in the current tree. Canadian lineage, previously part of B.1.114 lineage"
+  },
+  {
+    "Lineage": "B.1.351.4",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Potential contaminant lineage from mixture of B.1.351 and Delta, from #134. Sequences from Botswana, do not have E484K or N501Y but have L452R and T478K"
+  },
+  {
+    "Lineage": "*B.1.351.4",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Potential contaminant lineage from mixture of B.1.351 and Delta, from #134. Sequences from Botswana, do not have E484K or N501Y but have L452R and T478K"
+  },
+  {
+    "Lineage": "B.1.352",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Reassigned in the current tree. USA lineage (CA)"
+  },
+  {
+    "Lineage": "*B.1.352",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Reassigned in the current tree. USA lineage (CA)"
+  },
+  {
+    "Lineage": "B.1.353",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Reassigned in the current tree. European lineage"
+  },
+  {
+    "Lineage": "*B.1.353",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Reassigned in the current tree. European lineage"
+  },
+  {
+    "Lineage": "B.1.364",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Reassigned in the current tree. USA lineage"
+  },
+  {
+    "Lineage": "*B.1.364",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Reassigned in the current tree. USA lineage"
+  },
+  {
+    "Lineage": "B.1.365",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Reassigned in the current tree. USA lineage"
+  },
+  {
+    "Lineage": "*B.1.365",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Reassigned in the current tree. USA lineage"
+  },
+  {
+    "Lineage": "B.1.368",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Reassigned in the current tree. USA lineage"
+  },
+  {
+    "Lineage": "*B.1.368",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Reassigned in the current tree. USA lineage"
+  },
+  {
+    "Lineage": "B.1.373",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Reassigned in the current tree. Swedish lineage"
+  },
+  {
+    "Lineage": "*B.1.373",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Reassigned in the current tree. Swedish lineage"
+  },
+  {
+    "Lineage": "B.1.374",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Reassigned in the current tree. European lineage"
+  },
+  {
+    "Lineage": "*B.1.374",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Reassigned in the current tree. European lineage"
+  },
+  {
+    "Lineage": "B.1.374.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Reassigned in the current tree. Bangladesh lineage"
+  },
+  {
+    "Lineage": "*B.1.374.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Reassigned in the current tree. Bangladesh lineage"
+  },
+  {
+    "Lineage": "B.1.376",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Wales lineage"
+  },
+  {
+    "Lineage": "*B.1.376",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Wales lineage"
+  },
+  {
+    "Lineage": "B.1.386",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Reassigned in the current tree. USA lineage"
+  },
+  {
+    "Lineage": "*B.1.386",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Reassigned in the current tree. USA lineage"
+  },
+  {
+    "Lineage": "B.1.392",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: UK lineage"
+  },
+  {
+    "Lineage": "*B.1.392",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: UK lineage"
+  },
+  {
+    "Lineage": "B.1.394",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: North Macedonian lineage"
+  },
+  {
+    "Lineage": "*B.1.394",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: North Macedonian lineage"
+  },
+  {
+    "Lineage": "B.1.410",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Reassigned in the current tree. Danish lineage"
+  },
+  {
+    "Lineage": "*B.1.410",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Reassigned in the current tree. Danish lineage"
+  },
+  {
+    "Lineage": "B.1.412",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Russian lineage"
+  },
+  {
+    "Lineage": "*B.1.412",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Russian lineage"
+  },
+  {
+    "Lineage": "B.1.414",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Netherlands lineage"
+  },
+  {
+    "Lineage": "*B.1.414",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Netherlands lineage"
+  },
+  {
+    "Lineage": "B.1.419",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Iceland lineage"
+  },
+  {
+    "Lineage": "*B.1.419",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Iceland lineage"
+  },
+  {
+    "Lineage": "B.1.440",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: USA lineage (All NM, one AZ)"
+  },
+  {
+    "Lineage": "*B.1.440",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: USA lineage (All NM, one AZ)"
+  },
+  {
+    "Lineage": "B.1.447",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Saudi Arabian lineage"
+  },
+  {
+    "Lineage": "*B.1.447",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Saudi Arabian lineage"
+  },
+  {
+    "Lineage": "B.1.449",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Saudi Arabia (mixture of B.1.260 and B.1.160)"
+  },
+  {
+    "Lineage": "*B.1.449",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Saudi Arabia (mixture of B.1.260 and B.1.160)"
+  },
+  {
+    "Lineage": "B.1.454",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: India (was part of B.1.160)"
+  },
+  {
+    "Lineage": "*B.1.454",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: India (was part of B.1.160)"
+  },
+  {
+    "Lineage": "B.1.455",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Saudi Arabia (was part of B.1.247)"
+  },
+  {
+    "Lineage": "*B.1.455",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Saudi Arabia (was part of B.1.247)"
+  },
+  {
+    "Lineage": "B.1.457",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: UK, Norway, South Korea, Denmark (mostly B.1.160)"
+  },
+  {
+    "Lineage": "*B.1.457",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: UK, Norway, South Korea, Denmark (mostly B.1.160)"
+  },
+  {
+    "Lineage": "B.1.457.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: USA (MI) plus England (was B.1.247, B.1.160)"
+  },
+  {
+    "Lineage": "*B.1.457.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: USA (MI) plus England (was B.1.247, B.1.160)"
+  },
+  {
+    "Lineage": "B.1.461",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: India (from B.1.247)"
+  },
+  {
+    "Lineage": "*B.1.461",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: India (from B.1.247)"
+  },
+  {
+    "Lineage": "B.1.464",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: India and Nepal"
+  },
+  {
+    "Lineage": "*B.1.464",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: India and Nepal"
+  },
+  {
+    "Lineage": "B.1.472",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: England and Denmark (was part of B.1.160)"
+  },
+  {
+    "Lineage": "*B.1.472",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: England and Denmark (was part of B.1.160)"
+  },
+  {
+    "Lineage": "B.1.477",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: England (all were B.1.275)"
+  },
+  {
+    "Lineage": "*B.1.477",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: England (all were B.1.275)"
+  },
+  {
+    "Lineage": "B.1.481",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: DRC and Senegal base, into Switzerland"
+  },
+  {
+    "Lineage": "*B.1.481",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: DRC and Senegal base, into Switzerland"
+  },
+  {
+    "Lineage": "B.1.484",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: France and USA (MI)"
+  },
+  {
+    "Lineage": "*B.1.484",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: France and USA (MI)"
+  },
+  {
+    "Lineage": "B.1.512",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: UK, Australia, USA"
+  },
+  {
+    "Lineage": "*B.1.512",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: UK, Australia, USA"
+  },
+  {
+    "Lineage": "B.1.514",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: USA (TX) split from B.1.2"
+  },
+  {
+    "Lineage": "*B.1.514",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: USA (TX) split from B.1.2"
+  },
+  {
+    "Lineage": "B.1.519",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: England, split from B.1.117"
+  },
+  {
+    "Lineage": "*B.1.519",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: England, split from B.1.117"
+  },
+  {
+    "Lineage": "B.1.526.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Issue 45. New York. Sublineage of B.1.526 (with spike mutations T95I and D253G) that appears to have several more unique mutations."
+  },
+  {
+    "Lineage": "*B.1.526.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Issue 45. New York. Sublineage of B.1.526 (with spike mutations T95I and D253G) that appears to have several more unique mutations."
+  },
+  {
+    "Lineage": "B.1.526.2",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Issue 45. New York. Sublineage of B.1.526 (with spike mutations T95I and D253G) that appears to have several more unique mutations."
+  },
+  {
+    "Lineage": "*B.1.526.2",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Issue 45. New York. Sublineage of B.1.526 (with spike mutations T95I and D253G) that appears to have several more unique mutations."
+  },
+  {
+    "Lineage": "B.1.526.3",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Issue 45. Belgium and Luxembourg lineage"
+  },
+  {
+    "Lineage": "*B.1.526.3",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Issue 45. Belgium and Luxembourg lineage"
+  },
+  {
+    "Lineage": "BA.5.2.64",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Reassigned BA.5.12 Switzerland lineage"
+  },
+  {
+    "Lineage": "*BA.5.2.64",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Reassigned BA.5.12 Switzerland lineage"
+  },
+  {
+    "Lineage": "BB.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Redesignated as B.1.621.2"
+  },
+  {
+    "Lineage": "*BB.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Redesignated as B.1.621.2"
+  },
+  {
+    "Lineage": "AY.9.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Merged into AY.9.2 as these lineages likely form a single clade"
+  },
+  {
+    "Lineage": "*AY.9.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Merged into AY.9.2 as these lineages likely form a single clade"
+  },
+  {
+    "Lineage": "AY.12",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Reassigned to AY.122.1"
+  },
+  {
+    "Lineage": "*AY.12",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Reassigned to AY.122.1"
+  },
+  {
+    "Lineage": "AY.39.4",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Reassigned AY.134. Denmark lineage, from #406"
+  },
+  {
+    "Lineage": "*AY.39.4",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Reassigned AY.134. Denmark lineage, from #406"
+  },
+  {
+    "Lineage": "AY.75.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Did not have a defining mutation within the coding region so was merged into AY.75"
+  },
+  {
+    "Lineage": "*AY.75.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Did not have a defining mutation within the coding region so was merged into AY.75"
+  },
+  {
+    "Lineage": "AY.89",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Merged into AY.4, from #398"
+  },
+  {
+    "Lineage": "*AY.89",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Merged into AY.4, from #398"
+  },
+  {
+    "Lineage": "AY.96",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Based on discussion in, from #435"
+  },
+  {
+    "Lineage": "*AY.96",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Based on discussion in, from #435"
+  },
+  {
+    "Lineage": "AY.97",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Reassigned to AY.5.5"
+  },
+  {
+    "Lineage": "*AY.97",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Reassigned to AY.5.5"
+  },
+  {
+    "Lineage": "AY.115",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Merged into AY.116 as these lineages likely form a single clade"
+  },
+  {
+    "Lineage": "*AY.115",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Merged into AY.116 as these lineages likely form a single clade"
+  },
+  {
+    "Lineage": "B.1.624",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: India lineage, from #91. Redesignated as B.1.1.526"
+  },
+  {
+    "Lineage": "*B.1.624",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: India lineage, from #91. Redesignated as B.1.1.526"
+  },
+  {
+    "Lineage": "B.1.628",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Identified as a recombinant lineage and therefore renamed XB, from #189"
+  },
+  {
+    "Lineage": "*B.1.628",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Identified as a recombinant lineage and therefore renamed XB, from #189"
+  },
+  {
+    "Lineage": "B.2.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Reassigned to B.40"
+  },
+  {
+    "Lineage": "*B.2.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Reassigned to B.40"
+  },
+  {
+    "Lineage": "B.2.6",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Reassigned to B.35"
+  },
+  {
+    "Lineage": "*B.2.6",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Reassigned to B.35"
+  },
+  {
+    "Lineage": "B.2.10",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Reassigned to B.41"
+  },
+  {
+    "Lineage": "*B.2.10",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Reassigned to B.41"
+  },
+  {
+    "Lineage": "B.2.11",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Reassigned to B.36"
+  },
+  {
+    "Lineage": "*B.2.11",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Reassigned to B.36"
+  },
+  {
+    "Lineage": "B.2.12",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Reassigned to B.30"
+  },
+  {
+    "Lineage": "*B.2.12",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Reassigned to B.30"
+  },
+  {
+    "Lineage": "B.6.7",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: USA/Texas"
+  },
+  {
+    "Lineage": "*B.6.7",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: USA/Texas"
+  },
+  {
+    "Lineage": "B.14",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: USA lineage"
+  },
+  {
+    "Lineage": "*B.14",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: USA lineage"
+  },
+  {
+    "Lineage": "B.48",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Reassigned to B.23"
+  },
+  {
+    "Lineage": "*B.48",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Reassigned to B.23"
+  },
+  {
+    "Lineage": "B.54",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Distributed amongst other lineages"
+  },
+  {
+    "Lineage": "*B.54",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Distributed amongst other lineages"
+  },
+  {
+    "Lineage": "B.59",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Originally Latvian & Ireland, no longer monophyletic"
+  },
+  {
+    "Lineage": "*B.59",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Originally Latvian & Ireland, no longer monophyletic"
+  },
+  {
+    "Lineage": "C.15",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Alias of B.1.1.1.15, Denmark lineage"
+  },
+  {
+    "Lineage": "*C.15",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Alias of B.1.1.1.15, Denmark lineage"
+  },
+  {
+    "Lineage": "E.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Reassigned B.1.416.1. French lineage within the diversity of a Senegal/ Gambia lineage"
+  },
+  {
+    "Lineage": "*E.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Reassigned B.1.416.1. French lineage within the diversity of a Senegal/ Gambia lineage"
+  },
+  {
+    "Lineage": "F.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Alias of B.1.36.17.1, New Zealand lineage"
+  },
+  {
+    "Lineage": "*F.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Alias of B.1.36.17.1, New Zealand lineage"
+  },
+  {
+    "Lineage": "H.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Alias of B.1.1.67.1, South African lineage, split from B.1.1.10"
+  },
+  {
+    "Lineage": "*H.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Alias of B.1.1.67.1, South African lineage, split from B.1.1.10"
+  },
+  {
+    "Lineage": "I.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Alias of B.1.1.217.1, Latvian lineage, split from B.1.1.25"
+  },
+  {
+    "Lineage": "*I.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Alias of B.1.1.217.1, Latvian lineage, split from B.1.1.25"
+  },
+  {
+    "Lineage": "J.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Alias of B.1.1.250.1, Australian lineage"
+  },
+  {
+    "Lineage": "*J.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Alias of B.1.1.250.1, Australian lineage"
+  },
+  {
+    "Lineage": "HK.1.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn as smaller than thought (only 6 sequences have 257V and G22927T): Alias of XBB.1.9.2.5.1.1.1.1, S:L455F (G22927T), China (now considered as an HK.3+S:G257D branch being misplaced with HK.1+S:L455F)"
+  },
+  {
+    "Lineage": "*HK.1.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn as smaller than thought (only 6 sequences have 257V and G22927T): Alias of XBB.1.9.2.5.1.1.1.1, S:L455F (G22927T), China (now considered as an HK.3+S:G257D branch being misplaced with HK.1+S:L455F)"
+  },
+  {
+    "Lineage": "HK.10",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn unless lineage grows: Alias of XBB.1.9.2.5.1.1.10, S:L455F (G22927T), on C19983T branch, China (now considered as HK.3 with homoplastic C19983T)"
+  },
+  {
+    "Lineage": "*HK.10",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn unless lineage grows: Alias of XBB.1.9.2.5.1.1.10, S:L455F (G22927T), on C19983T branch, China (now considered as HK.3 with homoplastic C19983T)"
+  },
+  {
+    "Lineage": "*HK.3.11",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn, as part of 14988C sublineage of EG.5.1.1, not HK.3: Alias of XBB.1.9.2.5.1.1.3.11, S:A475V, Finland/Denmark/Sweden"
+  },
+  {
+    "Lineage": "JN.1.33",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Redesignated as JN.1.39.3, Alias of B.1.1.529.2.86.1.1.33, S:A67V, G2782T, C5512T, China from #2498"
+  },
+  {
+    "Lineage": "*JN.1.33",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Redesignated as JN.1.39.3, Alias of B.1.1.529.2.86.1.1.33, S:A67V, G2782T, C5512T, China from #2498"
+  },
+  {
+    "Lineage": "KD.5",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Withdrawn: Alias of XBC.1.3.1.5, S:L244F, Australia, indel artefact caused false S:L244F (#2405)"
+  },
+  {
+    "Lineage": "*KD.5",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Withdrawn: Alias of XBC.1.3.1.5, S:L244F, Australia, indel artefact caused false S:L244F (#2405)"
+  },
+  {
+    "Lineage": "KR.2",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Redesignated as LT.1 (JN.1.1.3.1) due to lack of C9142T"
+  },
+  {
+    "Lineage": "*KR.2",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Redesignated as LT.1 (JN.1.1.3.1) due to lack of C9142T"
+  },
+  {
+    "Lineage": "KP.2.14.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Lineage reassigned. Redesignated as KP.2.14: there's no good evidence for KP.2.14 lacking S:T22N in any sequences. Hence make KP.2.14.1 -> KP.2.14 and require S:T22N"
+  },
+  {
+    "Lineage": "*KP.2.14.1",
+    "Earliest date": "",
+    "Latest date": "",
+    "Description": "Redesignated as KP.2.14: there's no good evidence for KP.2.14 lacking S:T22N in any sequences. Hence make KP.2.14.1 -> KP.2.14 and require S:T22N"
+  }
+]


### PR DESCRIPTION
cc @szhan @hyanwong  - this adds the basic Pango lineage data from cov-lineages, cut down to the minimal useful fields. There's function to get it (``get_cov_lineages_data``)

It's not perfect, but it's a reasonable thing to compare to in terms of understanding how we're doing with backward and forward time travellers (which are also a thing, btw)