### PR TITLE
Add optional reference FASTA for non-SARS-CoV-2 genomes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 In development
 
+- Add basic support for non-SARS-CoV-2 genomes via an optional reference FASTA.
+  Supply `--reference` to `import-alignments` and a `reference_fasta` key in the
+  inference config; both default to the built-in SARS-CoV-2 reference, so
+  existing workflows are unchanged.
+
 ## [1.0.2] - 2026-03-05
 
 Maintenance release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ In development
 - Add basic support for non-SARS-CoV-2 genomes via an optional reference FASTA.
   Supply `--reference` to `import-alignments` and a `reference_fasta` key in the
   inference config; both default to the built-in SARS-CoV-2 reference, so
-  existing workflows are unchanged.
+  existing workflows are unchanged. When `reference_fasta` is set, a
+  `reference_date` config key is required (the date assigned to the reference).
+  The redundant `genbank_id` reference-sequence metadata field has been dropped.
 
 ## [1.0.2] - 2026-03-05
 

--- a/docs/example_config.toml
+++ b/docs/example_config.toml
@@ -1,10 +1,16 @@
 
 # This is a path to the dataset, in VCZ format.
 dataset="viridian_mafft_2024-10-14_v1.vcz.zip"
-# The metadata field used for dates. For the Viridian dataset, this is 
-# "Date_tree" (which means, "date used to partition samples when building 
+# The metadata field used for dates. For the Viridian dataset, this is
+# "Date_tree" (which means, "date used to partition samples when building
 # the Viridian tree")
 date_field="Date_tree"
+
+# Optional: path to a reference genome FASTA. If omitted, the built-in
+# SARS-CoV-2 reference (MN908947, Wuhan/Hu-1/2019) is used. Supply this to run
+# inference on another genome; it must be the same reference the dataset was
+# built with (see "sc2ts import-alignments --reference").
+# reference_fasta="reference.fasta"
 
 # The run_id is a prefix added to all output files. This is useful when 
 # running lots of different parameter combinations.

--- a/docs/example_config.toml
+++ b/docs/example_config.toml
@@ -7,10 +7,13 @@ dataset="viridian_mafft_2024-10-14_v1.vcz.zip"
 date_field="Date_tree"
 
 # Optional: path to a reference genome FASTA. If omitted, the built-in
-# SARS-CoV-2 reference (MN908947, Wuhan/Hu-1/2019) is used. Supply this to run
-# inference on another genome; it must be the same reference the dataset was
-# built with (see "sc2ts import-alignments --reference").
+# SARS-CoV-2 reference (Wuhan/Hu-1/2019) is used. Supply this to run inference
+# on another genome; it must be the same reference the dataset was built with
+# (see "sc2ts import-alignments --reference"). When set, reference_date is
+# required: it is the date assigned to the reference (time zero), and it is up
+# to you to ensure it precedes all sample dates.
 # reference_fasta="reference.fasta"
+# reference_date="1900-01-01"
 
 # The run_id is a prefix added to all output files. This is useful when 
 # running lots of different parameter combinations.

--- a/sc2ts/cli.py
+++ b/sc2ts/cli.py
@@ -127,15 +127,29 @@ def setup_logging(verbosity, log_file=None, date=None):
         "If true, initialise a new dataset. WARNING! This will erase an existing store"
     ),
 )
+@click.option(
+    "--reference",
+    type=click.Path(exists=True, dir_okay=False),
+    default=None,
+    help="Reference FASTA defining the genome (default: built-in SARS-CoV-2)",
+)
 @progress
 @verbose
-def import_alignments(dataset, fastas, initialise, progress, verbose):
+def import_alignments(dataset, fastas, initialise, reference, progress, verbose):
     """
     Import the alignments from all FASTAS into the dataset
     """
     setup_logging(verbose)
     if initialise:
-        sc2ts.Dataset.new(dataset)
+        if reference is None:
+            sc2ts.Dataset.new(dataset)
+        else:
+            ref_seq = data_import.get_reference_sequence(reference)
+            sc2ts.Dataset.new(
+                dataset,
+                sequence_length=len(ref_seq),
+                contig_id=data_import.get_reference_id(reference),
+            )
 
     f_bar = tqdm.tqdm(sorted(fastas), desc="Files", disable=not progress, position=0)
     for fasta_path in f_bar:
@@ -304,6 +318,7 @@ def infer(config_file, start, stop, force):
 
     ts_file_pattern = str(results_dir / f"{run_id}_{{date}}.ts")
     exclude_sites = config.pop("exclude_sites", [])
+    reference_fasta = config.pop("reference_fasta", None)
 
     if start is None:
         if match_db.exists() and not force:
@@ -311,7 +326,7 @@ def infer(config_file, start, stop, force):
                 f"Do you want to overwrite MatchDB at {match_db}",
                 abort=True,
             )
-        init_ts = si.initial_ts(exclude_sites)
+        init_ts = si.initial_ts(exclude_sites, reference_fasta=reference_fasta)
         si.MatchDb.initialise(match_db)
         base_ts = results_dir / f"{run_id}_init.ts"
         init_ts.dump(base_ts)
@@ -340,6 +355,16 @@ def infer(config_file, start, stop, force):
     if len(config) > 0:
         raise ValueError(f"Unknown keys in config: {list(config.keys())}")
     ds = sc2ts.Dataset(dataset, date_field=date_field)
+
+    if reference_fasta is not None:
+        reference_length = len(data_import.get_reference_sequence(reference_fasta))
+        contig_length = int(ds["contig_length"][0])
+        if reference_length != contig_length:
+            raise ValueError(
+                f"reference_fasta length ({reference_length}) does not match the "
+                f"dataset contig length ({contig_length}). The reference_fasta must "
+                "be the same genome the dataset was built with."
+            )
 
     for date in np.unique(ds.metadata.sample_date):
         if date >= stop:

--- a/sc2ts/cli.py
+++ b/sc2ts/cli.py
@@ -115,6 +115,17 @@ def setup_logging(verbosity, log_file=None, date=None):
         logger.addHandler(warn_handler)
 
 
+def get_reference(reference_fasta):
+    """
+    Return ``(reference_id, reference_sequence)`` for the supplied reference
+    FASTA, or the built-in SARS-CoV-2 reference when ``reference_fasta`` is None.
+    """
+    if reference_fasta is None:
+        _, sequence = data_import.read_fasta(data_import.data_path / "reference.fasta")
+        return core.REFERENCE_STRAIN, sequence
+    return data_import.read_fasta(reference_fasta)
+
+
 @click.command()
 @click.argument("dataset", type=click.Path(dir_okay=True, file_okay=False))
 @click.argument("fastas", type=click.Path(exists=True, dir_okay=False), nargs=-1)
