### PR TITLE
Show trees of Pango lineages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,9 @@ dependencies = [
   # FIXME
   "tsinfer @ git+https://github.com/jeromekelleher/tsinfer.git@experimental-hmm",
   "pyfaidx",
-  "tskit>=0.5.3",
+  # FIXME - reinstate when 0.5.9 is released
+  # "tskit>=0.5.9",
+  "tskit @ git+https://github.com/tskit-dev/tskit.git@main#subdirectory=python",
   "tszip",
   "pandas",
   "numba",

--- a/sc2ts/info.py
+++ b/sc2ts/info.py
@@ -1565,7 +1565,12 @@ class TreeInfo:
         if remove_clones:
             # TODO
             raise NotImplementedError("remove_clones not implemented")
-        ts = self.ts
+        # remove mutation times, so they get spaced evenly along a branch
+        tables = self.ts.dump_tables()
+        time = tables.mutations.time
+        time[:] = tskit.UNKNOWN_TIME
+        tables.mutations.time = time
+        ts = tables.tree_sequence()
         tracked_nodes = self.pango_lineage_samples[lineage]
         tree = ts.at(position, tracked_samples=tracked_nodes)
         order = np.array(list(tskit.drawing._postorder_tracked_minlex_traversal(


### PR DESCRIPTION
No tests: is there a test ARG we can call a function like this on?

Use like e.g.

```python
pango = "B.1.1.7"
ti.plot_pango_lineage_subtree(pango, collapse_tracked=0.99365, node_labels={}, time_scale="time")
```

Currently waiting on https://github.com/tskit-dev/tskit/pull/3015 to be merged before this actually works.