### PR TITLE
Move the zero edge dropping to minimise metadata

### DIFF
--- a/sc2ts/cli.py
+++ b/sc2ts/cli.py
@@ -558,7 +558,6 @@ def postprocess(
     ts = sc2ts.push_up_reversions(
         ts, ts.mutations_node[mutations_is_reversion], date=None
     )
-    ts = sc2ts.drop_vestigial_root_edge(ts)
     ts.dump(ts_out)
 
 
@@ -567,6 +566,7 @@ def postprocess(
 @click.argument("ts_out", type=click.Path(exists=False, dir_okay=False))
 @click.option("--field-mapping", "-m", type=(str, str), multiple=True)
 @click.option("--progress/--no-progress", default=True)
+@click.option("--drop-vestigial-root/--no-drop-vestigial-root", default=False)
 @click.option("-v", "--verbose", count=True)
 @click.option("-l", "--log-file", default=None, type=click.Path(dir_okay=False))
 def minimise_metadata(
@@ -574,6 +574,7 @@ def minimise_metadata(
     ts_out,
     field_mapping,
     progress,
+    drop_vestigial_root,
     verbose,
     log_file,
 ):
@@ -600,6 +601,8 @@ def minimise_metadata(
     setup_logging(verbose, log_file)
     ts = tszip.load(ts_in)
     ts = sc2ts.minimise_metadata(ts, field_mapping, show_progress=progress)
+    if drop_vestigial_root:
+        ts = sc2ts.drop_vestigial_root_edge(ts)
     ts.dump(ts_out)
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -392,13 +392,14 @@ class TestPostprocess:
         out = tskit.load(out_ts_path)
         assert out.num_samples == ts.num_samples + 8
         assert out.num_provenances == ts.num_provenances + 2
-        # Check we've dropped the vestigial root edge
-        assert out.edge(-1).parent == 1
+        # Check we've kept the vestigial root edge as the trees can't be
+        # dated otherwise
+        assert out.edge(-1).parent == 0
 
 
 class TestMinimiseMetadata:
 
-    def test_example(self, tmp_path, fx_ts_map, fx_match_db):
+    def test_example(self, tmp_path, fx_ts_map):
         ts = fx_ts_map["2020-02-13"]
         out_ts_path = tmp_path / "ts.ts"
         runner = ct.CliRunner()
@@ -414,8 +415,26 @@ class TestMinimiseMetadata:
         )
         dfn = sc2ts.node_data(out, inheritance_stats=False)
         assert "sample_id" in dfn
+        # Check we've kept the vestigial root edge
+        assert out.edge(-1).parent == 0
 
-    def test_example_args(self, tmp_path, fx_ts_map, fx_match_db):
+    def test_example_drop_vestigial_root(self, tmp_path, fx_ts_map):
+        ts = fx_ts_map["2020-02-13"]
+        out_ts_path = tmp_path / "ts.ts"
+        runner = ct.CliRunner()
+        result = runner.invoke(
+            cli.cli,
+            f"minimise-metadata {ts.path} {out_ts_path} --drop-vestigial-root",
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0
+        out = tskit.load(out_ts_path)
+        # Check we've dropped the vestigial root edge
+        dfn = sc2ts.node_data(out, inheritance_stats=False)
+        assert "sample_id" in dfn
+        assert out.edge(-1).parent == 1
+
+    def test_example_args(self, tmp_path, fx_ts_map):
         ts = fx_ts_map["2020-02-13"]
         out_ts_path = tmp_path / "ts.ts"
         runner = ct.CliRunner()


### PR DESCRIPTION
Otherwise we can't date the trees