@@ -141,15 +152,12 @@ def import_alignments(dataset, fastas, initialise, reference, progress, verbose)
     """
     setup_logging(verbose)
     if initialise:
-        if reference is None:
-            sc2ts.Dataset.new(dataset)
-        else:
-            ref_seq = data_import.get_reference_sequence(reference)
-            sc2ts.Dataset.new(
-                dataset,
-                sequence_length=len(ref_seq),
-                contig_id=data_import.get_reference_id(reference),
-            )
+        reference_id, reference_sequence = get_reference(reference)
+        sc2ts.Dataset.new(
+            dataset,
+            sequence_length=len(reference_sequence),
+            contig_id=reference_id,
+        )
 
     f_bar = tqdm.tqdm(sorted(fastas), desc="Files", disable=not progress, position=0)
     for fasta_path in f_bar:
@@ -319,6 +327,14 @@ def infer(config_file, start, stop, force):
     ts_file_pattern = str(results_dir / f"{run_id}_{{date}}.ts")
     exclude_sites = config.pop("exclude_sites", [])
     reference_fasta = config.pop("reference_fasta", None)
+    reference_date = config.pop("reference_date", None)
+
+    reference_id, reference_sequence = get_reference(reference_fasta)
+    if reference_fasta is None:
+        if reference_date is None:
+            reference_date = core.REFERENCE_DATE
+    elif reference_date is None:
+        raise ValueError("reference_date must be set when reference_fasta is given")
 
     if start is None:
         if match_db.exists() and not force:
@@ -326,7 +342,12 @@ def infer(config_file, start, stop, force):
                 f"Do you want to overwrite MatchDB at {match_db}",
                 abort=True,
             )
-        init_ts = si.initial_ts(exclude_sites, reference_fasta=reference_fasta)
+        init_ts = si.initial_ts(
+            reference_sequence=reference_sequence,
+            reference_id=reference_id,
+            reference_date=reference_date,
+            problematic_sites=exclude_sites,
+        )
         si.MatchDb.initialise(match_db)
         base_ts = results_dir / f"{run_id}_init.ts"
         init_ts.dump(base_ts)
@@ -357,7 +378,7 @@ def infer(config_file, start, stop, force):
     ds = sc2ts.Dataset(dataset, date_field=date_field)
 
     if reference_fasta is not None:
-        reference_length = len(data_import.get_reference_sequence(reference_fasta))
+        reference_length = len(reference_sequence)
         contig_length = int(ds["contig_length"][0])
         if reference_length != contig_length:
             raise ValueError(

--- a/sc2ts/core.py
+++ b/sc2ts/core.py
@@ -14,13 +14,7 @@ TIME_UNITS = "days"
 
 REFERENCE_STRAIN = "Wuhan/Hu-1/2019"
 REFERENCE_DATE = "2019-12-26"
-REFERENCE_GENBANK = "MN908947"
 REFERENCE_SEQUENCE_LENGTH = 29904
-
-# Generic time-zero epoch used as the reference date when inference is run on a
-# non-SARS-CoV-2 genome (i.e. a custom reference FASTA is supplied). It only
-# needs to be a valid date that precedes all sample dates.
-GENERIC_REFERENCE_DATE = "1900-01-01"
 
 # We omit N here as it's mapped to -1. Make "-" the 5th allele
 # as this is a valid allele for us.

--- a/sc2ts/core.py
+++ b/sc2ts/core.py
@@ -17,6 +17,11 @@ REFERENCE_DATE = "2019-12-26"
 REFERENCE_GENBANK = "MN908947"
 REFERENCE_SEQUENCE_LENGTH = 29904
 
+# Generic time-zero epoch used as the reference date when inference is run on a
+# non-SARS-CoV-2 genome (i.e. a custom reference FASTA is supplied). It only
+# needs to be a valid date that precedes all sample dates.
+GENERIC_REFERENCE_DATE = "1900-01-01"
+
 # We omit N here as it's mapped to -1. Make "-" the 5th allele
 # as this is a valid allele for us.
 # NOTE!! This string is also used in the jit module where it's

--- a/sc2ts/data_import.py
+++ b/sc2ts/data_import.py
@@ -31,42 +31,16 @@ class FastaReader(collections.abc.Mapping):
 
 data_path = pathlib.Path(__file__).parent / "data"
 
-__cached_reference = None
 
-
-def get_reference_sequence(path=None, as_array=False):
+def read_fasta(path):
     """
-    Return the reference sequence with an "X" prepended at position 0 so that
-    the genome uses 1-based coordinates. If ``path`` is None the built-in
-    SARS-CoV-2 reference is used; otherwise the first record in the FASTA at
-    ``path`` is used.
+    Read the first record of the FASTA at ``path``, returning
+    ``(record_id, sequence)`` with an "X" prepended so the genome uses 1-based
+    coordinates.
     """
-    if path is None:
-        global __cached_reference
-        if __cached_reference is None:
-            reader = pyfaidx.Fasta(str(data_path / "reference.fasta"))
-            __cached_reference = reader[core.REFERENCE_GENBANK]
-        reference = __cached_reference
-    else:
-        reader = pyfaidx.Fasta(str(path))
-        reference = reader[list(reader.keys())[0]]
-    if as_array:
-        h = np.array(reference).astype(str)
-        return np.append(["X"], h)
-    else:
-        return "X" + str(reference)
-
-
-def get_reference_id(path=None):
-    """
-    Return the identifier for the reference genome. If ``path`` is None this is
-    the built-in SARS-CoV-2 GenBank accession; otherwise it is the name of the
-    first record in the FASTA at ``path``.
-    """
-    if path is None:
-        return core.REFERENCE_GENBANK
     reader = pyfaidx.Fasta(str(path))
-    return list(reader.keys())[0]
+    name = list(reader.keys())[0]
+    return name, "X" + str(reader[name])
 
 
 __cached_genes = None
@@ -122,7 +96,7 @@ def get_flank_coordinates():
     start = genes["ORF1ab"][0]
     end = genes["ORF10"][1]
     return np.concatenate(
-        (np.arange(1, start), np.arange(end, REFERENCE_SEQUENCE_LENGTH))
+        (np.arange(1, start), np.arange(end, core.REFERENCE_SEQUENCE_LENGTH))
     )
 
 

--- a/sc2ts/data_import.py
+++ b/sc2ts/data_import.py
@@ -34,16 +34,39 @@ data_path = pathlib.Path(__file__).parent / "data"
 __cached_reference = None
 
 
-def get_reference_sequence(as_array=False):
-    global __cached_reference
-    if __cached_reference is None:
-        reader = pyfaidx.Fasta(str(data_path / "reference.fasta"))
-        __cached_reference = reader[core.REFERENCE_GENBANK]
+def get_reference_sequence(path=None, as_array=False):
+    """
+    Return the reference sequence with an "X" prepended at position 0 so that
+    the genome uses 1-based coordinates. If ``path`` is None the built-in
+    SARS-CoV-2 reference is used; otherwise the first record in the FASTA at
+    ``path`` is used.
+    """
+    if path is None:
+        global __cached_reference
+        if __cached_reference is None:
+            reader = pyfaidx.Fasta(str(data_path / "reference.fasta"))
+            __cached_reference = reader[core.REFERENCE_GENBANK]
+        reference = __cached_reference
+    else:
+        reader = pyfaidx.Fasta(str(path))
+        reference = reader[list(reader.keys())[0]]
     if as_array:
-        h = np.array(__cached_reference).astype(str)
+        h = np.array(reference).astype(str)
         return np.append(["X"], h)
     else:
-        return "X" + str(__cached_reference)
+        return "X" + str(reference)
+
+
+def get_reference_id(path=None):
+    """
+    Return the identifier for the reference genome. If ``path`` is None this is
+    the built-in SARS-CoV-2 GenBank accession; otherwise it is the name of the
+    first record in the FASTA at ``path``.
+    """
+    if path is None:
+        return core.REFERENCE_GENBANK
+    reader = pyfaidx.Fasta(str(path))
+    return list(reader.keys())[0]
 
 
 __cached_genes = None

--- a/sc2ts/data_import.py
+++ b/sc2ts/data_import.py
@@ -5,8 +5,6 @@ import pathlib
 import numpy as np
 import pyfaidx
 
-from . import core
-
 
 class FastaReader(collections.abc.Mapping):
     def __init__(self, path, add_zero_base=True):
@@ -85,18 +83,6 @@ def get_problematic_regions():
             np.arange(21602, 22472, dtype=np.int64),  # NTD domain in S
             np.arange(*orf8, dtype=np.int64),
         ]
-    )
-
-
-def get_flank_coordinates():
-    """
-    Return the coordinates at either end of the genome for masking out.
-    """
-    genes = get_gene_coordinates()
-    start = genes["ORF1ab"][0]
-    end = genes["ORF10"][1]
-    return np.concatenate(
-        (np.arange(1, start), np.arange(end, core.REFERENCE_SEQUENCE_LENGTH))
     )
 
 

--- a/sc2ts/dataset.py
+++ b/sc2ts/dataset.py
@@ -469,14 +469,24 @@ class Dataset(collections.abc.Mapping):
         self.copy(path, sample_id=sample_id[index], show_progress=show_progress)
 
     @staticmethod
-    def new(path, samples_chunk_size=None, variants_chunk_size=None):
+    def new(
+        path,
+        samples_chunk_size=None,
+        variants_chunk_size=None,
+        sequence_length=None,
+        contig_id=None,
+    ):
         if samples_chunk_size is None:
             samples_chunk_size = 10_000
         if variants_chunk_size is None:
             variants_chunk_size = 100
+        if sequence_length is None:
+            sequence_length = core.REFERENCE_SEQUENCE_LENGTH
+        if contig_id is None:
+            contig_id = core.REFERENCE_STRAIN
 
         logger.info(f"Creating new dataset at {path}")
-        L = core.REFERENCE_SEQUENCE_LENGTH - 1
+        L = sequence_length - 1
         N = 0  # Samples must be added
         store = zarr.DirectoryStore(path)
         root = zarr.open(store, mode="w")
@@ -508,7 +518,7 @@ class Dataset(collections.abc.Mapping):
             dtype="str",
             compressor=DEFAULT_ZARR_COMPRESSOR,
         )
-        z[0] = core.REFERENCE_STRAIN
+        z[0] = contig_id
         z.attrs["_ARRAY_DIMENSIONS"] = ["contigs"]
 
         z = root.empty(

--- a/sc2ts/dataset.py
+++ b/sc2ts/dataset.py
@@ -446,6 +446,8 @@ class Dataset(collections.abc.Mapping):
             sample_id = self["sample_id"][:]
         Dataset.new(
             path,
+            sequence_length=int(self["contig_length"][0]),
+            contig_id=self["contig_id"][0],
             samples_chunk_size=samples_chunk_size,
             variants_chunk_size=variants_chunk_size,
         )
@@ -471,19 +473,16 @@ class Dataset(collections.abc.Mapping):
     @staticmethod
     def new(
         path,
+        *,
+        sequence_length,
+        contig_id,
         samples_chunk_size=None,
         variants_chunk_size=None,
-        sequence_length=None,
-        contig_id=None,
     ):
         if samples_chunk_size is None:
             samples_chunk_size = 10_000
         if variants_chunk_size is None:
             variants_chunk_size = 100
-        if sequence_length is None:
-            sequence_length = core.REFERENCE_SEQUENCE_LENGTH
-        if contig_id is None:
-            contig_id = core.REFERENCE_STRAIN
 
         logger.info(f"Creating new dataset at {path}")
         L = sequence_length - 1
@@ -643,9 +642,12 @@ class Dataset(collections.abc.Mapping):
             add_to_zip(zf, in_path, ".")
 
 
-def tmp_dataset(path, alignments, date="2020-01-01"):
+def tmp_dataset(path, alignments, date="2020-01-01", contig_id=None):
     # Minimal hacky thing for testing. Should refactor into something more useful.
-    Dataset.new(path)
+    if contig_id is None:
+        contig_id = core.REFERENCE_STRAIN
+    sequence_length = len(next(iter(alignments.values()))) + 1
+    Dataset.new(path, sequence_length=sequence_length, contig_id=contig_id)
     Dataset.append_alignments(path, alignments)
     df = pd.DataFrame({"strain": alignments.keys(), "date": [date] * len(alignments)})
     Dataset.add_metadata(path, df.set_index("strain"))

--- a/sc2ts/inference.py
+++ b/sc2ts/inference.py
@@ -25,7 +25,7 @@ import tsinfer
 import tskit
 import tszip
 
-from . import core, data_import, jit, stats, tree_ops
+from . import core, jit, stats, tree_ops
 from . import dataset as _dataset
 
 logger = logging.getLogger(__name__)
@@ -264,22 +264,13 @@ def mirror_ts_coordinates(ts):
     return tables.tree_sequence()
 
 
-def initial_ts(problematic_sites=None, reference_fasta=None):
+def initial_ts(
+    *, reference_sequence, reference_id, reference_date, problematic_sites=None
+):
     if problematic_sites is None:
         problematic_sites = []
-    reference = data_import.get_reference_sequence(reference_fasta)
+    reference = reference_sequence
     L = len(reference)
-    if reference_fasta is None:
-        genbank_id = core.REFERENCE_GENBANK
-        reference_strain = core.REFERENCE_STRAIN
-        reference_date = core.REFERENCE_DATE
-    else:
-        contig_id = data_import.get_reference_id(reference_fasta)
-        genbank_id = contig_id
-        reference_strain = contig_id
-        # Generic epoch for non-SARS-CoV-2 genomes: the reference defines time
-        # zero, and this just needs to be a valid date preceding all samples.
-        reference_date = core.GENERIC_REFERENCE_DATE
     problematic_sites = set(problematic_sites)
 
     logger.info(f"Masking out {len(problematic_sites)} sites")
@@ -291,7 +282,6 @@ def initial_ts(problematic_sites=None, reference_fasta=None):
     base_schema = tskit.MetadataSchema.permissive_json().schema
     tables.reference_sequence.metadata_schema = tskit.MetadataSchema(base_schema)
     tables.reference_sequence.metadata = {
-        "genbank_id": genbank_id,
         "notes": "X prepended to alignment to map from 1-based to 0-based coordinates",
     }
     tables.reference_sequence.data = reference
@@ -338,7 +328,7 @@ def initial_ts(problematic_sites=None, reference_fasta=None):
         flags=core.NODE_IS_REFERENCE,
         time=0,
         metadata={
-            "strain": reference_strain,
+            "strain": reference_id,
             "date": reference_date,
             "sc2ts": {"notes": "Reference sequence"},
         },

--- a/sc2ts/inference.py
+++ b/sc2ts/inference.py
@@ -264,12 +264,22 @@ def mirror_ts_coordinates(ts):
     return tables.tree_sequence()
 
 
-def initial_ts(problematic_sites=None):
+def initial_ts(problematic_sites=None, reference_fasta=None):
     if problematic_sites is None:
         problematic_sites = []
-    reference = data_import.get_reference_sequence()
-    L = core.REFERENCE_SEQUENCE_LENGTH
-    assert L == len(reference)
+    reference = data_import.get_reference_sequence(reference_fasta)
+    L = len(reference)
+    if reference_fasta is None:
+        genbank_id = core.REFERENCE_GENBANK
+        reference_strain = core.REFERENCE_STRAIN
+        reference_date = core.REFERENCE_DATE
+    else:
+        contig_id = data_import.get_reference_id(reference_fasta)
+        genbank_id = contig_id
+        reference_strain = contig_id
+        # Generic epoch for non-SARS-CoV-2 genomes: the reference defines time
+        # zero, and this just needs to be a valid date preceding all samples.
+        reference_date = core.GENERIC_REFERENCE_DATE
     problematic_sites = set(problematic_sites)
 
     logger.info(f"Masking out {len(problematic_sites)} sites")
@@ -281,7 +291,7 @@ def initial_ts(problematic_sites=None):
     base_schema = tskit.MetadataSchema.permissive_json().schema
     tables.reference_sequence.metadata_schema = tskit.MetadataSchema(base_schema)
     tables.reference_sequence.metadata = {
-        "genbank_id": core.REFERENCE_GENBANK,
+        "genbank_id": genbank_id,
         "notes": "X prepended to alignment to map from 1-based to 0-based coordinates",
     }
     tables.reference_sequence.data = reference
@@ -289,7 +299,7 @@ def initial_ts(problematic_sites=None):
     tables.metadata_schema = tskit.MetadataSchema(base_schema)
     tables.metadata = {
         "sc2ts": {
-            "date": core.REFERENCE_DATE,
+            "date": reference_date,
             "samples_strain": [],
             "daily_stats": {},
             "cumulative_stats": {
@@ -328,8 +338,8 @@ def initial_ts(problematic_sites=None):
         flags=core.NODE_IS_REFERENCE,
         time=0,
         metadata={
-            "strain": core.REFERENCE_STRAIN,
-            "date": core.REFERENCE_DATE,
+            "strain": reference_strain,
+            "date": reference_date,
             "sc2ts": {"notes": "Reference sequence"},
         },
     )
@@ -806,12 +816,12 @@ def add_sample_to_tables(sample, tables, group_id=None, time=0):
     return tables.nodes.add_row(flags=sample.flags, metadata=metadata, time=time)
 
 
-def match_path_ts(group):
+def match_path_ts(group, sequence_length):
     """
     Given the specified SampleGroup return the tree sequence rooted at
     zero representing the data.
     """
-    tables = tskit.TableCollection(core.REFERENCE_SEQUENCE_LENGTH)
+    tables = tskit.TableCollection(sequence_length)
     tables.nodes.metadata_schema = tskit.MetadataSchema.permissive_json()
     tables.mutations.metadata_schema = tskit.MetadataSchema.permissive_json()
     site_id_map = {}
@@ -1039,7 +1049,7 @@ def add_matching_results(
                     f"{group.summary()}"
                 )
                 continue
-            flat_ts = match_path_ts(group)
+            flat_ts = match_path_ts(group, ts.sequence_length)
             if flat_ts.num_mutations == 0 or flat_ts.num_samples == 1:
                 poly_ts = flat_ts
             else:

--- a/tests/sc2ts_fixtures.py
+++ b/tests/sc2ts_fixtures.py
@@ -8,6 +8,7 @@ import numpy as np
 import pandas as pd
 import pytest
 import tskit
+import util
 
 import sc2ts
 from sc2ts import data_import, jit
@@ -103,7 +104,12 @@ def fx_dataset(tmp_path, fx_data_cache, fx_alignments_fasta, fx_metadata_df):
         fs_path = tmp_path / "dataset.vcz"
         # Use an awkward chunk size here to make sure we're hitting across
         # chunk stuff by default
-        sc2ts.Dataset.new(fs_path, samples_chunk_size=7)
+        sc2ts.Dataset.new(
+            fs_path,
+            sequence_length=sc2ts.REFERENCE_SEQUENCE_LENGTH,
+            contig_id=sc2ts.REFERENCE_STRAIN,
+            samples_chunk_size=7,
+        )
         sc2ts.Dataset.append_alignments(fs_path, encoded_alignments(fx_alignments_fasta))
         sc2ts.Dataset.add_metadata(fs_path, fx_metadata_df)
         sc2ts.Dataset.create_zip(fs_path, cache_path)
@@ -148,7 +154,7 @@ def fx_ts_map(tmp_path, fx_data_cache, fx_dataset, fx_match_db):
     if not cache_path.exists():
         # These sites are masked out in all alignments in the initial data
         # anyway; https://github.com/tskit-dev/sc2ts/issues/282
-        last_ts = si.initial_ts([56, 57, 58, 59, 60])
+        last_ts = util.initial_ts([56, 57, 58, 59, 60])
         cache_path = fx_data_cache / "initial.ts"
         last_ts.dump(cache_path)
         for date in dates:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,6 +8,7 @@ import pandas as pd
 import pytest
 import tomli_w
 import tskit
+import util
 
 import sc2ts
 from sc2ts import cli
@@ -107,6 +108,7 @@ class TestCustomReferenceGenome:
             "log_dir": str(tmp_path / "logs"),
             "matches_dir": str(tmp_path / "matches"),
             "reference_fasta": str(ref_path),
+            "reference_date": "2019-01-01",
             "extend_parameters": {"min_group_size": 1, "num_threads": 0},
         }
         config_file = tmp_path / "config.toml"
@@ -125,7 +127,12 @@ class TestCustomReferenceGenome:
 
         results_dir = tmp_path / "results" / "test"
         init_ts = tskit.load(results_dir / "test_init.ts")
-        expected = si.initial_ts(reference_fasta=str(ref_path))
+        reference_id, reference_sequence = cli.get_reference(str(ref_path))
+        expected = si.initial_ts(
+            reference_sequence=reference_sequence,
+            reference_id=reference_id,
+            reference_date="2019-01-01",
+        )
         expected.tables.assert_equals(init_ts.tables)
         # The initial ts is sized to the custom genome and labelled from it.
         assert init_ts.sequence_length == 61
@@ -152,6 +159,7 @@ class TestCustomReferenceGenome:
             "log_dir": str(tmp_path / "logs"),
             "matches_dir": str(tmp_path / "matches"),
             "reference_fasta": str(ref_path),
+            "reference_date": "2019-01-01",
             "extend_parameters": {},
         }
         config_file = tmp_path / "config.toml"
@@ -326,7 +334,7 @@ class TestInfer:
         assert result.exit_code == 0
         init_ts_path = tmp_path / "results" / "test" / "test_init.ts"
         init_ts = tskit.load(init_ts_path)
-        other_ts = si.initial_ts()
+        other_ts = util.initial_ts()
         other_ts.tables.assert_equals(init_ts.tables)
         match_db_path = tmp_path / "matches" / "test.matches.db"
         match_db = si.MatchDb(match_db_path)
@@ -344,7 +352,7 @@ class TestInfer:
         assert result.exit_code == 0
         init_ts_path = tmp_path / "results" / "test" / "test_init.ts"
         init_ts = tskit.load(init_ts_path)
-        other_ts = si.initial_ts(problematic_sites=problematic)
+        other_ts = util.initial_ts(problematic_sites=problematic)
         other_ts.tables.assert_equals(init_ts.tables)
         match_db_path = tmp_path / "matches" / "test.matches.db"
         match_db = si.MatchDb(match_db_path)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -42,6 +42,131 @@ class TestImportAlignments:
         assert result.exit_code == 1
 
 
+def write_custom_genome(tmp_path, length=60):
+    """
+    Write a small synthetic reference FASTA, a matching-length alignments FASTA
+    and a metadata TSV. Returns (reference_path, dataset_path, metadata_path).
+    """
+    rng = np.random.RandomState(42)
+    bases = np.array(list("ACGT"))
+    ref = "".join(rng.choice(bases, size=length))
+    ref_path = tmp_path / "ref.fasta"
+    ref_path.write_text(f">chr_test synthetic genome\n{ref}\n")
+
+    aln_path = tmp_path / "aln.fasta"
+    rows = []
+    for j in range(4):
+        # Each sample is the reference with a single mutation.
+        h = list(ref)
+        h[10 + j] = "A" if h[10 + j] != "A" else "C"
+        rows.append(f">s{j}\n{''.join(h)}\n")
+    aln_path.write_text("".join(rows))
+
+    meta_path = tmp_path / "meta.tsv"
+    meta_lines = ["Run\tdate"]
+    for j in range(4):
+        meta_lines.append(f"s{j}\t2020-01-0{j + 1}")
+    meta_path.write_text("\n".join(meta_lines) + "\n")
+    return ref_path, aln_path, meta_path
+
+
+class TestCustomReferenceGenome:
+    def build_dataset(self, tmp_path):
+        ref_path, aln_path, meta_path = write_custom_genome(tmp_path)
+        ds_path = tmp_path / "ds.zarr"
+        runner = ct.CliRunner()
+        result = runner.invoke(
+            cli.cli,
+            f"import-alignments {ds_path} {aln_path} -i "
+            f"--reference {ref_path} --no-progress",
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0
+        result = runner.invoke(
+            cli.cli,
+            f"import-metadata {ds_path} {meta_path}",
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0
+        return ref_path, ds_path
+
+    def test_import_alignments_reference(self, tmp_path):
+        ref_path, ds_path = self.build_dataset(tmp_path)
+        ds = sc2ts.Dataset(ds_path, date_field="date")
+        assert ds["contig_id"][0] == "chr_test"
+        assert int(ds["contig_length"][0]) == 61
+        assert ds.num_samples == 4
+
+    def test_infer_custom_reference(self, tmp_path):
+        ref_path, ds_path = self.build_dataset(tmp_path)
+        config = {
+            "dataset": str(ds_path),
+            "date_field": "date",
+            "run_id": "test",
+            "results_dir": str(tmp_path / "results"),
+            "log_dir": str(tmp_path / "logs"),
+            "matches_dir": str(tmp_path / "matches"),
+            "reference_fasta": str(ref_path),
+            "extend_parameters": {"min_group_size": 1, "num_threads": 0},
+        }
+        config_file = tmp_path / "config.toml"
+        with open(config_file, "w") as f:
+            f.write(tomli_w.dumps(config))
+
+        runner = ct.CliRunner()
+        # Run the full pipeline over the sample dates so the matching machinery
+        # (match_path_ts) exercises the custom genome length end-to-end.
+        result = runner.invoke(
+            cli.cli,
+            f"infer {config_file} --stop 2020-02-01",
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0
+
+        results_dir = tmp_path / "results" / "test"
+        init_ts = tskit.load(results_dir / "test_init.ts")
+        expected = si.initial_ts(reference_fasta=str(ref_path))
+        expected.tables.assert_equals(init_ts.tables)
+        # The initial ts is sized to the custom genome and labelled from it.
+        assert init_ts.sequence_length == 61
+        assert init_ts.node(1).metadata["strain"] == "chr_test"
+
+        # A dated tree sequence is produced for each sample date, at the custom
+        # genome length.
+        for day in range(1, 5):
+            dated = tskit.load(results_dir / f"test_2020-01-0{day}.ts")
+            assert dated.sequence_length == 61
+            assert dated.num_sites == 60
+
+    def test_infer_reference_length_mismatch(self, tmp_path):
+        # Build a length-60 custom dataset, then point the config at a reference
+        # of a different length -> the guard rejects the inconsistency.
+        _, ds_path = self.build_dataset(tmp_path)
+        ref_path = tmp_path / "wrong_ref.fasta"
+        ref_path.write_text(">chr_other\n" + "ACGT" * 10 + "\n")
+        config = {
+            "dataset": str(ds_path),
+            "date_field": "date",
+            "run_id": "test",
+            "results_dir": str(tmp_path / "results"),
+            "log_dir": str(tmp_path / "logs"),
+            "matches_dir": str(tmp_path / "matches"),
+            "reference_fasta": str(ref_path),
+            "extend_parameters": {},
+        }
+        config_file = tmp_path / "config.toml"
+        with open(config_file, "w") as f:
+            f.write(tomli_w.dumps(config))
+
+        runner = ct.CliRunner()
+        with pytest.raises(ValueError, match="does not match the dataset"):
+            runner.invoke(
+                cli.cli,
+                f"infer {config_file} --stop 2020-01-01 -f",
+                catch_exceptions=False,
+            )
+
+
 class TestImportMetadata:
     def test_suite_data(self, tmp_path, fx_metadata_tsv, fx_alignments_fasta):
         ds_path = tmp_path / "ds.zarr"

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -22,6 +22,16 @@ def assert_datasets_equal(ds1, ds2):
     xt.assert_equal(sg_ds1, sg_ds2)
 
 
+def new_reference_dataset(path, **kwargs):
+    # Create a dataset sized/labelled for the built-in SARS-CoV-2 reference.
+    return sc2ts.Dataset.new(
+        path,
+        sequence_length=sc2ts.REFERENCE_SEQUENCE_LENGTH,
+        contig_id=sc2ts.REFERENCE_STRAIN,
+        **kwargs,
+    )
+
+
 def test_massaged_viridian_metadata(fx_raw_viridian_metadata_df):
     df = fx_raw_viridian_metadata_df
     assert df["In_Viridian_tree"].dtype == bool
@@ -40,31 +50,25 @@ def test_massaged_viridian_metadata(fx_raw_viridian_metadata_df):
     assert np.sum(df["Genbank_N"]) > 0
 
 
-class TestReferenceSequence:
+class TestReadFasta:
     def test_builtin_default(self):
-        ref = data_import.get_reference_sequence()
+        name, ref = data_import.read_fasta(data_import.data_path / "reference.fasta")
+        assert name == "MN908947"
         assert ref[0] == "X"
-        assert data_import.get_reference_id() == "MN908947"
 
     def test_custom_fasta(self, tmp_path):
         seq = "ACGTACGTACGT"
         fasta = tmp_path / "ref.fasta"
         fasta.write_text(f">chr_test some description\n{seq}\n")
-        assert data_import.get_reference_sequence(str(fasta)) == "X" + seq
-        assert data_import.get_reference_id(str(fasta)) == "chr_test"
-
-    def test_custom_fasta_as_array(self, tmp_path):
-        seq = "ACGTACGTACGT"
-        fasta = tmp_path / "ref.fasta"
-        fasta.write_text(f">chr_test\n{seq}\n")
-        ref = data_import.get_reference_sequence(str(fasta), as_array=True)
-        nt.assert_array_equal(ref, ["X"] + list(seq))
+        name, ref = data_import.read_fasta(str(fasta))
+        assert name == "chr_test"
+        assert ref == "X" + seq
 
 
 class TestCreateDataset:
     def test_new(self, tmp_path):
         path = tmp_path / "dataset.vcz"
-        sc2ts.Dataset.new(path)
+        new_reference_dataset(path)
         sg_ds = load_dataset(path)
         assert dict(sg_ds.sizes) == {
             "variants": 29903,
@@ -111,7 +115,7 @@ class TestCreateDataset:
         self, tmp_path, fx_encoded_alignments, num_samples, chunk_size
     ):
         path = tmp_path / "dataset.vcz"
-        sc2ts.Dataset.new(path, samples_chunk_size=chunk_size)
+        new_reference_dataset(path, samples_chunk_size=chunk_size)
         alignments = {
             k: fx_encoded_alignments[k]
             for k in itertools.islice(fx_encoded_alignments.keys(), num_samples)
@@ -135,7 +139,7 @@ class TestCreateDataset:
     @pytest.mark.parametrize("num_samples", [1, 10, 20])
     def test_append_same_alignments(self, tmp_path, fx_encoded_alignments, num_samples):
         path = tmp_path / "dataset.vcz"
-        sc2ts.Dataset.new(path)
+        new_reference_dataset(path)
         sc2ts.Dataset.append_alignments(path, fx_encoded_alignments)
         alignments = {
             k: fx_encoded_alignments[k]
@@ -158,7 +162,7 @@ class TestCreateDataset:
         self, tmp_path, fx_encoded_alignments, num_samples, chunk_size
     ):
         path = tmp_path / "dataset.vcz"
-        sc2ts.Dataset.new(path, samples_chunk_size=chunk_size)
+        new_reference_dataset(path, samples_chunk_size=chunk_size)
         alignments = {
             k: fx_encoded_alignments[k]
             for k in itertools.islice(fx_encoded_alignments.keys(), num_samples)
@@ -183,7 +187,7 @@ class TestCreateDataset:
     def test_add_metadata(self, tmp_path, fx_encoded_alignments, fx_metadata_df):
 
         path = tmp_path / "dataset.vcz"
-        ds = sc2ts.Dataset.new(path)
+        new_reference_dataset(path)
         sc2ts.Dataset.append_alignments(path, fx_encoded_alignments)
         field_descriptions = {col: col.upper() for col in fx_metadata_df}
         sc2ts.Dataset.add_metadata(
@@ -207,7 +211,7 @@ class TestCreateDataset:
     def test_create_zip(self, tmp_path, fx_encoded_alignments, fx_metadata_df):
 
         path = tmp_path / "dataset.vcz"
-        sc2ts.Dataset.new(path)
+        new_reference_dataset(path)
         sc2ts.Dataset.append_alignments(path, fx_encoded_alignments)
         sc2ts.Dataset.add_metadata(path, fx_metadata_df)
         zip_path = tmp_path / "dataset.vcz.zip"
@@ -429,7 +433,7 @@ class TestDatasetMethods:
 class TestMafftAlignments:
     def test_import(self, tmp_path, fx_encoded_alignments_mafft):
         path = tmp_path / "dataset.vcz"
-        sc2ts.Dataset.new(path)
+        new_reference_dataset(path)
         sc2ts.Dataset.append_alignments(path, fx_encoded_alignments_mafft)
         ds = sc2ts.Dataset(path)
         assert len(ds.alignment) == 19
@@ -483,7 +487,7 @@ class TestDatasetAlignments:
         cache_size,
     ):
         path = tmp_path / "dataset.vcz"
-        sc2ts.Dataset.new(path, samples_chunk_size=chunk_size)
+        new_reference_dataset(path, samples_chunk_size=chunk_size)
         sc2ts.Dataset.append_alignments(path, fx_encoded_alignments)
         sc2ts.Dataset.add_metadata(path, fx_metadata_df)
         ds = sc2ts.Dataset(path, chunk_cache_size=cache_size)
@@ -530,7 +534,7 @@ class TestDatasetMetadata:
         cache_size,
     ):
         path = tmp_path / "dataset.vcz"
-        sc2ts.Dataset.new(path, samples_chunk_size=chunk_size)
+        new_reference_dataset(path, samples_chunk_size=chunk_size)
         sc2ts.Dataset.append_alignments(path, fx_encoded_alignments)
         sc2ts.Dataset.add_metadata(path, fx_metadata_df)
         ds = sc2ts.Dataset(path, chunk_cache_size=cache_size, date_field="date")

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -40,6 +40,27 @@ def test_massaged_viridian_metadata(fx_raw_viridian_metadata_df):
     assert np.sum(df["Genbank_N"]) > 0
 
 
+class TestReferenceSequence:
+    def test_builtin_default(self):
+        ref = data_import.get_reference_sequence()
+        assert ref[0] == "X"
+        assert data_import.get_reference_id() == "MN908947"
+
+    def test_custom_fasta(self, tmp_path):
+        seq = "ACGTACGTACGT"
+        fasta = tmp_path / "ref.fasta"
+        fasta.write_text(f">chr_test some description\n{seq}\n")
+        assert data_import.get_reference_sequence(str(fasta)) == "X" + seq
+        assert data_import.get_reference_id(str(fasta)) == "chr_test"
+
+    def test_custom_fasta_as_array(self, tmp_path):
+        seq = "ACGTACGTACGT"
+        fasta = tmp_path / "ref.fasta"
+        fasta.write_text(f">chr_test\n{seq}\n")
+        ref = data_import.get_reference_sequence(str(fasta), as_array=True)
+        nt.assert_array_equal(ref, ["X"] + list(seq))
+
+
 class TestCreateDataset:
     def test_new(self, tmp_path):
         path = tmp_path / "dataset.vcz"
@@ -53,6 +74,29 @@ class TestCreateDataset:
             "alleles": 16,
         }
         # TODO check various properties of the dataset
+
+    def test_new_custom_genome(self, tmp_path):
+        path = tmp_path / "dataset.vcz"
+        seq = "ACGTACGTACGTAACCGGTT"
+        sc2ts.Dataset.new(path, sequence_length=len(seq) + 1, contig_id="chr_test")
+        sg_ds = load_dataset(path)
+        assert dict(sg_ds.sizes) == {
+            "variants": len(seq),
+            "samples": 0,
+            "ploidy": 1,
+            "contigs": 1,
+            "alleles": 16,
+        }
+        assert sg_ds["contig_id"].values[0] == "chr_test"
+        assert sg_ds["contig_length"].values[0] == len(seq) + 1
+
+        # Length-M encoded alignments round-trip through append.
+        h = jit.encode_alleles(np.array(list(seq)))
+        sc2ts.Dataset.append_alignments(path, {"s0": h})
+        sg_ds = load_dataset(path)
+        assert sg_ds.sizes["samples"] == 1
+        H = sg_ds["call_genotype"].values.squeeze(2).T
+        nt.assert_array_equal(h, H[0])
 
     @pytest.mark.parametrize(
         ["num_samples", "chunk_size"],

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -160,6 +160,26 @@ class TestInitialTs:
         }
         assert node.flags == sc2ts.NODE_IS_REFERENCE
 
+    def test_custom_reference_fasta(self, tmp_path):
+        seq = "ACGTACGTACGTAACCGGTT"
+        fasta = tmp_path / "ref.fasta"
+        fasta.write_text(f">chr_test some description\n{seq}\n")
+
+        ts = si.initial_ts(reference_fasta=str(fasta))
+        # sequence_length and number of sites are driven by the reference length
+        # (with the "X" prepended at position 0 for 1-based coordinates).
+        assert ts.sequence_length == len(seq) + 1
+        assert ts.num_sites == len(seq)
+        assert ts.reference_sequence.data == "X" + seq
+        # Ancestral states match the reference (1-based coordinates).
+        for site in ts.sites():
+            assert site.ancestral_state == seq[int(site.position) - 1]
+        # Identity metadata is derived from the FASTA header, not SARS-CoV-2.
+        assert ts.reference_sequence.metadata["genbank_id"] == "chr_test"
+        node = ts.node(1)
+        assert node.metadata["strain"] == "chr_test"
+        assert node.metadata["date"] == "1900-01-01"
+
 
 class TestMatchTsinfer:
     def match_tsinfer(self, samples, ts, mirror_coordinates=False, **kwargs):

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -8,6 +8,7 @@ import numpy.testing as nt
 import pandas as pd
 import pytest
 import tskit
+import util
 
 import sc2ts
 from sc2ts import debug, jit, tree_ops, validation
@@ -144,12 +145,12 @@ class TestSolveNumMismatches:
 
 class TestInitialTs:
     def test_reference_sequence(self):
-        ts = si.initial_ts()
-        assert ts.reference_sequence.metadata["genbank_id"] == "MN908947"
-        assert ts.reference_sequence.data == sc2ts.data_import.get_reference_sequence()
+        ts = util.initial_ts()
+        assert "genbank_id" not in ts.reference_sequence.metadata
+        assert ts.reference_sequence.data == util.reference_sequence()
 
     def test_reference_node(self):
-        ts = si.initial_ts()
+        ts = util.initial_ts()
         assert ts.num_samples == 0
         node = ts.node(1)
         assert node.time == 0
@@ -160,12 +161,13 @@ class TestInitialTs:
         }
         assert node.flags == sc2ts.NODE_IS_REFERENCE
 
-    def test_custom_reference_fasta(self, tmp_path):
+    def test_custom_reference(self):
         seq = "ACGTACGTACGTAACCGGTT"
-        fasta = tmp_path / "ref.fasta"
-        fasta.write_text(f">chr_test some description\n{seq}\n")
-
-        ts = si.initial_ts(reference_fasta=str(fasta))
+        ts = si.initial_ts(
+            reference_sequence="X" + seq,
+            reference_id="chr_test",
+            reference_date="2020-05-01",
+        )
         # sequence_length and number of sites are driven by the reference length
         # (with the "X" prepended at position 0 for 1-based coordinates).
         assert ts.sequence_length == len(seq) + 1
@@ -174,11 +176,101 @@ class TestInitialTs:
         # Ancestral states match the reference (1-based coordinates).
         for site in ts.sites():
             assert site.ancestral_state == seq[int(site.position) - 1]
-        # Identity metadata is derived from the FASTA header, not SARS-CoV-2.
-        assert ts.reference_sequence.metadata["genbank_id"] == "chr_test"
+        # Identity comes from the supplied values, not SARS-CoV-2.
+        assert "genbank_id" not in ts.reference_sequence.metadata
         node = ts.node(1)
         assert node.metadata["strain"] == "chr_test"
-        assert node.metadata["date"] == "1900-01-01"
+        assert node.metadata["date"] == "2020-05-01"
+
+
+class TestTinyGenomeInference:
+    """
+    Run the full inference pipeline over a tiny synthetic genome with a handful
+    of samples, and check the resulting tree and mutations explicitly.
+    """
+
+    # A 30bp reference and three samples, each the reference with a single known
+    # point mutation at a known (0-based) position.
+    reference = "AAAACCCCGGGGTTTTAAAACCCCGGGGTT"
+    plants = {
+        "s0": (4, "T"),  # ref C -> T
+        "s1": (12, "A"),  # ref G -> A
+        "s2": (21, "A"),  # ref C -> A
+    }
+
+    def build(self, tmp_path):
+        ref = self.reference
+        alignments = {}
+        for name, (pos, base) in self.plants.items():
+            h = list(ref)
+            assert h[pos] != base
+            h[pos] = base
+            alignments[name] = jit.encode_alleles(np.array(h))
+        ds = sc2ts.dataset.tmp_dataset(
+            tmp_path / "ds.zarr",
+            alignments,
+            date="2020-01-01",
+            contig_id="chr_test",
+        )
+        base_ts = si.initial_ts(
+            reference_sequence="X" + ref,
+            reference_id="chr_test",
+            reference_date="2019-01-01",
+        )
+        base_path = tmp_path / "base.ts"
+        base_ts.dump(base_path)
+        si.MatchDb.initialise(tmp_path / "match.db")
+        ts = si.extend(
+            dataset=ds.path,
+            base_ts=str(base_path),
+            date="2020-01-01",
+            match_db=str(tmp_path / "match.db"),
+            min_group_size=1,
+            num_threads=0,
+        )
+        return ts
+
+    def test_dimensions(self, tmp_path):
+        ts = self.build(tmp_path)
+        assert ts.sequence_length == len(self.reference) + 1
+        assert ts.num_sites == len(self.reference)
+        assert ts.num_samples == len(self.plants)
+        assert ts.num_trees == 1
+        # Ancestral states are the reference bases (1-based coordinates).
+        for site in ts.sites():
+            assert site.ancestral_state == self.reference[int(site.position) - 1]
+
+    def test_mutations(self, tmp_path):
+        ts = self.build(tmp_path)
+        # Exactly the planted mutations appear, at the expected positions and
+        # with the expected derived states.
+        observed = sorted(
+            (int(ts.sites_position[m.site]), m.derived_state) for m in ts.mutations()
+        )
+        expected = sorted((pos + 1, base) for (pos, base) in self.plants.values())
+        assert observed == expected
+
+        # Each mutation is carried by exactly the sample that introduced it.
+        strain_to_node = {ts.node(u).metadata["strain"]: u for u in ts.samples()}
+        for name, (pos, base) in self.plants.items():
+            node = strain_to_node[name]
+            mut_ids = np.where(ts.mutations_node == node)[0]
+            assert len(mut_ids) == 1
+            mut = ts.mutation(mut_ids[0])
+            assert mut.derived_state == base
+            assert int(ts.sites_position[mut.site]) == pos + 1
+            assert mut.parent == tskit.NULL
+
+    def test_topology(self, tmp_path):
+        ts = self.build(tmp_path)
+        tree = ts.first()
+        (reference_node,) = [u for u in ts.nodes() if u.flags & sc2ts.NODE_IS_REFERENCE]
+        # Every sample descends from the reference node.
+        for u in ts.samples():
+            v = u
+            while v != tskit.NULL and v != reference_node.id:
+                v = tree.parent(v)
+            assert v == reference_node.id
 
 
 class TestMatchTsinfer:
@@ -195,11 +287,11 @@ class TestMatchTsinfer:
 
     @pytest.mark.parametrize("mirror", [False, True])
     def test_match_reference(self, mirror):
-        ts = si.initial_ts()
+        ts = util.initial_ts()
         tables = ts.dump_tables()
         tables.sites.truncate(20)
         ts = tables.tree_sequence()
-        alignment = sc2ts.data_import.get_reference_sequence(as_array=True)
+        alignment = util.reference_array()
         alignment[0] = "A"
         a = jit.encode_alleles(alignment)
         h = a[ts.sites_position.astype(int)]
@@ -212,11 +304,11 @@ class TestMatchTsinfer:
     @pytest.mark.parametrize("mirror", [False, True])
     @pytest.mark.parametrize("site_id", [0, 10, 19])
     def test_match_reference_one_mutation(self, mirror, site_id):
-        ts = si.initial_ts()
+        ts = util.initial_ts()
         tables = ts.dump_tables()
         tables.sites.truncate(20)
         ts = tables.tree_sequence()
-        alignment = sc2ts.data_import.get_reference_sequence(as_array=True)
+        alignment = util.reference_array()
         alignment[0] = "A"
         a = jit.encode_alleles(alignment)
         h = a[ts.sites_position.astype(int)]
@@ -238,11 +330,11 @@ class TestMatchTsinfer:
     @pytest.mark.parametrize("mirror", [False, True])
     @pytest.mark.parametrize("allele", range(5))
     def test_match_reference_all_same(self, mirror, allele):
-        ts = si.initial_ts()
+        ts = util.initial_ts()
         tables = ts.dump_tables()
         tables.sites.truncate(20)
         ts = tables.tree_sequence()
-        alignment = sc2ts.data_import.get_reference_sequence(as_array=True)
+        alignment = util.reference_array()
         alignment[0] = "A"
         a = jit.encode_alleles(alignment)
         ref = a[ts.sites_position.astype(int)]

--- a/tests/util.py
+++ b/tests/util.py
@@ -2,18 +2,44 @@ import numpy as np
 import tskit
 
 import sc2ts
+from sc2ts import data_import
+from sc2ts import inference as si
+
+
+def reference_sequence():
+    """The built-in SARS-CoV-2 reference, with "X" prepended (1-based)."""
+    _, sequence = data_import.read_fasta(data_import.data_path / "reference.fasta")
+    return sequence
+
+
+def reference_array():
+    """The built-in SARS-CoV-2 reference as a char array with "X" at index 0."""
+    return np.array(list(reference_sequence()))
+
+
+def initial_ts(problematic_sites=None):
+    """
+    Build an initial tree sequence using the built-in SARS-CoV-2 reference.
+    This mirrors what the CLI does by default (see ``sc2ts.cli.get_reference``).
+    """
+    return si.initial_ts(
+        reference_sequence=reference_sequence(),
+        reference_id=sc2ts.REFERENCE_STRAIN,
+        reference_date=sc2ts.REFERENCE_DATE,
+        problematic_sites=problematic_sites,
+    )
 
 
 def get_match_db(ts, db_path, samples, date, num_mismatches):
-    sc2ts.MatchDb.initialise(db_path)
-    match_db = sc2ts.MatchDb(db_path)
+    si.MatchDb.initialise(db_path)
+    match_db = si.MatchDb(db_path)
     match_db.add(samples, date, num_mismatches)
     match_db.create_mask_table(ts)
     return match_db
 
 
 def example_binary(n, date="2020-01-01"):
-    base = sc2ts.initial_ts()
+    base = initial_ts()
     tables = base.dump_tables()
     tree = tskit.Tree.generate_balanced(n, span=base.sequence_length)
     binary_tables = tree.tree_sequence.dump_tables()


### PR DESCRIPTION
Make the reference genome an optional input so inference can run on genomes other than SARS-CoV-2, as a non-breaking change: all new parameters default to the built-in SARS-CoV-2 reference.

- import-alignments gains a --reference option, sizing/labelling the dataset from the supplied FASTA (Dataset.new gains sequence_length and contig_id kwargs).
- infer reads an optional reference_fasta config key, threaded through initial_ts; genome length and identity metadata are derived from the FASTA and the length is checked against the dataset contig length.
- match_path_ts takes the sequence length from the working tree sequence rather than the hardcoded constant.
- Non-SARS-CoV-2 runs use a generic time-zero epoch for the reference.

Closes #609 